### PR TITLE
Update Go to v1.26.1

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/sebrandon1/go-skylight
 
-go 1.24.0
+go 1.26.1
 
 require github.com/spf13/cobra v1.10.2
 


### PR DESCRIPTION
## Summary
- Update Go version to v1.26.1 across go.mod, Dockerfiles, and CI workflows