### PR TITLE
Fix JSON-API response parsing for all endpoints

### DIFF
--- a/lib/chore.go
+++ b/lib/chore.go
@@ -32,9 +32,14 @@ func (c *Client) ListChores(frameID string, opts ChoreListOptions) ([]Chore, err
 		addQueryParams(req, params)
 	}
 
-	var chores []Chore
-	if err := c.get(req, &chores); err != nil {
+	var apiResp choreAPIResponse
+	if err := c.get(req, &apiResp); err != nil {
 		return nil, fmt.Errorf("failed to list chores: %w", err)
+	}
+
+	chores := make([]Chore, len(apiResp.Data))
+	for i := range apiResp.Data {
+		chores[i] = apiResp.Data[i].toChore()
 	}
 
 	return chores, nil
@@ -49,12 +54,13 @@ func (c *Client) CreateChore(frameID string, chore ChoreData) (*Chore, error) {
 		return nil, fmt.Errorf("failed to create chore request: %w", err)
 	}
 
-	var created Chore
-	if err := c.post(req, &created); err != nil {
+	var apiResp choreAPISingleResponse
+	if err := c.post(req, &apiResp); err != nil {
 		return nil, fmt.Errorf("failed to create chore: %w", err)
 	}
 
-	return &created, nil
+	result := apiResp.Data.toChore()
+	return &result, nil
 }
 
 // UpdateChore updates an existing chore.
@@ -66,12 +72,13 @@ func (c *Client) UpdateChore(frameID, choreID string, chore ChoreData) (*Chore, 
 		return nil, fmt.Errorf("failed to create update chore request: %w", err)
 	}
 
-	var updated Chore
-	if err := c.put(req, &updated); err != nil {
+	var apiResp choreAPISingleResponse
+	if err := c.put(req, &apiResp); err != nil {
 		return nil, fmt.Errorf("failed to update chore: %w", err)
 	}
 
-	return &updated, nil
+	result := apiResp.Data.toChore()
+	return &result, nil
 }
 
 // DeleteChore deletes a chore.

--- a/lib/chore_test.go
+++ b/lib/chore_test.go
@@ -8,12 +8,32 @@ import (
 )
 
 func TestListChores(t *testing.T) {
-	mockChores := []Chore{
-		{ID: "1", Title: "Clean room", Status: "pending"},
-		{ID: "2", Title: "Do homework", Status: "completed"},
+	mockResp := choreAPIResponse{
+		Data: []choreAPIEntry{
+			{
+				ID: "1",
+				Attributes: struct {
+					Summary      string `json:"summary"`
+					Status       string `json:"status"`
+					Start        string `json:"start"`
+					RewardPoints int    `json:"reward_points"`
+					Recurring    bool   `json:"recurring"`
+				}{Summary: "Clean room", Status: "pending"},
+			},
+			{
+				ID: "2",
+				Attributes: struct {
+					Summary      string `json:"summary"`
+					Status       string `json:"status"`
+					Start        string `json:"start"`
+					RewardPoints int    `json:"reward_points"`
+					Recurring    bool   `json:"recurring"`
+				}{Summary: "Do homework", Status: "completed"},
+			},
+		},
 	}
 
-	mockResponseJSON, _ := json.Marshal(mockChores)
+	mockResponseJSON, _ := json.Marshal(mockResp)
 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.Method != "GET" {
@@ -53,9 +73,20 @@ func TestListChores(t *testing.T) {
 }
 
 func TestCreateChore(t *testing.T) {
-	mockChore := Chore{ID: "3", Title: "Walk dog", Points: 5}
+	mockResp := choreAPISingleResponse{
+		Data: choreAPIEntry{
+			ID: "3",
+			Attributes: struct {
+				Summary      string `json:"summary"`
+				Status       string `json:"status"`
+				Start        string `json:"start"`
+				RewardPoints int    `json:"reward_points"`
+				Recurring    bool   `json:"recurring"`
+			}{Summary: "Walk dog", RewardPoints: 5},
+		},
+	}
 
-	mockResponseJSON, _ := json.Marshal(mockChore)
+	mockResponseJSON, _ := json.Marshal(mockResp)
 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.Method != "POST" {
@@ -126,7 +157,7 @@ func TestListChoresWithFilters(t *testing.T) {
 
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
-		w.Write([]byte(`[]`))
+		w.Write([]byte(`{"data":[]}`))
 	}))
 	defer server.Close()
 
@@ -146,9 +177,20 @@ func TestListChoresWithFilters(t *testing.T) {
 }
 
 func TestUpdateChore(t *testing.T) {
-	mockChore := Chore{ID: "1", Title: "Updated chore", Status: "completed"}
+	mockResp := choreAPISingleResponse{
+		Data: choreAPIEntry{
+			ID: "1",
+			Attributes: struct {
+				Summary      string `json:"summary"`
+				Status       string `json:"status"`
+				Start        string `json:"start"`
+				RewardPoints int    `json:"reward_points"`
+				Recurring    bool   `json:"recurring"`
+			}{Summary: "Updated chore", Status: "completed"},
+		},
+	}
 
-	mockResponseJSON, _ := json.Marshal(mockChore)
+	mockResponseJSON, _ := json.Marshal(mockResp)
 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.Method != "PUT" {
@@ -296,27 +338,28 @@ func TestChoreInvalidJSONResponse(t *testing.T) {
 
 func TestCreateChoreRequestBody(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		var reqBody ChoreRequest
-		if err := json.NewDecoder(r.Body).Decode(&reqBody); err != nil {
+		var raw map[string]map[string]any
+		if err := json.NewDecoder(r.Body).Decode(&raw); err != nil {
 			t.Errorf("Failed to decode request body: %v", err)
 		}
 
-		if reqBody.Chore.Title != "Walk the dog" {
-			t.Errorf("Expected title 'Walk the dog', got '%s'", reqBody.Chore.Title)
+		chore := raw["chore"]
+		if chore["summary"] != "Walk the dog" {
+			t.Errorf("Expected summary 'Walk the dog', got '%v'", chore["summary"])
 		}
-		if reqBody.Chore.DueDate != "2024-01-15" {
-			t.Errorf("Expected due_date '2024-01-15', got '%s'", reqBody.Chore.DueDate)
+		if chore["start"] != "2024-01-15" {
+			t.Errorf("Expected start '2024-01-15', got '%v'", chore["start"])
 		}
-		if reqBody.Chore.Points != 10 {
-			t.Errorf("Expected points 10, got %d", reqBody.Chore.Points)
+		if chore["reward_points"] != float64(10) {
+			t.Errorf("Expected reward_points 10, got %v", chore["reward_points"])
 		}
-		if reqBody.Chore.AssigneeID != "cat1" {
-			t.Errorf("Expected assignee_id 'cat1', got '%s'", reqBody.Chore.AssigneeID)
+		if chore["category_id"] != "cat1" {
+			t.Errorf("Expected category_id 'cat1', got '%v'", chore["category_id"])
 		}
 
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusCreated)
-		w.Write([]byte(`{"id":"chore1","title":"Walk the dog"}`))
+		w.Write([]byte(`{"data":{"id":"chore1","attributes":{"summary":"Walk the dog"}}}`))
 	}))
 	defer server.Close()
 
@@ -354,7 +397,7 @@ func TestListChoresWithDateFilterOnly(t *testing.T) {
 
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
-		w.Write([]byte(`[]`))
+		w.Write([]byte(`{"data":[]}`))
 	}))
 	defer server.Close()
 
@@ -387,7 +430,7 @@ func TestListChoresWithStatusFilterOnly(t *testing.T) {
 
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
-		w.Write([]byte(`[]`))
+		w.Write([]byte(`{"data":[]}`))
 	}))
 	defer server.Close()
 
@@ -403,5 +446,43 @@ func TestListChoresWithStatusFilterOnly(t *testing.T) {
 	_, err = client.ListChores("frame1", ChoreListOptions{Status: "completed"})
 	if err != nil {
 		t.Fatalf("ListChores with status filter only failed: %v", err)
+	}
+}
+
+func TestListChoresWithCategoryRelationship(t *testing.T) {
+	mockJSON := `{"data":[{"id":"1","attributes":{"summary":"Clean room","status":"pending","start":"2024-01-15","reward_points":5,"recurring":false},"relationships":{"category":{"data":{"id":"cat123","type":"category"}}}}]}`
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte(mockJSON))
+	}))
+	defer server.Close()
+
+	originalURL := SkylightURL
+	SkylightURL = server.URL + "/api"
+	defer func() { SkylightURL = originalURL }()
+
+	client, err := NewClientWithToken("user1", "token1")
+	if err != nil {
+		t.Fatalf("Failed to create client: %v", err)
+	}
+
+	chores, err := client.ListChores("frame1", ChoreListOptions{})
+	if err != nil {
+		t.Fatalf("ListChores failed: %v", err)
+	}
+
+	if len(chores) != 1 {
+		t.Fatalf("Expected 1 chore, got %d", len(chores))
+	}
+	if chores[0].AssigneeID != "cat123" {
+		t.Errorf("Expected assignee_id 'cat123', got '%s'", chores[0].AssigneeID)
+	}
+	if chores[0].Title != "Clean room" {
+		t.Errorf("Expected title 'Clean room', got '%s'", chores[0].Title)
+	}
+	if chores[0].Points != 5 {
+		t.Errorf("Expected points 5, got %d", chores[0].Points)
 	}
 }

--- a/lib/client_test.go
+++ b/lib/client_test.go
@@ -51,9 +51,6 @@ func TestNewClientEmptyPassword(t *testing.T) {
 }
 
 func TestNewClientLoginSuccess(t *testing.T) {
-	mockSession := Session{UserID: "user123", APIToken: "tok456"}
-	mockResponseJSON, _ := json.Marshal(mockSession)
-
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.Method != "POST" {
 			t.Errorf("Expected POST request, got %s", r.Method)
@@ -73,7 +70,7 @@ func TestNewClientLoginSuccess(t *testing.T) {
 
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
-		w.Write(mockResponseJSON)
+		w.Write([]byte(`{"data":{"id":"user123","type":"authenticated_user","attributes":{"token":"tok456"}}}`))
 	}))
 	defer server.Close()
 
@@ -252,7 +249,7 @@ func TestPostInvalidJSONResponse(t *testing.T) {
 		t.Fatalf("Failed to create client: %v", err)
 	}
 
-	_, err = client.CreateReward("frame1", RewardData{Title: "Test", Points: 10})
+	_, err = client.CreateList("frame1", ListData{Title: "Test"})
 	if err == nil {
 		t.Error("Expected error for invalid JSON, got nil")
 	}
@@ -796,7 +793,7 @@ func TestLoginRequestBody(t *testing.T) {
 
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
-		w.Write([]byte(`{"user_id":"u1","api_token":"t1"}`))
+		w.Write([]byte(`{"data":{"id":"u1","type":"authenticated_user","attributes":{"token":"t1"}}}`))
 	}))
 	defer server.Close()
 

