### PR TITLE
Update CLAUDE.md with config file, update commands, and CI changes

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,7 +13,7 @@ Go 1.26.1 (see `go.mod`)
 ## Build / Test / Lint
 
 ```bash
-make build          # go build -o go-skylight
+make build          # go build with version injection via ldflags
 make test           # go test ./... -v
 make lint           # golangci-lint run ./...
 make vet            # go vet ./...
@@ -22,19 +22,23 @@ make clean          # rm -f go-skylight
 
 Run `make lint` before committing and fix any issues.
 
+The build target injects version via ldflags: `-X main.Version=$(git describe --tags --always)`. Use `./go-skylight --version` to verify.
+
 ## Project Structure
 
 ```
-main.go                 # Entrypoint, calls cmd.Execute()
+main.go                 # Entrypoint, sets Version, calls cmd.Execute()
 cmd/                    # Cobra command definitions
-  root.go               # Root command, persistent flags (--email, --password, --token, --user-id, --frame-id)
-  session.go            # login command
+  root.go               # Root command, persistent flags (--email, --password, --token, --user-id, --frame-id, --config), version
+  session.go            # login command (with --save flag for config file)
+  config.go             # Config file loading/saving (~/.skylight/config)
+  config_test.go        # Config file tests
   frame.go              # frame info, devices, avatars, colors
-  calendar.go           # calendar list, create, delete, sources
-  chore.go              # chore list, create, delete
-  reward.go             # reward list, create, delete, redeem, unredeem, points
-  list.go               # list all, info, create, delete, add-item, delete-item
-  meal.go               # meal categories, recipes, sittings, grocery list
+  calendar.go           # calendar list, create, update, delete, sources
+  chore.go              # chore list, create, update, delete
+  reward.go             # reward list, create, update, delete, redeem, unredeem, points
+  list.go               # list all, info, create, update, delete, add-item, update-item, delete-item
+  meal.go               # meal categories, recipes (create, update, delete), sittings, grocery list
   category.go           # list family member categories
   dashboard.go          # today command (aggregates events, chores, points, meals, lists)
   bounty.go             # bounty create/list (chore + reward pairs)
@@ -59,11 +63,61 @@ lib/                    # API client library
 
 ## Authentication
 
-Two modes:
-1. **Email/password:** `--email` + `--password` (auto-login via `POST /api/sessions`)
-2. **Token:** `--user-id` + `--token` (skip login, use pre-existing credentials)
+Three modes:
+1. **Email/password flags:** `--email` + `--password` (auto-login via `POST /api/sessions`)
+2. **Token flags:** `--user-id` + `--token` (skip login, use pre-existing credentials)
+3. **Config file:** `~/.skylight/config` (loaded automatically, CLI flags take precedence)
 
 Most commands require `--frame-id` to identify the target Skylight frame.
+
+### Config File
+
+Location: `~/.skylight/config` (override with `--config` flag)
+
+Format (KEY=VALUE, one per line):
+```
+SKYLIGHT_EMAIL=user@example.com
+SKYLIGHT_PASSWORD=secret
+SKYLIGHT_TOKEN=abc123
+SKYLIGHT_USER_ID=uid456
+SKYLIGHT_FRAME_ID=fid789
+```
+
+- CLI flags take precedence over config file values
+- `login --save` writes credentials to config file after successful login
+- Comments (`#`) and blank lines are supported
+
+## CLI Commands
+
+### Top-level
+- `login` -- Authenticate and print credentials (with `--save` to write config)
+- `dashboard` / `today` -- Today's aggregated dashboard
+- `bounty create|list` -- Chore + reward pairs
+- `rotation create` -- Rotating chore assignments
+
+### Under `get`
+- `get calendar list|create|update|delete|sources`
+- `get chore list|create|update|delete`
+- `get reward list|create|update|delete|redeem|unredeem|points`
+- `get list all|info|create|update|delete|add-item|update-item|delete-item`
+- `get meal categories|recipes|recipe-info|create-recipe|update-recipe|delete-recipe|sittings|create-sitting|add-to-grocery`
+- `get category`
+- `get frame info|devices|avatars|colors`
+
+### Update Commands
+
+All update commands use `cmd.Flags().Changed()` to only send fields that were explicitly set:
+
+- `get chore update --chore-id ID [--title] [--status] [--points] [--assignee-id] [--date]`
+- `get calendar update --event-id ID [--title] [--start-at] [--end-at] [--all-day]`
+- `get list update --list-id ID [--title] [--color]`
+- `get list update-item --list-id ID --item-id ID [--title] [--completed]`
+- `get reward update --reward-id ID [--title] [--points] [--emoji-icon]`
+- `get meal update-recipe --recipe-id ID [--title] [--description] [--ingredients] [--url]`
+
+### Recipe Create Flags
+
+`get meal create-recipe --title TITLE [--description] [--ingredients item1,item2] [--url]`
 
 ## API Base URL
 
@@ -71,9 +125,10 @@ Most commands require `--frame-id` to identify the target Skylight frame.
 
 ## CI/CD
 
-- GitHub Actions workflow at `.github/workflows/release-binaries.yaml`
-- Builds cross-platform binaries (linux/darwin, amd64/arm64) on release publish
-- Dependabot configured for dependency updates
+- Pre-main workflow at `.github/workflows/pre-main.yaml` -- runs lint, test, build on matrix (ubuntu + macos), plus govulncheck
+- Release workflow at `.github/workflows/release-binaries.yaml` -- cross-platform binaries (linux/darwin, amd64/arm64) with SHA256 checksums
+- Version injected via ldflags at build time
+- Linters: goconst, gocritic, gocyclo, misspell, unparam, errcheck, gosec, ineffassign, revive, staticcheck
 
 ## Notes
 


### PR DESCRIPTION
## Summary

- Document config file support (`~/.skylight/config`, `--config`, `login --save`)
- Document all update CLI commands (chore, calendar, list, list-item, reward, recipe)
- Document enhanced `create-recipe` flags (--description, --ingredients, --url)
- Update build section with version injection via ldflags
- Update CI section with consolidated matrix workflow, govulncheck, expanded linters, and release checksums
- Add full CLI command reference section

## Test plan

- [x] `make lint` passes
- [x] `make test` passes
- [ ] CI passes