### PR TITLE
Add macOS CI workflow and nightly schedule

### DIFF
--- a/.github/workflows/pre-main-macos.yaml
+++ b/.github/workflows/pre-main-macos.yaml
@@ -1,4 +1,4 @@
-name: Pre-Main Checks
+name: Pre-Main Checks (macOS)
 
 on:
   push:
@@ -13,7 +13,7 @@ permissions: read-all
 jobs:
   lint:
     name: Lint
-    runs-on: ubuntu-latest
+    runs-on: macos-latest
     steps:
     - name: Checkout code
       uses: actions/checkout@v6
@@ -31,7 +31,7 @@ jobs:
 
   test:
     name: Test
-    runs-on: ubuntu-latest
+    runs-on: macos-latest
     steps:
     - name: Checkout code
       uses: actions/checkout@v6
@@ -47,16 +47,9 @@ jobs:
     - name: Run tests
       run: go test -v -race -coverprofile=coverage.out ./...
 
-    - name: Upload coverage to Codecov
-      uses: codecov/codecov-action@v5
-      with:
-        files: ./coverage.out
-        flags: unittests
-        name: codecov-umbrella
-
   build:
     name: Build
-    runs-on: ubuntu-latest
+    runs-on: macos-latest
     steps:
     - name: Checkout code
       uses: actions/checkout@v6


### PR DESCRIPTION
## Summary
- Add a new `pre-main-macos.yaml` workflow that runs lint, test, and build jobs on `macos-latest`
- Add a nightly schedule (`0 3 * * *` UTC) to both the existing Linux and new macOS CI workflows

## Test plan
- [ ] Verify Linux CI jobs still pass on push/PR triggers
- [ ] Verify macOS CI jobs pass on push/PR triggers
- [ ] Confirm nightly schedule triggers both workflows after midnight UTC