### PR TITLE
Add config file support with ~/.skylight/config

### DIFF
--- a/cmd/config.go
+++ b/cmd/config.go
@@ -1,0 +1,117 @@
+package cmd
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+var configPath string
+
+func defaultConfigPath() string {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return ""
+	}
+	return filepath.Join(home, ".skylight", "config")
+}
+
+func loadConfig() {
+	path := configPath
+	if path == "" {
+		path = defaultConfigPath()
+	}
+	if path == "" {
+		return
+	}
+
+	f, err := os.Open(path)
+	if err != nil {
+		return
+	}
+	defer f.Close()
+
+	vars := map[string]*string{
+		"SKYLIGHT_EMAIL":    &email,
+		"SKYLIGHT_PASSWORD": &password,
+		"SKYLIGHT_TOKEN":    &token,
+		"SKYLIGHT_USER_ID":  &userID,
+		"SKYLIGHT_FRAME_ID": &frameID,
+	}
+
+	scanner := bufio.NewScanner(f)
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		if line == "" || strings.HasPrefix(line, "#") {
+			continue
+		}
+		key, value, ok := strings.Cut(line, "=")
+		if !ok {
+			continue
+		}
+		key = strings.TrimSpace(key)
+		value = strings.TrimSpace(value)
+		if ptr, exists := vars[key]; exists && *ptr == "" {
+			*ptr = value
+		}
+	}
+}
+
+func saveConfig(values map[string]string) error {
+	path := configPath
+	if path == "" {
+		path = defaultConfigPath()
+	}
+	if path == "" {
+		return fmt.Errorf("could not determine config path")
+	}
+
+	dir := filepath.Dir(path)
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		return fmt.Errorf("creating config directory: %w", err)
+	}
+
+	// Read existing config to preserve unknown keys
+	existing := make(map[string]string)
+	var orderedKeys []string
+	if f, err := os.Open(path); err == nil {
+		scanner := bufio.NewScanner(f)
+		for scanner.Scan() {
+			line := strings.TrimSpace(scanner.Text())
+			if line == "" || strings.HasPrefix(line, "#") {
+				continue
+			}
+			key, val, ok := strings.Cut(line, "=")
+			if !ok {
+				continue
+			}
+			key = strings.TrimSpace(key)
+			val = strings.TrimSpace(val)
+			existing[key] = val
+			orderedKeys = append(orderedKeys, key)
+		}
+		f.Close()
+	}
+
+	// Merge new values
+	for k, v := range values {
+		if _, exists := existing[k]; !exists {
+			orderedKeys = append(orderedKeys, k)
+		}
+		existing[k] = v
+	}
+
+	f, err := os.OpenFile(path, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0o600)
+	if err != nil {
+		return fmt.Errorf("writing config: %w", err)
+	}
+	defer f.Close()
+
+	for _, k := range orderedKeys {
+		fmt.Fprintf(f, "%s=%s\n", k, existing[k])
+	}
+
+	return nil
+}

