### PR TITLE
Fix goconst lint for login string literal

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -30,7 +30,7 @@ var getCmd = &cobra.Command{
 func init() {
 	rootCmd.PersistentPreRunE = func(cmd *cobra.Command, args []string) error {
 		// Skip auto-login for login command itself and help
-		if cmd.Name() == "login" || cmd.Name() == "help" {
+		if cmd.Name() == loginCmd.Name() || cmd.Name() == "help" {
 			return nil
 		}
 		// Auto-login if email/password set but no token/userID


### PR DESCRIPTION
## Summary
- Reference `loginCmd.Name()` instead of `"login"` string literal in `PersistentPreRunE` to satisfy goconst linter (3 occurrences of the same string)