### PR TITLE
Fix recurring field omitted from JSON when false

### DIFF
--- a/lib/structs.go
+++ b/lib/structs.go
@@ -68,7 +68,7 @@ type Chore struct {
 	Status     string `json:"status,omitempty"`
 	DueDate    string `json:"due_date,omitempty"`
 	Points     int    `json:"points,omitempty"`
-	Recurring  bool   `json:"recurring,omitempty"`
+	Recurring  bool   `json:"recurring"`
 	AssigneeID string `json:"assignee_id,omitempty"`
 }
 


### PR DESCRIPTION
## Summary
- Remove `omitempty` from the `Recurring` bool field on the `Chore` struct
- With `omitempty`, Go JSON marshaler omits bool fields when `false`, so downstream jq filters (`.recurring == false`) see `null` instead of `false` and never match
- This broke the Skylight late-chore cleanup cron, which filters for non-recurring (one-time) bounty chores to delete

## Test plan
- [x] `make lint` passes
- [x] `make test` passes
- [ ] Verify cleanup cron correctly identifies and deletes late one-time bounties