--- a/cmd/config_test.go
+++ b/cmd/config_test.go
@@ -1,0 +1,176 @@
+package cmd
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestLoadConfig(t *testing.T) {
+	// Create temp config file
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config")
+	content := `SKYLIGHT_EMAIL=test@example.com
+SKYLIGHT_PASSWORD=secret123
+SKYLIGHT_TOKEN=tok123
+SKYLIGHT_USER_ID=uid456
+SKYLIGHT_FRAME_ID=fid789
+`
+	if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	// Reset globals
+	email = ""
+	password = ""
+	token = ""
+	userID = ""
+	frameID = ""
+	configPath = path
+
+	loadConfig()
+
+	if email != "test@example.com" {
+		t.Errorf("email = %q, want %q", email, "test@example.com")
+	}
+	if password != "secret123" {
+		t.Errorf("password = %q, want %q", password, "secret123")
+	}
+	if token != "tok123" {
+		t.Errorf("token = %q, want %q", token, "tok123")
+	}
+	if userID != "uid456" {
+		t.Errorf("userID = %q, want %q", userID, "uid456")
+	}
+	if frameID != "fid789" {
+		t.Errorf("frameID = %q, want %q", frameID, "fid789")
+	}
+
+	// Reset for other tests
+	email = ""
+	password = ""
+	token = ""
+	userID = ""
+	frameID = ""
+	configPath = ""
+}
+
+func TestLoadConfigCLIFlagsTakePrecedence(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config")
+	content := `SKYLIGHT_EMAIL=config@example.com
+SKYLIGHT_TOKEN=config-token
+`
+	if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	// Simulate CLI flags already set
+	email = "cli@example.com"
+	token = ""
+	configPath = path
+
+	loadConfig()
+
+	if email != "cli@example.com" {
+		t.Errorf("email = %q, want CLI value %q", email, "cli@example.com")
+	}
+	if token != "config-token" {
+		t.Errorf("token = %q, want config value %q", token, "config-token")
+	}
+
+	// Reset
+	email = ""
+	token = ""
+	configPath = ""
+}
+
+func TestLoadConfigSkipsComments(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config")
+	content := `# This is a comment
+SKYLIGHT_EMAIL=test@example.com
+
+# Another comment
+SKYLIGHT_TOKEN=tok123
+`
+	if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	email = ""
+	token = ""
+	configPath = path
+
+	loadConfig()
+
+	if email != "test@example.com" {
+		t.Errorf("email = %q, want %q", email, "test@example.com")
+	}
+	if token != "tok123" {
+		t.Errorf("token = %q, want %q", token, "tok123")
+	}
+
+	email = ""
+	token = ""
+	configPath = ""
+}
+
+func TestLoadConfigMissingFile(t *testing.T) {
+	configPath = "/nonexistent/path/config"
+	email = ""
+
+	loadConfig()
+
+	if email != "" {
+		t.Errorf("email should be empty when config file is missing")
+	}
+
+	configPath = ""
+}
+
+func TestSaveConfig(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, ".skylight", "config")
+	configPath = path
+
+	err := saveConfig(map[string]string{
+		"SKYLIGHT_EMAIL":   "test@example.com",
+		"SKYLIGHT_TOKEN":   "tok123",
+		"SKYLIGHT_USER_ID": "uid456",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	content := string(data)
+
+	if content == "" {
+		t.Error("config file should not be empty")
+	}
+
+	// Verify the saved file can be read back
+	email = ""
+	token = ""
+	userID = ""
+	loadConfig()
+
+	if email != "test@example.com" {
+		t.Errorf("email = %q, want %q", email, "test@example.com")
+	}
+	if token != "tok123" {
+		t.Errorf("token = %q, want %q", token, "tok123")
+	}
+	if userID != "uid456" {
+		t.Errorf("userID = %q, want %q", userID, "uid456")
+	}
+
+	email = ""
+	token = ""
+	userID = ""
+	configPath = ""
+}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -38,6 +38,9 @@ var getCmd = &cobra.Command{
 
 func init() {
 	rootCmd.PersistentPreRunE = func(cmd *cobra.Command, args []string) error {
+		// Load config file first (CLI flags take precedence since they're already set)
+		loadConfig()
+
 		// Skip auto-login for login command itself and help
 		if cmd.Name() == loginCmd.Name() || cmd.Name() == "help" {
 			return nil
@@ -55,6 +58,7 @@ func init() {
 		return nil
 	}
 
+	rootCmd.PersistentFlags().StringVar(&configPath, "config", "", "Config file path (default ~/.skylight/config)")
 	rootCmd.PersistentFlags().StringVar(&email, "email", "", "Skylight account email")
 	rootCmd.PersistentFlags().StringVar(&password, "password", "", "Skylight account password")
 	rootCmd.PersistentFlags().StringVar(&token, "token", "", "API token (alternative to email/password)")

--- a/cmd/session.go
+++ b/cmd/session.go
@@ -8,6 +8,8 @@ import (
 	"github.com/spf13/cobra"
 )
 
+var saveCredentials bool
+
 var loginCmd = &cobra.Command{
 	Use:   "login",
 	Short: "Authenticate with Skylight and get API credentials",
@@ -26,5 +28,30 @@ var loginCmd = &cobra.Command{
 		fmt.Printf("Login successful!\n")
 		fmt.Printf("User ID: %s\n", client.UserID)
 		fmt.Printf("API Token: %s\n", client.APIToken)
+
+		if saveCredentials {
+			values := map[string]string{
+				"SKYLIGHT_EMAIL":    email,
+				"SKYLIGHT_PASSWORD": password,
+				"SKYLIGHT_TOKEN":    client.APIToken,
+				"SKYLIGHT_USER_ID":  client.UserID,
+			}
+			if frameID != "" {
+				values["SKYLIGHT_FRAME_ID"] = frameID
+			}
+			if err := saveConfig(values); err != nil {
+				fmt.Printf("Warning: could not save config: %v\n", err)
+			} else {
+				path := configPath
+				if path == "" {
+					path = defaultConfigPath()
+				}
+				fmt.Printf("Credentials saved to %s\n", path)
+			}
+		}
 	},
+}
+
+func init() {
+	loginCmd.Flags().BoolVar(&saveCredentials, "save", false, "Save credentials to config file")
 }


### PR DESCRIPTION
## Summary

- Add `~/.skylight/config` support (KEY=VALUE format, following go-enphase pattern)
- Config vars: `SKYLIGHT_EMAIL`, `SKYLIGHT_PASSWORD`, `SKYLIGHT_TOKEN`, `SKYLIGHT_USER_ID`, `SKYLIGHT_FRAME_ID`
- CLI flags take precedence over config file values
- Add `--config` flag to override default config path
- Add `--save` flag to `login` command to write credentials to config file
- Existing config keys are preserved when saving

## Test plan

- [x] `make lint` passes
- [x] `make test` passes
- [x] Config loading, precedence, comments, and missing file tests pass
- [x] Config save and round-trip test passes
- [ ] CI passes on both ubuntu and macos