### PR TITLE
Fix request body format: send flat JSON

### DIFF
--- a/lib/chore.go
+++ b/lib/chore.go
@@ -47,9 +47,7 @@ func (c *Client) ListChores(frameID string, opts ChoreListOptions) ([]Chore, err
 
 // CreateChore creates a new chore on a frame.
 func (c *Client) CreateChore(frameID string, chore ChoreData) (*Chore, error) {
-	reqBody := ChoreRequest{Chore: chore}
-
-	req, err := newRequestWithBody("POST", fmt.Sprintf("%s/frames/%s/chores", SkylightURL, frameID), reqBody)
+	req, err := newRequestWithBody("POST", fmt.Sprintf("%s/frames/%s/chores", SkylightURL, frameID), chore)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create chore request: %w", err)
 	}
@@ -65,9 +63,7 @@ func (c *Client) CreateChore(frameID string, chore ChoreData) (*Chore, error) {
 
 // UpdateChore updates an existing chore.
 func (c *Client) UpdateChore(frameID, choreID string, chore ChoreData) (*Chore, error) {
-	reqBody := ChoreRequest{Chore: chore}
-
-	req, err := newRequestWithBody("PUT", fmt.Sprintf("%s/frames/%s/chores/%s", SkylightURL, frameID, choreID), reqBody)
+	req, err := newRequestWithBody("PUT", fmt.Sprintf("%s/frames/%s/chores/%s", SkylightURL, frameID, choreID), chore)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create update chore request: %w", err)
 	}

--- a/lib/chore_test.go
+++ b/lib/chore_test.go
@@ -338,23 +338,22 @@ func TestChoreInvalidJSONResponse(t *testing.T) {
 
 func TestCreateChoreRequestBody(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		var raw map[string]map[string]any
+		var raw map[string]any
 		if err := json.NewDecoder(r.Body).Decode(&raw); err != nil {
 			t.Errorf("Failed to decode request body: %v", err)
 		}
 
-		chore := raw["chore"]
-		if chore["summary"] != "Walk the dog" {
-			t.Errorf("Expected summary 'Walk the dog', got '%v'", chore["summary"])
+		if raw["summary"] != "Walk the dog" {
+			t.Errorf("Expected summary 'Walk the dog', got '%v'", raw["summary"])
 		}
-		if chore["start"] != "2024-01-15" {
-			t.Errorf("Expected start '2024-01-15', got '%v'", chore["start"])
+		if raw["start"] != "2024-01-15" {
+			t.Errorf("Expected start '2024-01-15', got '%v'", raw["start"])
 		}
-		if chore["reward_points"] != float64(10) {
-			t.Errorf("Expected reward_points 10, got %v", chore["reward_points"])
+		if raw["reward_points"] != float64(10) {
+			t.Errorf("Expected reward_points 10, got %v", raw["reward_points"])
 		}
-		if chore["category_id"] != "cat1" {
-			t.Errorf("Expected category_id 'cat1', got '%v'", chore["category_id"])
+		if raw["category_id"] != "cat1" {
+			t.Errorf("Expected category_id 'cat1', got '%v'", raw["category_id"])
 		}
 
 		w.Header().Set("Content-Type", "application/json")

--- a/lib/reward.go
+++ b/lib/reward.go
@@ -24,9 +24,7 @@ func (c *Client) ListRewards(frameID string) ([]Reward, error) {
 
 // CreateReward creates a new reward on a frame.
 func (c *Client) CreateReward(frameID string, reward RewardData) (*Reward, error) {
-	reqBody := RewardRequest{Reward: reward}
-
-	req, err := newRequestWithBody("POST", fmt.Sprintf("%s/frames/%s/rewards", SkylightURL, frameID), reqBody)
+	req, err := newRequestWithBody("POST", fmt.Sprintf("%s/frames/%s/rewards", SkylightURL, frameID), reward)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create reward request: %w", err)
 	}
@@ -42,9 +40,7 @@ func (c *Client) CreateReward(frameID string, reward RewardData) (*Reward, error
 
 // UpdateReward updates an existing reward.
 func (c *Client) UpdateReward(frameID, rewardID string, reward RewardData) (*Reward, error) {
-	reqBody := RewardRequest{Reward: reward}
-
-	req, err := newRequestWithBody("PATCH", fmt.Sprintf("%s/frames/%s/rewards/%s", SkylightURL, frameID, rewardID), reqBody)
+	req, err := newRequestWithBody("PATCH", fmt.Sprintf("%s/frames/%s/rewards/%s", SkylightURL, frameID, rewardID), reward)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create update reward request: %w", err)
 	}

--- a/lib/reward_test.go
+++ b/lib/reward_test.go
@@ -457,17 +457,16 @@ func TestRewardInvalidJSONResponse(t *testing.T) {
 
 func TestCreateRewardRequestBody(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		var raw map[string]map[string]any
+		var raw map[string]any
 		if err := json.NewDecoder(r.Body).Decode(&raw); err != nil {
 			t.Errorf("Failed to decode request body: %v", err)
 		}
 
-		reward := raw["reward"]
-		if reward["name"] != "Pizza Night" {
-			t.Errorf("Expected name 'Pizza Night', got '%v'", reward["name"])
+		if raw["name"] != "Pizza Night" {
+			t.Errorf("Expected name 'Pizza Night', got '%v'", raw["name"])
 		}
-		if reward["point_value"] != float64(50) {
-			t.Errorf("Expected point_value 50, got %v", reward["point_value"])
+		if raw["point_value"] != float64(50) {
+			t.Errorf("Expected point_value 50, got %v", raw["point_value"])
 		}
 
 		w.Header().Set("Content-Type", "application/json")

--- a/lib/structs.go
+++ b/lib/structs.go
@@ -117,11 +117,6 @@ func (e *choreAPIEntry) toChore() Chore {
 	return c
 }
 
-// ChoreRequest represents the API request body for creating/updating a chore.
-type ChoreRequest struct {
-	Chore ChoreData `json:"chore"`
-}
-
 // ChoreData holds the chore fields for create/update requests.
 // JSON tags match the Skylight API field names.
 type ChoreData struct {
@@ -245,11 +240,6 @@ func (e *rewardAPIEntry) toReward() Reward {
 		r.CategoryID = e.Relationships.Category.Data.ID
 	}
 	return r
-}
-
-// RewardRequest represents the request body for creating/updating a reward.
-type RewardRequest struct {
-	Reward RewardData `json:"reward"`
 }
 
 // RewardData holds the reward fields for create/update requests.


### PR DESCRIPTION
## Summary
- Remove `ChoreRequest`/`RewardRequest` wrapper types — the Skylight API expects flat request bodies, not objects wrapped in `{"chore":{...}}` or `{"reward":{...}}`
- Send `ChoreData` and `RewardData` structs directly as the request body
- Verified against real API: chore create + delete, reward create all work correctly

## Test plan
- [x] `go test ./...` passes
- [x] `make lint` passes
- [x] Chore create verified against real Skylight API
- [x] Chore delete verified against real Skylight API