### PR TITLE
Add update commands for chores, calendar, lists, rewards, and recipes

### DIFF
--- a/cmd/calendar.go
+++ b/cmd/calendar.go
@@ -116,9 +116,42 @@ var sourceCalendarsCmd = &cobra.Command{
 	},
 }
 
+var calendarUpdateCmd = &cobra.Command{
+	Use:   "update",
+	Short: "Update a calendar event",
+	Run: func(cmd *cobra.Command, args []string) {
+		requireFrameID()
+
+		client := getClient()
+
+		data := lib.CalendarEventData{}
+		if cmd.Flags().Changed("title") {
+			data.Title = calendarTitle
+		}
+		if cmd.Flags().Changed("start-at") {
+			data.StartAt = calendarStartAt
+		}
+		if cmd.Flags().Changed("end-at") {
+			data.EndAt = calendarEndAt
+		}
+		if cmd.Flags().Changed("all-day") {
+			data.AllDay = calendarAllDay
+		}
+
+		event, err := client.UpdateCalendarEvent(frameID, calendarEventID, data)
+		if err != nil {
+			fmt.Printf("Error updating calendar event: %v\n", err)
+			os.Exit(1)
+		}
+
+		printJSON(event)
+	},
+}
+
 func init() {
 	calendarCmd.AddCommand(calendarListCmd)
 	calendarCmd.AddCommand(calendarCreateCmd)
+	calendarCmd.AddCommand(calendarUpdateCmd)
 	calendarCmd.AddCommand(calendarDeleteCmd)
 	calendarCmd.AddCommand(sourceCalendarsCmd)
 
@@ -129,6 +162,12 @@ func init() {
 	calendarCreateCmd.Flags().StringVar(&calendarStartAt, "start-at", "", "Event start time")
 	calendarCreateCmd.Flags().StringVar(&calendarEndAt, "end-at", "", "Event end time")
 	calendarCreateCmd.Flags().BoolVar(&calendarAllDay, "all-day", false, "All day event")
+
+	calendarUpdateCmd.Flags().StringVar(&calendarEventID, "event-id", "", "Event ID to update")
+	calendarUpdateCmd.Flags().StringVar(&calendarTitle, "title", "", "Event title")
+	calendarUpdateCmd.Flags().StringVar(&calendarStartAt, "start-at", "", "Event start time")
+	calendarUpdateCmd.Flags().StringVar(&calendarEndAt, "end-at", "", "Event end time")
+	calendarUpdateCmd.Flags().BoolVar(&calendarAllDay, "all-day", false, "All day event")
 
 	calendarDeleteCmd.Flags().StringVar(&calendarEventID, "event-id", "", "Event ID to delete")
 }

--- a/cmd/chore.go
+++ b/cmd/chore.go
@@ -93,9 +93,45 @@ var choreDeleteCmd = &cobra.Command{
 	},
 }
 