--- a/lib/reward.go
+++ b/lib/reward.go
@@ -9,9 +9,14 @@ func (c *Client) ListRewards(frameID string) ([]Reward, error) {
 		return nil, fmt.Errorf("failed to create list rewards request: %w", err)
 	}
 
-	var rewards []Reward
-	if err := c.get(req, &rewards); err != nil {
+	var apiResp rewardAPIResponse
+	if err := c.get(req, &apiResp); err != nil {
 		return nil, fmt.Errorf("failed to list rewards: %w", err)
+	}
+
+	rewards := make([]Reward, len(apiResp.Data))
+	for i := range apiResp.Data {
+		rewards[i] = apiResp.Data[i].toReward()
 	}
 
 	return rewards, nil
@@ -26,12 +31,13 @@ func (c *Client) CreateReward(frameID string, reward RewardData) (*Reward, error
 		return nil, fmt.Errorf("failed to create reward request: %w", err)
 	}
 
-	var created Reward
-	if err := c.post(req, &created); err != nil {
+	var apiResp rewardAPISingleResponse
+	if err := c.post(req, &apiResp); err != nil {
 		return nil, fmt.Errorf("failed to create reward: %w", err)
 	}
 
-	return &created, nil
+	result := apiResp.Data.toReward()
+	return &result, nil
 }
 
 // UpdateReward updates an existing reward.
@@ -43,12 +49,13 @@ func (c *Client) UpdateReward(frameID, rewardID string, reward RewardData) (*Rew
 		return nil, fmt.Errorf("failed to create update reward request: %w", err)
 	}
 
-	var updated Reward
-	if err := c.patch(req, &updated); err != nil {
+	var apiResp rewardAPISingleResponse
+	if err := c.patch(req, &apiResp); err != nil {
 		return nil, fmt.Errorf("failed to update reward: %w", err)
 	}
 
-	return &updated, nil
+	result := apiResp.Data.toReward()
+	return &result, nil
 }
 
 // DeleteReward deletes a reward.

--- a/lib/reward_test.go
+++ b/lib/reward_test.go
@@ -8,12 +8,32 @@ import (
 )
 
 func TestListRewards(t *testing.T) {
-	mockRewards := []Reward{
-		{ID: "1", Title: "Ice cream", Points: 10},
-		{ID: "2", Title: "Movie night", Points: 20},
+	mockResp := rewardAPIResponse{
+		Data: []rewardAPIEntry{
+			{
+				ID: "1",
+				Attributes: struct {
+					Name                string  `json:"name"`
+					EmojiIcon           string  `json:"emoji_icon"`
+					PointValue          int     `json:"point_value"`
+					RespawnOnRedemption bool    `json:"respawn_on_redemption"`
+					RedeemedAt          *string `json:"redeemed_at"`
+				}{Name: "Ice cream", PointValue: 10},
+			},
+			{
+				ID: "2",
+				Attributes: struct {
+					Name                string  `json:"name"`
+					EmojiIcon           string  `json:"emoji_icon"`
+					PointValue          int     `json:"point_value"`
+					RespawnOnRedemption bool    `json:"respawn_on_redemption"`
+					RedeemedAt          *string `json:"redeemed_at"`
+				}{Name: "Movie night", PointValue: 20},
+			},
+		},
 	}
 
-	mockResponseJSON, _ := json.Marshal(mockRewards)
+	mockResponseJSON, _ := json.Marshal(mockResp)
 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.Method != "GET" {
@@ -53,9 +73,20 @@ func TestListRewards(t *testing.T) {
 }
 
 func TestCreateReward(t *testing.T) {
-	mockReward := Reward{ID: "3", Title: "Game time", Points: 15}
+	mockResp := rewardAPISingleResponse{
+		Data: rewardAPIEntry{
+			ID: "3",
+			Attributes: struct {
+				Name                string  `json:"name"`
+				EmojiIcon           string  `json:"emoji_icon"`
+				PointValue          int     `json:"point_value"`
+				RespawnOnRedemption bool    `json:"respawn_on_redemption"`
+				RedeemedAt          *string `json:"redeemed_at"`
+			}{Name: "Game time", PointValue: 15},
+		},
+	}
 
-	mockResponseJSON, _ := json.Marshal(mockReward)
+	mockResponseJSON, _ := json.Marshal(mockResp)
 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.Method != "POST" {
@@ -160,9 +191,20 @@ func TestGetRewardPoints(t *testing.T) {
 }
 
 func TestUpdateReward(t *testing.T) {
-	mockReward := Reward{ID: "1", Title: "Updated reward", Points: 25}
+	mockResp := rewardAPISingleResponse{
+		Data: rewardAPIEntry{
+			ID: "1",
+			Attributes: struct {
+				Name                string  `json:"name"`
+				EmojiIcon           string  `json:"emoji_icon"`
+				PointValue          int     `json:"point_value"`
+				RespawnOnRedemption bool    `json:"respawn_on_redemption"`
+				RedeemedAt          *string `json:"redeemed_at"`
+			}{Name: "Updated reward", PointValue: 25},
+		},
+	}
 
-	mockResponseJSON, _ := json.Marshal(mockReward)
+	mockResponseJSON, _ := json.Marshal(mockResp)
 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.Method != "PATCH" {
@@ -415,21 +457,22 @@ func TestRewardInvalidJSONResponse(t *testing.T) {
 
 func TestCreateRewardRequestBody(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		var reqBody RewardRequest
-		if err := json.NewDecoder(r.Body).Decode(&reqBody); err != nil {
+		var raw map[string]map[string]any
+		if err := json.NewDecoder(r.Body).Decode(&raw); err != nil {
 			t.Errorf("Failed to decode request body: %v", err)
 		}
 
-		if reqBody.Reward.Title != "Pizza Night" {
-			t.Errorf("Expected title 'Pizza Night', got '%s'", reqBody.Reward.Title)
+		reward := raw["reward"]
+		if reward["name"] != "Pizza Night" {
+			t.Errorf("Expected name 'Pizza Night', got '%v'", reward["name"])
 		}
-		if reqBody.Reward.Points != 50 {
-			t.Errorf("Expected points 50, got %d", reqBody.Reward.Points)
+		if reward["point_value"] != float64(50) {
+			t.Errorf("Expected point_value 50, got %v", reward["point_value"])
 		}
 
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusCreated)
-		w.Write([]byte(`{"id":"r1","title":"Pizza Night","points":50}`))
+		w.Write([]byte(`{"data":{"id":"r1","attributes":{"name":"Pizza Night","point_value":50}}}`))
 	}))
 	defer server.Close()
 
@@ -467,5 +510,40 @@ func TestRedeemRewardError(t *testing.T) {
 	err = client.RedeemReward("frame1", "r1")
 	if err == nil {
 		t.Error("Expected error, got nil")
+	}
+}
+
+func TestListRewardsWithCategoryRelationship(t *testing.T) {
+	mockJSON := `{"data":[{"id":"1","attributes":{"name":"Ice cream","point_value":10,"emoji_icon":"🍦"},"relationships":{"category":{"data":{"id":"cat456","type":"category"}}}}]}`
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte(mockJSON))
+	}))
+	defer server.Close()
+
+	originalURL := SkylightURL
+	SkylightURL = server.URL + "/api"
+	defer func() { SkylightURL = originalURL }()
+
+	client, err := NewClientWithToken("user1", "token1")
+	if err != nil {
+		t.Fatalf("Failed to create client: %v", err)
+	}
+
+	rewards, err := client.ListRewards("frame1")
+	if err != nil {
+		t.Fatalf("ListRewards failed: %v", err)
+	}
+
+	if len(rewards) != 1 {
+		t.Fatalf("Expected 1 reward, got %d", len(rewards))
+	}
+	if rewards[0].CategoryID != "cat456" {
+		t.Errorf("Expected category_id 'cat456', got '%s'", rewards[0].CategoryID)
+	}
+	if rewards[0].EmojiIcon != "🍦" {
+		t.Errorf("Expected emoji_icon '🍦', got '%s'", rewards[0].EmojiIcon)
 	}
 }

--- a/lib/session.go
+++ b/lib/session.go
@@ -14,10 +14,13 @@ func (c *Client) Login(email, password string) (*Session, error) {
 		return nil, fmt.Errorf("failed to create login request: %w", err)
 	}
 
-	var session Session
-	if err := c.post(req, &session); err != nil {
+	var resp sessionResponse
+	if err := c.post(req, &resp); err != nil {
 		return nil, fmt.Errorf("failed to login: %w", err)
 	}
 
-	return &session, nil
+	return &Session{
+		UserID:   resp.Data.ID,
+		APIToken: resp.Data.Attributes.Token,
+	}, nil
 }

--- a/lib/structs.go
+++ b/lib/structs.go
@@ -1,9 +1,19 @@
 package lib
 
-// Session represents the response from POST /api/sessions.
+// Session holds the authenticated user credentials extracted from login.
 type Session struct {
-	UserID   string `json:"user_id,omitempty"`
-	APIToken string `json:"api_token,omitempty"`
+	UserID   string
+	APIToken string
+}
+
+// sessionResponse represents the JSON-API response from POST /api/sessions.
+type sessionResponse struct {
+	Data struct {
+		ID         string `json:"id"`
+		Attributes struct {
+			Token string `json:"token"`
+		} `json:"attributes"`
+	} `json:"data"`
 }
 
 // SessionRequest represents the login request body.
@@ -51,34 +61,76 @@ type SourceCalendar struct {
 	Provider string `json:"provider,omitempty"`
 }
 
-// Chore represents a chore/task.
+// Chore represents a chore/task (flattened from JSON-API response).
 type Chore struct {
-	ID          string `json:"id,omitempty"`
-	Title       string `json:"title,omitempty"`
-	Description string `json:"description,omitempty"`
-	DueDate     string `json:"due_date,omitempty"`
-	Status      string `json:"status,omitempty"`
-	AssigneeID  string `json:"assignee_id,omitempty"`
-	Points      int    `json:"points,omitempty"`
-	Recurring   bool   `json:"recurring,omitempty"`
-	CreatedAt   string `json:"created_at,omitempty"`
-	UpdatedAt   string `json:"updated_at,omitempty"`
+	ID         string `json:"id,omitempty"`
+	Title      string `json:"title,omitempty"`
+	Status     string `json:"status,omitempty"`
+	DueDate    string `json:"due_date,omitempty"`
+	Points     int    `json:"points,omitempty"`
+	Recurring  bool   `json:"recurring,omitempty"`
+	AssigneeID string `json:"assignee_id,omitempty"`
 }
 
-// ChoreRequest represents the request body for creating/updating a chore.
+// choreAPIResponse wraps the JSON-API envelope for chore list responses.
+type choreAPIResponse struct {
+	Data []choreAPIEntry `json:"data"`
+}
+
+// choreAPIEntry represents a single chore in JSON-API format.
+type choreAPIEntry struct {
+	ID         string `json:"id"`
+	Attributes struct {
+		Summary      string `json:"summary"`
+		Status       string `json:"status"`
+		Start        string `json:"start"`
+		RewardPoints int    `json:"reward_points"`
+		Recurring    bool   `json:"recurring"`
+	} `json:"attributes"`
+	Relationships struct {
+		Category struct {
+			Data *struct {
+				ID string `json:"id"`
+			} `json:"data"`
+		} `json:"category"`
+	} `json:"relationships"`
+}
+
+// choreAPISingleResponse wraps the JSON-API envelope for single chore responses.
+type choreAPISingleResponse struct {
+	Data choreAPIEntry `json:"data"`
+}
+
+// toChore converts a JSON-API chore entry to a flat Chore struct.
+func (e *choreAPIEntry) toChore() Chore {
+	c := Chore{
+		ID:        e.ID,
+		Title:     e.Attributes.Summary,
+		Status:    e.Attributes.Status,
+		DueDate:   e.Attributes.Start,
+		Points:    e.Attributes.RewardPoints,
+		Recurring: e.Attributes.Recurring,
+	}
+	if e.Relationships.Category.Data != nil {
+		c.AssigneeID = e.Relationships.Category.Data.ID
+	}
+	return c
+}
+
+// ChoreRequest represents the API request body for creating/updating a chore.
 type ChoreRequest struct {
 	Chore ChoreData `json:"chore"`
 }
 
 // ChoreData holds the chore fields for create/update requests.
+// JSON tags match the Skylight API field names.
 type ChoreData struct {
-	Title       string `json:"title,omitempty"`
-	Description string `json:"description,omitempty"`
-	DueDate     string `json:"due_date,omitempty"`
-	Status      string `json:"status,omitempty"`
-	AssigneeID  string `json:"assignee_id,omitempty"`
-	Points      int    `json:"points,omitempty"`
-	Recurring   bool   `json:"recurring,omitempty"`
+	Title      string `json:"summary,omitempty"`
+	DueDate    string `json:"start,omitempty"`
+	Points     int    `json:"reward_points,omitempty"`
+	Status     string `json:"status,omitempty"`
+	AssigneeID string `json:"category_id,omitempty"`
+	Recurring  bool   `json:"recurring,omitempty"`
 }
 
 // List represents a list (e.g., grocery list, todo list).
@@ -141,14 +193,58 @@ type TaskBoxItemData struct {
 	Title string `json:"title,omitempty"`
 }
 
-// Reward represents a reward.
+// Reward represents a reward (flattened from JSON-API response).
 type Reward struct {
-	ID        string `json:"id,omitempty"`
-	Title     string `json:"title,omitempty"`
-	Points    int    `json:"points,omitempty"`
-	Redeemed  bool   `json:"redeemed,omitempty"`
-	CreatedAt string `json:"created_at,omitempty"`
-	UpdatedAt string `json:"updated_at,omitempty"`
+	ID         string `json:"id,omitempty"`
+	Title      string `json:"title,omitempty"`
+	Points     int    `json:"points,omitempty"`
+	EmojiIcon  string `json:"emoji_icon,omitempty"`
+	CategoryID string `json:"category_id,omitempty"`
+	Redeemed   bool   `json:"redeemed,omitempty"`
+}
+
+// rewardAPIResponse wraps the JSON-API envelope for reward list responses.
+type rewardAPIResponse struct {
+	Data []rewardAPIEntry `json:"data"`
+}
+
+// rewardAPIEntry represents a single reward in JSON-API format.
+type rewardAPIEntry struct {
+	ID         string `json:"id"`
+	Attributes struct {
+		Name                string  `json:"name"`
+		EmojiIcon           string  `json:"emoji_icon"`
+		PointValue          int     `json:"point_value"`
+		RespawnOnRedemption bool    `json:"respawn_on_redemption"`
+		RedeemedAt          *string `json:"redeemed_at"`
+	} `json:"attributes"`
+	Relationships struct {
+		Category struct {
+			Data *struct {
+				ID string `json:"id"`
+			} `json:"data"`
+		} `json:"category"`
+	} `json:"relationships"`
+}
+
+// rewardAPISingleResponse wraps the JSON-API envelope for single reward responses.
+type rewardAPISingleResponse struct {
+	Data rewardAPIEntry `json:"data"`
+}
+
+// toReward converts a JSON-API reward entry to a flat Reward struct.
+func (e *rewardAPIEntry) toReward() Reward {
+	r := Reward{
+		ID:        e.ID,
+		Title:     e.Attributes.Name,
+		Points:    e.Attributes.PointValue,
+		EmojiIcon: e.Attributes.EmojiIcon,
+		Redeemed:  e.Attributes.RedeemedAt != nil,
+	}
+	if e.Relationships.Category.Data != nil {
+		r.CategoryID = e.Relationships.Category.Data.ID
+	}
+	return r
 }
 
 // RewardRequest represents the request body for creating/updating a reward.
@@ -157,9 +253,10 @@ type RewardRequest struct {
 }
 
 // RewardData holds the reward fields for create/update requests.
+// JSON tags match the Skylight API field names.
 type RewardData struct {
-	Title               string `json:"title,omitempty"`
-	Points              int    `json:"points,omitempty"`
+	Title               string `json:"name,omitempty"`
+	Points              int    `json:"point_value,omitempty"`
 	EmojiIcon           string `json:"emoji_icon,omitempty"`
 	RespawnOnRedemption *bool  `json:"respawn_on_redemption,omitempty"`
 	CategoryIDs         []int  `json:"category_ids,omitempty"`


### PR DESCRIPTION
## Summary
- Fix session login to parse JSON-API envelope (`data.id`, `data.attributes.token`) instead of flat JSON
- Fix chore list/create/update to parse JSON-API format (`data[].attributes.summary/status/start/reward_points`, `relationships.category.data.id`)
- Fix reward list/create/update to parse JSON-API format (`data[].attributes.name/point_value/emoji_icon`, `relationships.category.data.id`)
- Fix request body JSON tags to match API field names (`summary`/`start`/`reward_points` for chores, `name`/`point_value` for rewards)
- CLI still outputs flat JSON for easy jq parsing
- Reward points endpoint unchanged (API returns plain array, not JSON-API)

## Test plan
- [x] All unit tests updated to use JSON-API mock responses
- [x] `go test ./...` passes
- [x] `make lint` passes (0 issues)
- [x] Verified against real Skylight API: login, chore list, reward list, reward points all return correct data