### PR TITLE
fix: unify getClient usage, add required flag validation, and add missing godoc

### DIFF
--- a/cmd/bounty.go
+++ b/cmd/bounty.go
@@ -78,4 +78,7 @@ func init() {
 	bountyCreateCmd.Flags().StringVar(&bountyRewardTitle, "reward-title", "", "Reward title")
 	bountyCreateCmd.Flags().StringVar(&bountyEmojiIcon, "emoji-icon", "", "Reward emoji icon")
 	bountyCreateCmd.Flags().BoolVar(&bountyRecurring, "recurring", false, "Make chore recurring")
+	bountyCreateCmd.MarkFlagRequired("title")        //nolint:errcheck
+	bountyCreateCmd.MarkFlagRequired("points")       //nolint:errcheck
+	bountyCreateCmd.MarkFlagRequired("reward-title") //nolint:errcheck
 }

--- a/cmd/calendar.go
+++ b/cmd/calendar.go
@@ -29,11 +29,7 @@ var calendarListCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		requireFrameID()
 
-		client, err := lib.NewClientWithToken(userID, token)
-		if err != nil {
-			fmt.Printf("Error creating client: %v\n", err)
-			os.Exit(1)
-		}
+		client := getClient()
 
 		events, err := client.ListCalendarEvents(frameID, calendarStartDate, calendarEndDate)
 		if err != nil {
@@ -51,11 +47,7 @@ var calendarCreateCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		requireFrameID()
 
-		client, err := lib.NewClientWithToken(userID, token)
-		if err != nil {
-			fmt.Printf("Error creating client: %v\n", err)
-			os.Exit(1)
-		}
+		client := getClient()
 
 		event, err := client.CreateCalendarEvent(frameID, lib.CalendarEventData{
 			Title:   calendarTitle,
@@ -78,13 +70,9 @@ var calendarDeleteCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		requireFrameID()
 
-		client, err := lib.NewClientWithToken(userID, token)
-		if err != nil {
-			fmt.Printf("Error creating client: %v\n", err)
-			os.Exit(1)
-		}
+		client := getClient()
 
-		err = client.DeleteCalendarEvent(frameID, calendarEventID)
+		err := client.DeleteCalendarEvent(frameID, calendarEventID)
 		if err != nil {
 			fmt.Printf("Error deleting calendar event: %v\n", err)
 			os.Exit(1)
@@ -100,11 +88,7 @@ var sourceCalendarsCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		requireFrameID()
 
-		client, err := lib.NewClientWithToken(userID, token)
-		if err != nil {
-			fmt.Printf("Error creating client: %v\n", err)
-			os.Exit(1)
-		}
+		client := getClient()
 
 		calendars, err := client.ListSourceCalendars(frameID)
 		if err != nil {
@@ -162,6 +146,8 @@ func init() {
 	calendarCreateCmd.Flags().StringVar(&calendarStartAt, "start-at", "", "Event start time")
 	calendarCreateCmd.Flags().StringVar(&calendarEndAt, "end-at", "", "Event end time")
 	calendarCreateCmd.Flags().BoolVar(&calendarAllDay, "all-day", false, "All day event")
+	calendarCreateCmd.MarkFlagRequired("title")    //nolint:errcheck
+	calendarCreateCmd.MarkFlagRequired("start-at") //nolint:errcheck
 
 	calendarUpdateCmd.Flags().StringVar(&calendarEventID, "event-id", "", "Event ID to update")
 	calendarUpdateCmd.Flags().StringVar(&calendarTitle, "title", "", "Event title")
@@ -170,4 +156,5 @@ func init() {
 	calendarUpdateCmd.Flags().BoolVar(&calendarAllDay, "all-day", false, "All day event")
 
 	calendarDeleteCmd.Flags().StringVar(&calendarEventID, "event-id", "", "Event ID to delete")
+	calendarDeleteCmd.MarkFlagRequired("event-id") //nolint:errcheck
 }

--- a/cmd/category.go
+++ b/cmd/category.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/sebrandon1/go-skylight/lib"
 	"github.com/spf13/cobra"
 )
 
@@ -14,11 +13,7 @@ var categoryCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		requireFrameID()
 
-		client, err := lib.NewClientWithToken(userID, token)
-		if err != nil {
-			fmt.Printf("Error creating client: %v\n", err)
-			os.Exit(1)
-		}
+		client := getClient()
 
 		categories, err := client.ListCategories(frameID)
 		if err != nil {

--- a/cmd/chore.go
+++ b/cmd/chore.go
@@ -147,6 +147,7 @@ func init() {
 	choreCreateCmd.Flags().StringVar(&choreAssigneeID, "assignee-id", "", "Assignee ID")
 	choreCreateCmd.Flags().IntVar(&chorePoints, "points", 0, "Points value")
 	choreCreateCmd.Flags().BoolVar(&choreRecurring, "recurring", false, "Make chore recurring")
+	choreCreateCmd.MarkFlagRequired("title") //nolint:errcheck
 
 	choreUpdateCmd.Flags().StringVar(&choreID, "chore-id", "", "Chore ID to update")
 	choreUpdateCmd.Flags().StringVar(&choreTitle, "title", "", "Chore title")

--- a/cmd/frame.go
+++ b/cmd/frame.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/sebrandon1/go-skylight/lib"
 	"github.com/spf13/cobra"
 )
 
@@ -19,11 +18,7 @@ var frameInfoCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		requireFrameID()
 
-		client, err := lib.NewClientWithToken(userID, token)
-		if err != nil {
-			fmt.Printf("Error creating client: %v\n", err)
-			os.Exit(1)
-		}
+		client := getClient()
 
 		frame, err := client.GetFrame(frameID)
 		if err != nil {
@@ -41,11 +36,7 @@ var frameDevicesCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		requireFrameID()
 
-		client, err := lib.NewClientWithToken(userID, token)
-		if err != nil {
-			fmt.Printf("Error creating client: %v\n", err)
-			os.Exit(1)
-		}
+		client := getClient()
 
 		devices, err := client.ListDevices(frameID)
 		if err != nil {
@@ -61,11 +52,7 @@ var frameAvatarsCmd = &cobra.Command{
 	Use:   "avatars",
 	Short: "List available avatars",
 	Run: func(cmd *cobra.Command, args []string) {
-		client, err := lib.NewClientWithToken(userID, token)
-		if err != nil {
-			fmt.Printf("Error creating client: %v\n", err)
-			os.Exit(1)
-		}
+		client := getClient()
 
 		avatars, err := client.GetAvatars()
 		if err != nil {
@@ -81,11 +68,7 @@ var frameColorsCmd = &cobra.Command{
 	Use:   "colors",
 	Short: "List available colors",
 	Run: func(cmd *cobra.Command, args []string) {
-		client, err := lib.NewClientWithToken(userID, token)
-		if err != nil {
-			fmt.Printf("Error creating client: %v\n", err)
-			os.Exit(1)
-		}
+		client := getClient()
 
 		colors, err := client.GetColors()
 		if err != nil {

--- a/cmd/list.go
+++ b/cmd/list.go
@@ -28,11 +28,7 @@ var listListCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		requireFrameID()
 
-		client, err := lib.NewClientWithToken(userID, token)
-		if err != nil {
-			fmt.Printf("Error creating client: %v\n", err)
-			os.Exit(1)
-		}
+		client := getClient()
 
 		lists, err := client.ListLists(frameID)
 		if err != nil {
@@ -50,11 +46,7 @@ var listGetCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		requireFrameID()
 
-		client, err := lib.NewClientWithToken(userID, token)
-		if err != nil {
-			fmt.Printf("Error creating client: %v\n", err)
-			os.Exit(1)
-		}
+		client := getClient()
 
 		list, err := client.GetList(frameID, listID)
 		if err != nil {
@@ -72,11 +64,7 @@ var listCreateCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		requireFrameID()
 
-		client, err := lib.NewClientWithToken(userID, token)
-		if err != nil {
-			fmt.Printf("Error creating client: %v\n", err)
-			os.Exit(1)
-		}
+		client := getClient()
 
 		list, err := client.CreateList(frameID, lib.ListData{
 			Title: listTitle,
@@ -97,13 +85,9 @@ var listDeleteCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		requireFrameID()
 
-		client, err := lib.NewClientWithToken(userID, token)
-		if err != nil {
-			fmt.Printf("Error creating client: %v\n", err)
-			os.Exit(1)
-		}
+		client := getClient()
 
-		err = client.DeleteList(frameID, listID)
+		err := client.DeleteList(frameID, listID)
 		if err != nil {
 			fmt.Printf("Error deleting list: %v\n", err)
 			os.Exit(1)
@@ -119,11 +103,7 @@ var listAddItemCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		requireFrameID()
 
-		client, err := lib.NewClientWithToken(userID, token)
-		if err != nil {
-			fmt.Printf("Error creating client: %v\n", err)
-			os.Exit(1)
-		}
+		client := getClient()
 
 		item, err := client.AddListItem(frameID, listID, lib.ListItemData{
 			Title: listItemTitle,
@@ -143,13 +123,9 @@ var listDeleteItemCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		requireFrameID()
 
-		client, err := lib.NewClientWithToken(userID, token)
-		if err != nil {
-			fmt.Printf("Error creating client: %v\n", err)
-			os.Exit(1)
-		}
+		client := getClient()
 
-		err = client.DeleteListItem(frameID, listID, listItemID)
+		err := client.DeleteListItem(frameID, listID, listItemID)
 		if err != nil {
 			fmt.Printf("Error deleting list item: %v\n", err)
 			os.Exit(1)
@@ -222,9 +198,14 @@ func init() {
 	listCmd.AddCommand(listDeleteItemCmd)
 
 	listGetCmd.Flags().StringVar(&listID, "list-id", "", "List ID")
+	listGetCmd.MarkFlagRequired("list-id") //nolint:errcheck
+
 	listCreateCmd.Flags().StringVar(&listTitle, "title", "", "List title")
 	listCreateCmd.Flags().StringVar(&listColor, "color", "", "List color")
+	listCreateCmd.MarkFlagRequired("title") //nolint:errcheck
+
 	listDeleteCmd.Flags().StringVar(&listID, "list-id", "", "List ID")
+	listDeleteCmd.MarkFlagRequired("list-id") //nolint:errcheck
 
 	listUpdateCmd.Flags().StringVar(&listID, "list-id", "", "List ID")
 	listUpdateCmd.Flags().StringVar(&listTitle, "title", "", "List title")
@@ -232,12 +213,18 @@ func init() {
 
 	listAddItemCmd.Flags().StringVar(&listID, "list-id", "", "List ID")
 	listAddItemCmd.Flags().StringVar(&listItemTitle, "title", "", "Item title")
+	listAddItemCmd.MarkFlagRequired("list-id") //nolint:errcheck
+	listAddItemCmd.MarkFlagRequired("title")   //nolint:errcheck
 
 	listUpdateItemCmd.Flags().StringVar(&listID, "list-id", "", "List ID")
 	listUpdateItemCmd.Flags().StringVar(&listItemID, "item-id", "", "Item ID")
 	listUpdateItemCmd.Flags().StringVar(&listItemTitle, "title", "", "Item title")
 	listUpdateItemCmd.Flags().BoolVar(&listItemCompleted, "completed", false, "Mark item as completed")
+	listUpdateItemCmd.MarkFlagRequired("list-id") //nolint:errcheck
+	listUpdateItemCmd.MarkFlagRequired("item-id") //nolint:errcheck
 
 	listDeleteItemCmd.Flags().StringVar(&listID, "list-id", "", "List ID")
 	listDeleteItemCmd.Flags().StringVar(&listItemID, "item-id", "", "Item ID")
+	listDeleteItemCmd.MarkFlagRequired("list-id") //nolint:errcheck
+	listDeleteItemCmd.MarkFlagRequired("item-id") //nolint:errcheck
 }

--- a/cmd/meal.go
+++ b/cmd/meal.go
@@ -29,11 +29,7 @@ var mealCategoriesCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		requireFrameID()
 
-		client, err := lib.NewClientWithToken(userID, token)
-		if err != nil {
-			fmt.Printf("Error creating client: %v\n", err)
-			os.Exit(1)
-		}
+		client := getClient()
 
 		categories, err := client.ListMealCategories(frameID)
 		if err != nil {
@@ -51,11 +47,7 @@ var mealRecipesCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		requireFrameID()
 
-		client, err := lib.NewClientWithToken(userID, token)
-		if err != nil {
-			fmt.Printf("Error creating client: %v\n", err)
-			os.Exit(1)
-		}
+		client := getClient()
 
 		recipes, err := client.ListRecipes(frameID)
 		if err != nil {
@@ -73,11 +65,7 @@ var mealRecipeInfoCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		requireFrameID()
 
-		client, err := lib.NewClientWithToken(userID, token)
-		if err != nil {
-			fmt.Printf("Error creating client: %v\n", err)
-			os.Exit(1)
-		}
+		client := getClient()
 
 		recipe, err := client.GetRecipe(frameID, recipeID)
 		if err != nil {
@@ -95,11 +83,7 @@ var mealCreateRecipeCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		requireFrameID()
 
-		client, err := lib.NewClientWithToken(userID, token)
-		if err != nil {
-			fmt.Printf("Error creating client: %v\n", err)
-			os.Exit(1)
-		}
+		client := getClient()
 
 		recipe, err := client.CreateRecipe(frameID, lib.RecipeData{
 			Title:       recipeTitle,
@@ -122,13 +106,9 @@ var mealDeleteRecipeCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		requireFrameID()
 
-		client, err := lib.NewClientWithToken(userID, token)
-		if err != nil {
-			fmt.Printf("Error creating client: %v\n", err)
-			os.Exit(1)
-		}
+		client := getClient()
 
-		err = client.DeleteRecipe(frameID, recipeID)
+		err := client.DeleteRecipe(frameID, recipeID)
 		if err != nil {
 			fmt.Printf("Error deleting recipe: %v\n", err)
 			os.Exit(1)
@@ -144,11 +124,7 @@ var mealSittingsCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		requireFrameID()
 
-		client, err := lib.NewClientWithToken(userID, token)
-		if err != nil {
-			fmt.Printf("Error creating client: %v\n", err)
-			os.Exit(1)
-		}
+		client := getClient()
 
 		sittings, err := client.ListMealSittings(frameID)
 		if err != nil {
@@ -166,11 +142,7 @@ var mealCreateSittingCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		requireFrameID()
 
-		client, err := lib.NewClientWithToken(userID, token)
-		if err != nil {
-			fmt.Printf("Error creating client: %v\n", err)
-			os.Exit(1)
-		}
+		client := getClient()
 
 		sitting, err := client.CreateMealSitting(frameID, lib.MealSittingData{
 			RecipeID: recipeID,
@@ -192,13 +164,9 @@ var mealAddToGroceryCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		requireFrameID()
 
-		client, err := lib.NewClientWithToken(userID, token)
-		if err != nil {
-			fmt.Printf("Error creating client: %v\n", err)
-			os.Exit(1)
-		}
+		client := getClient()
 
-		err = client.AddRecipeToGroceryList(frameID, recipeID)
+		err := client.AddRecipeToGroceryList(frameID, recipeID)
 		if err != nil {
 			fmt.Printf("Error adding to grocery list: %v\n", err)
 			os.Exit(1)
@@ -252,11 +220,13 @@ func init() {
 	mealCmd.AddCommand(mealAddToGroceryCmd)
 
 	mealRecipeInfoCmd.Flags().StringVar(&recipeID, "recipe-id", "", "Recipe ID")
+	mealRecipeInfoCmd.MarkFlagRequired("recipe-id") //nolint:errcheck
 
 	mealCreateRecipeCmd.Flags().StringVar(&recipeTitle, "title", "", "Recipe title")
 	mealCreateRecipeCmd.Flags().StringVar(&recipeDescription, "description", "", "Recipe description")
 	mealCreateRecipeCmd.Flags().StringSliceVar(&recipeIngredients, "ingredients", nil, "Ingredients (comma-separated)")
 	mealCreateRecipeCmd.Flags().StringVar(&recipeURL, "url", "", "Recipe URL")
+	mealCreateRecipeCmd.MarkFlagRequired("title") //nolint:errcheck
 
 	mealUpdateRecipeCmd.Flags().StringVar(&recipeID, "recipe-id", "", "Recipe ID to update")
 	mealUpdateRecipeCmd.Flags().StringVar(&recipeTitle, "title", "", "Recipe title")
@@ -265,6 +235,7 @@ func init() {
 	mealUpdateRecipeCmd.Flags().StringVar(&recipeURL, "url", "", "Recipe URL")
 
 	mealDeleteRecipeCmd.Flags().StringVar(&recipeID, "recipe-id", "", "Recipe ID")
+	mealDeleteRecipeCmd.MarkFlagRequired("recipe-id") //nolint:errcheck
 
 	mealCreateSittingCmd.Flags().StringVar(&recipeID, "recipe-id", "", "Recipe ID")
 	mealCreateSittingCmd.Flags().StringVar(&sittingDate, "date", "", "Sitting date")

--- a/cmd/reward.go
+++ b/cmd/reward.go
@@ -187,6 +187,8 @@ func init() {
 	rewardCreateCmd.Flags().StringVar(&rewardEmojiIcon, "emoji-icon", "", "Emoji icon for the reward")
 	rewardCreateCmd.Flags().BoolVar(&rewardNoRespawn, "no-respawn", false, "Disable respawn on redemption")
 	rewardCreateCmd.Flags().IntSliceVar(&rewardCategoryIDs, "category-ids", nil, "Category IDs to assign reward to")
+	rewardCreateCmd.MarkFlagRequired("title")  //nolint:errcheck
+	rewardCreateCmd.MarkFlagRequired("points") //nolint:errcheck
 
 	rewardUpdateCmd.Flags().StringVar(&rewardID, "reward-id", "", "Reward ID to update")
 	rewardUpdateCmd.Flags().StringVar(&rewardTitle, "title", "", "Reward title")


### PR DESCRIPTION
## Summary

- **Unify `getClient()` usage** — `cmd/calendar.go`, `cmd/list.go`, `cmd/meal.go`, `cmd/frame.go`, and `cmd/category.go` were calling `lib.NewClientWithToken()` directly inside `RunE`, bypassing the root-level `PersistentPreRunE` that handles email/password auto-login and config file loading. All now use `getClient()` so auth works consistently regardless of which command is run.

- **Required flag validation** — Added `MarkFlagRequired` for mandatory flags on create/delete/get commands across `calendar`, `chore`, `reward`, `list`, `meal`, and `bounty`. Users now get a clear usage error instead of a cryptic API response when required flags are omitted.

- **Missing godoc** — Verified all exported functions in `lib/meal.go`, `lib/list.go`, and `lib/dashboard.go` have godoc comments (they were already present; no changes needed).

## Test plan

- [ ] `make lint` — 0 issues
- [ ] `make test` — all packages pass
- [ ] `go-skylight get chore create` (no flags) → shows usage error with required flag message
- [ ] `go-skylight get calendar list --email user@example.com --password pw` → auth works via config/email path for all commands