+var choreUpdateCmd = &cobra.Command{
+	Use:   "update",
+	Short: "Update a chore",
+	Run: func(cmd *cobra.Command, args []string) {
+		requireFrameID()
+
+		client := getClient()
+
+		data := lib.ChoreData{}
+		if cmd.Flags().Changed("title") {
+			data.Title = choreTitle
+		}
+		if cmd.Flags().Changed("status") {
+			data.Status = choreStatus
+		}
+		if cmd.Flags().Changed("points") {
+			data.Points = chorePoints
+		}
+		if cmd.Flags().Changed("assignee-id") {
+			data.AssigneeID = choreAssigneeID
+		}
+		if cmd.Flags().Changed("date") {
+			data.DueDate = choreDate
+		}
+
+		chore, err := client.UpdateChore(frameID, choreID, data)
+		if err != nil {
+			fmt.Printf("Error updating chore: %v\n", err)
+			os.Exit(1)
+		}
+
+		printJSON(chore)
+	},
+}
+
 func init() {
 	choreCmd.AddCommand(choreListCmd)
 	choreCmd.AddCommand(choreCreateCmd)
+	choreCmd.AddCommand(choreUpdateCmd)
 	choreCmd.AddCommand(choreDeleteCmd)
 
 	choreListCmd.Flags().StringVar(&choreDate, "date", "", "Date filter")
@@ -111,6 +147,13 @@ func init() {
 	choreCreateCmd.Flags().StringVar(&choreAssigneeID, "assignee-id", "", "Assignee ID")
 	choreCreateCmd.Flags().IntVar(&chorePoints, "points", 0, "Points value")
 	choreCreateCmd.Flags().BoolVar(&choreRecurring, "recurring", false, "Make chore recurring")
+
+	choreUpdateCmd.Flags().StringVar(&choreID, "chore-id", "", "Chore ID to update")
+	choreUpdateCmd.Flags().StringVar(&choreTitle, "title", "", "Chore title")
+	choreUpdateCmd.Flags().StringVar(&choreStatus, "status", "", "Chore status")
+	choreUpdateCmd.Flags().IntVar(&chorePoints, "points", 0, "Points value")
+	choreUpdateCmd.Flags().StringVar(&choreAssigneeID, "assignee-id", "", "Assignee ID")
+	choreUpdateCmd.Flags().StringVar(&choreDate, "date", "", "Due date")
 
 	choreDeleteCmd.Flags().StringVar(&choreID, "chore-id", "", "Chore ID to delete")
 }

--- a/cmd/list.go
+++ b/cmd/list.go
@@ -9,11 +9,12 @@ import (
 )
 
 var (
-	listID        string
-	listTitle     string
-	listColor     string
-	listItemID    string
-	listItemTitle string
+	listID            string
+	listTitle         string
+	listColor         string
+	listItemID        string
+	listItemTitle     string
+	listItemCompleted bool
 )
 
 var listCmd = &cobra.Command{
@@ -158,12 +159,66 @@ var listDeleteItemCmd = &cobra.Command{
 	},
 }
 
+var listUpdateCmd = &cobra.Command{
+	Use:   "update",
+	Short: "Update a list",
+	Run: func(cmd *cobra.Command, args []string) {
+		requireFrameID()
+
+		client := getClient()
+
+		data := lib.ListData{}
+		if cmd.Flags().Changed("title") {
+			data.Title = listTitle
+		}
+		if cmd.Flags().Changed("color") {
+			data.Color = listColor
+		}
+
+		list, err := client.UpdateList(frameID, listID, data)
+		if err != nil {
+			fmt.Printf("Error updating list: %v\n", err)
+			os.Exit(1)
+		}
+
+		printJSON(list)
+	},
+}
+
+var listUpdateItemCmd = &cobra.Command{
+	Use:   "update-item",
+	Short: "Update a list item",
+	Run: func(cmd *cobra.Command, args []string) {
+		requireFrameID()
+
+		client := getClient()
+
+		data := lib.ListItemData{}
+		if cmd.Flags().Changed("title") {
+			data.Title = listItemTitle
+		}
+		if cmd.Flags().Changed("completed") {
+			data.Completed = listItemCompleted
+		}
+
+		item, err := client.UpdateListItem(frameID, listID, listItemID, data)
+		if err != nil {
+			fmt.Printf("Error updating list item: %v\n", err)
+			os.Exit(1)
+		}
+
+		printJSON(item)
+	},
+}
+
 func init() {
 	listCmd.AddCommand(listListCmd)
 	listCmd.AddCommand(listGetCmd)
 	listCmd.AddCommand(listCreateCmd)
+	listCmd.AddCommand(listUpdateCmd)
 	listCmd.AddCommand(listDeleteCmd)
 	listCmd.AddCommand(listAddItemCmd)
+	listCmd.AddCommand(listUpdateItemCmd)
 	listCmd.AddCommand(listDeleteItemCmd)
 
 	listGetCmd.Flags().StringVar(&listID, "list-id", "", "List ID")
@@ -171,8 +226,17 @@ func init() {
 	listCreateCmd.Flags().StringVar(&listColor, "color", "", "List color")
 	listDeleteCmd.Flags().StringVar(&listID, "list-id", "", "List ID")
 
+	listUpdateCmd.Flags().StringVar(&listID, "list-id", "", "List ID")
+	listUpdateCmd.Flags().StringVar(&listTitle, "title", "", "List title")
+	listUpdateCmd.Flags().StringVar(&listColor, "color", "", "List color")
+
 	listAddItemCmd.Flags().StringVar(&listID, "list-id", "", "List ID")
 	listAddItemCmd.Flags().StringVar(&listItemTitle, "title", "", "Item title")
+
+	listUpdateItemCmd.Flags().StringVar(&listID, "list-id", "", "List ID")
+	listUpdateItemCmd.Flags().StringVar(&listItemID, "item-id", "", "Item ID")
+	listUpdateItemCmd.Flags().StringVar(&listItemTitle, "title", "", "Item title")
+	listUpdateItemCmd.Flags().BoolVar(&listItemCompleted, "completed", false, "Mark item as completed")
 
 	listDeleteItemCmd.Flags().StringVar(&listID, "list-id", "", "List ID")
 	listDeleteItemCmd.Flags().StringVar(&listItemID, "item-id", "", "Item ID")

--- a/cmd/meal.go
+++ b/cmd/meal.go
@@ -9,10 +9,13 @@ import (
 )
 
 var (
-	recipeID    string
-	recipeTitle string
-	sittingDate string
-	mealType    string
+	recipeID          string
+	recipeTitle       string
+	recipeDescription string
+	recipeIngredients []string
+	recipeURL         string
+	sittingDate       string
+	mealType          string
 )
 
 var mealCmd = &cobra.Command{
@@ -99,7 +102,10 @@ var mealCreateRecipeCmd = &cobra.Command{
 		}
 
 		recipe, err := client.CreateRecipe(frameID, lib.RecipeData{
-			Title: recipeTitle,
+			Title:       recipeTitle,
+			Description: recipeDescription,
+			Ingredients: recipeIngredients,
+			URL:         recipeURL,
 		})
 		if err != nil {
 			fmt.Printf("Error creating recipe: %v\n", err)
@@ -202,18 +208,62 @@ var mealAddToGroceryCmd = &cobra.Command{
 	},
 }
 
+var mealUpdateRecipeCmd = &cobra.Command{
+	Use:   "update-recipe",
+	Short: "Update a recipe",
+	Run: func(cmd *cobra.Command, args []string) {
+		requireFrameID()
+
+		client := getClient()
+
+		data := lib.RecipeData{}
+		if cmd.Flags().Changed("title") {
+			data.Title = recipeTitle
+		}
+		if cmd.Flags().Changed("description") {
+			data.Description = recipeDescription
+		}
+		if cmd.Flags().Changed("ingredients") {
+			data.Ingredients = recipeIngredients
+		}
+		if cmd.Flags().Changed("url") {
+			data.URL = recipeURL
+		}
+
+		recipe, err := client.UpdateRecipe(frameID, recipeID, data)
+		if err != nil {
+			fmt.Printf("Error updating recipe: %v\n", err)
+			os.Exit(1)
+		}
+
+		printJSON(recipe)
+	},
+}
+
 func init() {
 	mealCmd.AddCommand(mealCategoriesCmd)
 	mealCmd.AddCommand(mealRecipesCmd)
 	mealCmd.AddCommand(mealRecipeInfoCmd)
 	mealCmd.AddCommand(mealCreateRecipeCmd)
+	mealCmd.AddCommand(mealUpdateRecipeCmd)
 	mealCmd.AddCommand(mealDeleteRecipeCmd)
 	mealCmd.AddCommand(mealSittingsCmd)
 	mealCmd.AddCommand(mealCreateSittingCmd)
 	mealCmd.AddCommand(mealAddToGroceryCmd)
 
 	mealRecipeInfoCmd.Flags().StringVar(&recipeID, "recipe-id", "", "Recipe ID")
+
 	mealCreateRecipeCmd.Flags().StringVar(&recipeTitle, "title", "", "Recipe title")
+	mealCreateRecipeCmd.Flags().StringVar(&recipeDescription, "description", "", "Recipe description")
+	mealCreateRecipeCmd.Flags().StringSliceVar(&recipeIngredients, "ingredients", nil, "Ingredients (comma-separated)")
+	mealCreateRecipeCmd.Flags().StringVar(&recipeURL, "url", "", "Recipe URL")
+
+	mealUpdateRecipeCmd.Flags().StringVar(&recipeID, "recipe-id", "", "Recipe ID to update")
+	mealUpdateRecipeCmd.Flags().StringVar(&recipeTitle, "title", "", "Recipe title")
+	mealUpdateRecipeCmd.Flags().StringVar(&recipeDescription, "description", "", "Recipe description")
+	mealUpdateRecipeCmd.Flags().StringSliceVar(&recipeIngredients, "ingredients", nil, "Ingredients (comma-separated)")
+	mealUpdateRecipeCmd.Flags().StringVar(&recipeURL, "url", "", "Recipe URL")
+
 	mealDeleteRecipeCmd.Flags().StringVar(&recipeID, "recipe-id", "", "Recipe ID")
 
 	mealCreateSittingCmd.Flags().StringVar(&recipeID, "recipe-id", "", "Recipe ID")

--- a/cmd/reward.go
+++ b/cmd/reward.go
@@ -144,9 +144,39 @@ var rewardPointsCmd = &cobra.Command{
 	},
 }
 
+var rewardUpdateCmd = &cobra.Command{
+	Use:   "update",
+	Short: "Update a reward",
+	Run: func(cmd *cobra.Command, args []string) {
+		requireFrameID()
+
+		client := getClient()
+
+		data := lib.RewardData{}
+		if cmd.Flags().Changed("title") {
+			data.Title = rewardTitle
+		}
+		if cmd.Flags().Changed("points") {
+			data.Points = rewardPoints
+		}
+		if cmd.Flags().Changed("emoji-icon") {
+			data.EmojiIcon = rewardEmojiIcon
+		}
+
+		reward, err := client.UpdateReward(frameID, rewardID, data)
+		if err != nil {
+			fmt.Printf("Error updating reward: %v\n", err)
+			os.Exit(1)
+		}
+
+		printJSON(reward)
+	},
+}
+
 func init() {
 	rewardCmd.AddCommand(rewardListCmd)
 	rewardCmd.AddCommand(rewardCreateCmd)
+	rewardCmd.AddCommand(rewardUpdateCmd)
 	rewardCmd.AddCommand(rewardDeleteCmd)
 	rewardCmd.AddCommand(rewardRedeemCmd)
 	rewardCmd.AddCommand(rewardUnredeemCmd)
@@ -157,6 +187,11 @@ func init() {
 	rewardCreateCmd.Flags().StringVar(&rewardEmojiIcon, "emoji-icon", "", "Emoji icon for the reward")
 	rewardCreateCmd.Flags().BoolVar(&rewardNoRespawn, "no-respawn", false, "Disable respawn on redemption")
 	rewardCreateCmd.Flags().IntSliceVar(&rewardCategoryIDs, "category-ids", nil, "Category IDs to assign reward to")
+
+	rewardUpdateCmd.Flags().StringVar(&rewardID, "reward-id", "", "Reward ID to update")
+	rewardUpdateCmd.Flags().StringVar(&rewardTitle, "title", "", "Reward title")
+	rewardUpdateCmd.Flags().IntVar(&rewardPoints, "points", 0, "Points cost")
+	rewardUpdateCmd.Flags().StringVar(&rewardEmojiIcon, "emoji-icon", "", "Emoji icon for the reward")
 
 	rewardDeleteCmd.Flags().StringVar(&rewardID, "reward-id", "", "Reward ID")
 	rewardRedeemCmd.Flags().StringVar(&rewardID, "reward-id", "", "Reward ID")


### PR DESCRIPTION
## Summary

- Add `get chore update` command (--chore-id, --status, --title, --points, --assignee-id, --date)
- Add `get calendar update` command (--event-id, --title, --start-at, --end-at, --all-day)
- Add `get list update` command (--list-id, --title, --color)
- Add `get list update-item` command (--list-id, --item-id, --title, --completed)
- Add `get reward update` command (--reward-id, --title, --points, --emoji-icon)
- Add `get meal update-recipe` command (--recipe-id, --title, --description, --ingredients, --url)
- Enhance `get meal create-recipe` with --description, --ingredients, --url flags
- All update commands use `cmd.Flags().Changed()` to only send modified fields

These CLI commands expose the existing `lib.Update*()` functions that were already implemented but had no CLI interface.

## Test plan

- [x] `make lint` passes
- [x] `make test` passes
- [ ] CI passes on both ubuntu and macos