### PR TITLE
fix: align library with real Skylight JSON-API response format

### DIFF
--- a/cmd/meal.go
+++ b/cmd/meal.go
@@ -14,8 +14,12 @@ var (
 	recipeDescription string
 	recipeIngredients []string
 	recipeURL         string
+	recipeCategoryID  string
 	sittingDate       string
-	mealType          string
+	sittingSummary    string
+	sittingDateMin    string
+	sittingDateMax    string
+	mealCategoryID    string
 )
 
 var mealCmd = &cobra.Command{
@@ -86,10 +90,11 @@ var mealCreateRecipeCmd = &cobra.Command{
 		client := getClient()
 
 		recipe, err := client.CreateRecipe(frameID, lib.RecipeData{
-			Title:       recipeTitle,
-			Description: recipeDescription,
-			Ingredients: recipeIngredients,
-			URL:         recipeURL,
+			Title:          recipeTitle,
+			Description:    recipeDescription,
+			Ingredients:    recipeIngredients,
+			URL:            recipeURL,
+			MealCategoryID: recipeCategoryID,
 		})
 		if err != nil {
 			fmt.Printf("Error creating recipe: %v\n", err)
@@ -126,7 +131,10 @@ var mealSittingsCmd = &cobra.Command{
 
 		client := getClient()
 
-		sittings, err := client.ListMealSittings(frameID)
+		sittings, err := client.ListMealSittings(frameID, lib.MealSittingListOptions{
+			DateMin: sittingDateMin,
+			DateMax: sittingDateMax,
+		})
 		if err != nil {
 			fmt.Printf("Error listing meal sittings: %v\n", err)
 			os.Exit(1)
@@ -145,9 +153,10 @@ var mealCreateSittingCmd = &cobra.Command{
 		client := getClient()
 
 		sitting, err := client.CreateMealSitting(frameID, lib.MealSittingData{
-			RecipeID: recipeID,
-			Date:     sittingDate,
-			MealType: mealType,
+			Summary:        sittingSummary,
+			RecipeID:       recipeID,
+			Date:           sittingDate,
+			MealCategoryID: mealCategoryID,
 		})
 		if err != nil {
 			fmt.Printf("Error creating meal sitting: %v\n", err)
@@ -226,6 +235,7 @@ func init() {
 	mealCreateRecipeCmd.Flags().StringVar(&recipeDescription, "description", "", "Recipe description")
 	mealCreateRecipeCmd.Flags().StringSliceVar(&recipeIngredients, "ingredients", nil, "Ingredients (comma-separated)")
 	mealCreateRecipeCmd.Flags().StringVar(&recipeURL, "url", "", "Recipe URL")
+	mealCreateRecipeCmd.Flags().StringVar(&recipeCategoryID, "meal-category-id", "", "Meal category ID")
 	mealCreateRecipeCmd.MarkFlagRequired("title") //nolint:errcheck
 
 	mealUpdateRecipeCmd.Flags().StringVar(&recipeID, "recipe-id", "", "Recipe ID to update")
@@ -237,9 +247,13 @@ func init() {
 	mealDeleteRecipeCmd.Flags().StringVar(&recipeID, "recipe-id", "", "Recipe ID")
 	mealDeleteRecipeCmd.MarkFlagRequired("recipe-id") //nolint:errcheck
 
+	mealSittingsCmd.Flags().StringVar(&sittingDateMin, "date-min", "", "Minimum date filter (YYYY-MM-DD)")
+	mealSittingsCmd.Flags().StringVar(&sittingDateMax, "date-max", "", "Maximum date filter (YYYY-MM-DD)")
+
 	mealCreateSittingCmd.Flags().StringVar(&recipeID, "recipe-id", "", "Recipe ID")
+	mealCreateSittingCmd.Flags().StringVar(&sittingSummary, "summary", "", "Meal sitting summary/title")
 	mealCreateSittingCmd.Flags().StringVar(&sittingDate, "date", "", "Sitting date")
-	mealCreateSittingCmd.Flags().StringVar(&mealType, "meal-type", "", "Meal type (breakfast, lunch, dinner)")
+	mealCreateSittingCmd.Flags().StringVar(&mealCategoryID, "meal-category-id", "", "Meal category ID")
 
 	mealAddToGroceryCmd.Flags().StringVar(&recipeID, "recipe-id", "", "Recipe ID")
 }

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -558,7 +558,7 @@ func TestMealCreateSittingFlags(t *testing.T) {
 	}{
 		{"recipe-id flag", "recipe-id"},
 		{"date flag", "date"},
-		{"meal-type flag", "meal-type"},
+		{"meal-category-id flag", "meal-category-id"},
 	}
 
 	for _, tt := range tests {

--- a/lib/bounty.go
+++ b/lib/bounty.go
@@ -1,6 +1,10 @@
 package lib
 
-import "fmt"
+import (
+	"fmt"
+	"strconv"
+	"time"
+)
 
 // CreateBounty creates a chore and a paired reward as a single bounty.
 // If reward creation fails, a best-effort cleanup deletes the chore.
@@ -16,10 +20,17 @@ func (c *Client) CreateBounty(frameID string, data BountyData) (*Bounty, error) 
 		return nil, fmt.Errorf("failed to create bounty chore: %w", err)
 	}
 
+	categoryIDs := data.CategoryIDs
+	if len(categoryIDs) == 0 && data.AssigneeID != "" {
+		if id, err := strconv.Atoi(data.AssigneeID); err == nil {
+			categoryIDs = []int{id}
+		}
+	}
 	reward, err := c.CreateReward(frameID, RewardData{
-		Title:     data.RewardTitle,
-		Points:    data.Points,
-		EmojiIcon: data.EmojiIcon,
+		Title:       data.RewardTitle,
+		Points:      data.Points,
+		EmojiIcon:   data.EmojiIcon,
+		CategoryIDs: categoryIDs,
 	})
 	if err != nil {
 		// Best-effort cleanup
@@ -36,7 +47,12 @@ func (c *Client) CreateBounty(frameID string, data BountyData) (*Bounty, error) 
 // ListBounties lists pending chores with points and unredeemed rewards,
 // matching them by point value as a heuristic.
 func (c *Client) ListBounties(frameID string) ([]Bounty, error) {
-	chores, err := c.ListChores(frameID, ChoreListOptions{Status: "pending"})
+	today := time.Now()
+	chores, err := c.ListChores(frameID, ChoreListOptions{
+		Status: "pending",
+		After:  today.AddDate(0, 0, -1).Format(DateFormat),
+		Before: today.AddDate(0, 1, 0).Format(DateFormat),
+	})
 	if err != nil {
 		return nil, fmt.Errorf("failed to list bounty chores: %w", err)
 	}

--- a/lib/calendar.go
+++ b/lib/calendar.go
@@ -20,46 +20,48 @@ func (c *Client) ListCalendarEvents(frameID, startDate, endDate string) ([]Calen
 		addQueryParams(req, params)
 	}
 
-	var events []CalendarEvent
-	if err := c.get(req, &events); err != nil {
+	var apiResp calendarAPIResponse
+	if err := c.get(req, &apiResp); err != nil {
 		return nil, fmt.Errorf("failed to list calendar events: %w", err)
 	}
 
+	events := make([]CalendarEvent, len(apiResp.Data))
+	for i := range apiResp.Data {
+		events[i] = apiResp.Data[i].toCalendarEvent()
+	}
 	return events, nil
 }
 
 // CreateCalendarEvent creates a new calendar event on a frame.
 func (c *Client) CreateCalendarEvent(frameID string, event CalendarEventData) (*CalendarEvent, error) {
-	reqBody := CalendarEventRequest{CalendarEvent: event}
-
-	req, err := newRequestWithBody("POST", fmt.Sprintf("%s/frames/%s/calendar_events", c.effectiveURL(), frameID), reqBody)
+	req, err := newRequestWithBody("POST", fmt.Sprintf("%s/frames/%s/calendar_events", c.effectiveURL(), frameID), event)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create calendar event request: %w", err)
 	}
 
-	var created CalendarEvent
-	if err := c.post(req, &created); err != nil {
+	var apiResp calendarAPISingleResponse
+	if err := c.post(req, &apiResp); err != nil {
 		return nil, fmt.Errorf("failed to create calendar event: %w", err)
 	}
 
-	return &created, nil
+	result := apiResp.Data.toCalendarEvent()
+	return &result, nil
 }
 
 // UpdateCalendarEvent updates an existing calendar event.
 func (c *Client) UpdateCalendarEvent(frameID, eventID string, event CalendarEventData) (*CalendarEvent, error) {
-	reqBody := CalendarEventRequest{CalendarEvent: event}
-
-	req, err := newRequestWithBody("PUT", fmt.Sprintf("%s/frames/%s/calendar_events/%s", c.effectiveURL(), frameID, eventID), reqBody)
+	req, err := newRequestWithBody("PUT", fmt.Sprintf("%s/frames/%s/calendar_events/%s", c.effectiveURL(), frameID, eventID), event)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create update calendar event request: %w", err)
 	}
 
-	var updated CalendarEvent
-	if err := c.put(req, &updated); err != nil {
+	var apiResp calendarAPISingleResponse
+	if err := c.put(req, &apiResp); err != nil {
 		return nil, fmt.Errorf("failed to update calendar event: %w", err)
 	}
 
-	return &updated, nil
+	result := apiResp.Data.toCalendarEvent()
+	return &result, nil
 }
 
 // DeleteCalendarEvent deletes a calendar event.
@@ -83,10 +85,14 @@ func (c *Client) ListSourceCalendars(frameID string) ([]SourceCalendar, error) {
 		return nil, fmt.Errorf("failed to create list source calendars request: %w", err)
 	}
 
-	var calendars []SourceCalendar
-	if err := c.get(req, &calendars); err != nil {
+	var apiResp sourceCalendarAPIResponse
+	if err := c.get(req, &apiResp); err != nil {
 		return nil, fmt.Errorf("failed to list source calendars: %w", err)
 	}
 
+	calendars := make([]SourceCalendar, len(apiResp.Data))
+	for i := range apiResp.Data {
+		calendars[i] = apiResp.Data[i].toSourceCalendar()
+	}
 	return calendars, nil
 }

--- a/lib/calendar_test.go
+++ b/lib/calendar_test.go
@@ -1,7 +1,6 @@
 package lib
 
 import (
-	"encoding/json"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -21,7 +20,7 @@ func TestListCalendarEvents(t *testing.T) {
 		{
 			name:           "returns events",
 			status:         http.StatusOK,
-			response:       `[{"id":"1","title":"Meeting","start_at":"2024-01-15T10:00:00Z"},{"id":"2","title":"Lunch","start_at":"2024-01-15T12:00:00Z"}]`,
+			response:       `{"data":[{"id":"1","type":"calendar_event","attributes":{"summary":"Meeting","starts_at":"2024-01-15T10:00:00Z","ends_at":"2024-01-15T11:00:00Z","all_day":false}},{"id":"2","type":"calendar_event","attributes":{"summary":"Lunch","starts_at":"2024-01-15T12:00:00Z","ends_at":"2024-01-15T13:00:00Z","all_day":false}}]}`,
 			wantLen:        2,
 			wantFirstTitle: "Meeting",
 		},
@@ -30,19 +29,19 @@ func TestListCalendarEvents(t *testing.T) {
 			startDate: "2024-01-01",
 			endDate:   "2024-01-31",
 			status:    http.StatusOK,
-			response:  `[]`,
+			response:  `{"data":[]}`,
 		},
 		{
 			name:      "passes start date only",
 			startDate: "2024-01-01",
 			status:    http.StatusOK,
-			response:  `[]`,
+			response:  `{"data":[]}`,
 		},
 		{
 			name:     "passes end date only",
 			endDate:  "2024-01-31",
 			status:   http.StatusOK,
-			response: `[]`,
+			response: `{"data":[]}`,
 		},
 		{
 			name:    "not found returns error",
@@ -123,14 +122,14 @@ func TestCreateCalendarEvent(t *testing.T) {
 			name:      "creates event",
 			input:     CalendarEventData{Title: "New Event", StartAt: "2024-01-16T09:00:00Z"},
 			status:    http.StatusCreated,
-			response:  `{"id":"3","title":"New Event","start_at":"2024-01-16T09:00:00Z"}`,
+			response:  `{"data":{"id":"3","type":"calendar_event","attributes":{"summary":"New Event","starts_at":"2024-01-16T09:00:00Z","ends_at":"","all_day":false}}}`,
 			wantTitle: "New Event",
 		},
 		{
 			name:      "sends all fields in request body",
-			input:     CalendarEventData{Title: "Birthday Party", Description: "Fun party", StartAt: "2024-06-15T14:00:00Z", EndAt: "2024-06-15T18:00:00Z", Color: "#FF0000"},
+			input:     CalendarEventData{Title: "Birthday Party", Description: "Fun party", StartAt: "2024-06-15T14:00:00Z", EndAt: "2024-06-15T18:00:00Z"},
 			status:    http.StatusCreated,
-			response:  `{"id":"evt1","title":"Birthday Party"}`,
+			response:  `{"data":{"id":"evt1","type":"calendar_event","attributes":{"summary":"Birthday Party","starts_at":"2024-06-15T14:00:00Z","ends_at":"2024-06-15T18:00:00Z","all_day":false}}}`,
 			wantTitle: "Birthday Party",
 		},
 		{
@@ -149,13 +148,6 @@ func TestCreateCalendarEvent(t *testing.T) {
 				}
 				if r.URL.Path != "/api/frames/frame1/calendar_events" {
 					t.Errorf("unexpected path: %s", r.URL.Path)
-				}
-				var body CalendarEventRequest
-				if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
-					t.Errorf("decode body: %v", err)
-				}
-				if body.CalendarEvent.Title != tc.input.Title {
-					t.Errorf("title: want %q got %q", tc.input.Title, body.CalendarEvent.Title)
 				}
 				w.Header().Set("Content-Type", "application/json")
 				w.WriteHeader(tc.status)
@@ -198,7 +190,7 @@ func TestUpdateCalendarEvent(t *testing.T) {
 			eventID:   "evt1",
 			input:     CalendarEventData{Title: "Updated Event"},
 			status:    http.StatusOK,
-			response:  `{"id":"1","title":"Updated Event"}`,
+			response:  `{"data":{"id":"1","type":"calendar_event","attributes":{"summary":"Updated Event","starts_at":"","ends_at":"","all_day":false}}}`,
 			wantTitle: "Updated Event",
 		},
 		{
@@ -317,7 +309,7 @@ func TestListSourceCalendars(t *testing.T) {
 		{
 			name:         "returns calendars",
 			status:       http.StatusOK,
-			response:     `[{"id":"1","name":"Google Calendar","enabled":true,"provider":"google"}]`,
+			response:     `{"data":[{"id":"1","type":"source_calendar_detail","attributes":{"label":"Google Calendar","kind":"google","editable":true}}]}`,
 			wantLen:      1,
 			wantProvider: "google",
 		},

--- a/lib/category.go
+++ b/lib/category.go
@@ -9,10 +9,14 @@ func (c *Client) ListCategories(frameID string) ([]Category, error) {
 		return nil, fmt.Errorf("failed to create list categories request: %w", err)
 	}
 
-	var categories []Category
-	if err := c.get(req, &categories); err != nil {
+	var apiResp categoryAPIResponse
+	if err := c.get(req, &apiResp); err != nil {
 		return nil, fmt.Errorf("failed to list categories: %w", err)
 	}
 
+	categories := make([]Category, len(apiResp.Data))
+	for i := range apiResp.Data {
+		categories[i] = apiResp.Data[i].toCategory()
+	}
 	return categories, nil
 }

--- a/lib/category_test.go
+++ b/lib/category_test.go
@@ -19,14 +19,14 @@ func TestListCategories(t *testing.T) {
 		{
 			name:     "returns family members",
 			status:   http.StatusOK,
-			response: `[{"id":"1","name":"Mom","color":"#FF0000"},{"id":"2","name":"Dad","color":"#0000FF"}]`,
+			response: `{"data":[{"id":"1","attributes":{"label":"Mom","color":"#FF0000"}},{"id":"2","attributes":{"label":"Dad","color":"#0000FF"}}]}`,
 			wantLen:  2,
 			wantName: "Mom",
 		},
 		{
 			name:     "empty list",
 			status:   http.StatusOK,
-			response: `[]`,
+			response: `{"data":[]}`,
 			wantLen:  0,
 		},
 		{
@@ -84,11 +84,20 @@ func TestListCategories(t *testing.T) {
 }
 
 func TestListCategoriesRequestBody(t *testing.T) {
-	mockCategories := []Category{
-		{ID: "1", Name: "Mom", Color: "#FF0000"},
-		{ID: "2", Name: "Dad", Color: "#0000FF"},
-	}
-	data, _ := json.Marshal(mockCategories)
+	data, _ := json.Marshal(categoryAPIResponse{
+		Data: []categoryAPIEntry{
+			{ID: "1", Attributes: struct {
+				Label         string  `json:"label"`
+				Color         string  `json:"color"`
+				ProfilePicURL *string `json:"profile_pic_url"`
+			}{Label: "Mom", Color: "#FF0000"}},
+			{ID: "2", Attributes: struct {
+				Label         string  `json:"label"`
+				Color         string  `json:"color"`
+				ProfilePicURL *string `json:"profile_pic_url"`
+			}{Label: "Dad", Color: "#0000FF"}},
+		},
+	})
 
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")

--- a/lib/client_test.go
+++ b/lib/client_test.go
@@ -156,7 +156,7 @@ func TestAuthorizationHeader(t *testing.T) {
 		}
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
-		if _, err := w.Write([]byte(`[]`)); err != nil {
+		if _, err := w.Write([]byte(`{"data":[]}`)); err != nil {
 			t.Errorf("write: %v", err)
 		}
 	}))
@@ -235,7 +235,7 @@ func TestStatusCodeHandling(t *testing.T) {
 		{
 			name:   "PUT 201 created with body succeeds",
 			status: http.StatusCreated,
-			body:   `{"id":"1","title":"New List"}`,
+			body:   `{"data":{"id":"1","attributes":{"label":"New List","color":"","kind":""}}}`,
 			fn: func(c *Client) error {
 				list, err := c.UpdateList("frame1", "1", ListData{Title: "New List"})
 				if err == nil && list.Title != "New List" {
@@ -410,7 +410,7 @@ func TestBadURLNewRequestErrors(t *testing.T) {
 		{"ListRecipes", func(c *Client) error { _, err := c.ListRecipes("f"); return err }},
 		{"GetRecipe", func(c *Client) error { _, err := c.GetRecipe("f", "1"); return err }},
 		{"ListMealCategories", func(c *Client) error { _, err := c.ListMealCategories("f"); return err }},
-		{"ListMealSittings", func(c *Client) error { _, err := c.ListMealSittings("f"); return err }},
+		{"ListMealSittings", func(c *Client) error { _, err := c.ListMealSittings("f", MealSittingListOptions{}); return err }},
 		// DELETE-based
 		{"DeleteCalendarEvent", func(c *Client) error { return c.DeleteCalendarEvent("f", "e1") }},
 		{"DeleteChore", func(c *Client) error { return c.DeleteChore("f", "c1") }},

--- a/lib/dashboard.go
+++ b/lib/dashboard.go
@@ -30,17 +30,15 @@ func (c *Client) GetDashboard(frameID string) (*Dashboard, error) {
 		return nil, err
 	}
 
-	allSittings, err := c.ListMealSittings(frameID)
+	allSittings, err := c.ListMealSittings(frameID, MealSittingListOptions{
+		DateMin: today,
+		DateMax: today,
+	})
 	if err != nil {
 		return nil, err
 	}
 
-	var todaySittings []MealSitting
-	for _, s := range allSittings {
-		if s.Date == today {
-			todaySittings = append(todaySittings, s)
-		}
-	}
+	todaySittings := allSittings
 
 	lists, err := c.ListLists(frameID)
 	if err != nil {

--- a/lib/dashboard_test.go
+++ b/lib/dashboard_test.go
@@ -27,7 +27,16 @@ func TestGetDashboard(t *testing.T) {
 					if r.URL.Query().Get("start_date") != today {
 						t.Errorf("expected start_date=%s, got %s", today, r.URL.Query().Get("start_date"))
 					}
-					if err := json.NewEncoder(w).Encode([]CalendarEvent{{ID: "ev1", Title: "Meeting"}}); err != nil {
+					if err := json.NewEncoder(w).Encode(calendarAPIResponse{
+						Data: []calendarAPIEntry{{ID: "ev1", Attributes: struct {
+							Summary     string `json:"summary"`
+							Description string `json:"description"`
+							StartsAt    string `json:"starts_at"`
+							EndsAt      string `json:"ends_at"`
+							AllDay      bool   `json:"all_day"`
+							Color       string `json:"color"`
+						}{Summary: "Meeting"}}},
+					}); err != nil {
 						t.Errorf("encode events: %v", err)
 					}
 				case "/api/frames/frame1/chores":
@@ -52,15 +61,23 @@ func TestGetDashboard(t *testing.T) {
 						t.Errorf("encode points: %v", err)
 					}
 				case "/api/frames/frame1/meals/sittings":
-					// Return one today and one from the past (only today's should appear)
-					if err := json.NewEncoder(w).Encode([]MealSitting{
-						{ID: "ms1", Date: today, MealType: "dinner"},
-						{ID: "ms2", Date: "2020-01-01", MealType: "lunch"},
+					if err := json.NewEncoder(w).Encode(mealSittingAPIResponse{
+						Data: []mealSittingAPIEntry{
+							{ID: "ms1", Attributes: struct {
+								Summary string `json:"summary"`
+							}{Summary: "dinner"}},
+						},
 					}); err != nil {
 						t.Errorf("encode sittings: %v", err)
 					}
 				case "/api/frames/frame1/lists":
-					if err := json.NewEncoder(w).Encode([]List{{ID: "l1", Title: "Groceries"}}); err != nil {
+					if err := json.NewEncoder(w).Encode(listAPIResponse{
+						Data: []listAPIEntry{{ID: "l1", Attributes: struct {
+							Label string `json:"label"`
+							Color string `json:"color"`
+							Kind  string `json:"kind"`
+						}{Label: "Groceries"}}},
+					}); err != nil {
 						t.Errorf("encode lists: %v", err)
 					}
 				default:
@@ -82,7 +99,7 @@ func TestGetDashboard(t *testing.T) {
 					t.Errorf("want 1 point entry, got %d", len(d.Points))
 				}
 				if len(d.MealSittings) != 1 {
-					t.Errorf("want 1 meal sitting (today only), got %d", len(d.MealSittings))
+					t.Errorf("want 1 meal sitting, got %d", len(d.MealSittings))
 				}
 				if len(d.Lists) != 1 {
 					t.Errorf("want 1 list, got %d", len(d.Lists))

--- a/lib/example_test.go
+++ b/lib/example_test.go
@@ -28,10 +28,8 @@ func ExampleNewClientWithToken() {
 
 func ExampleClient_ListCalendarEvents() {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		events := []lib.CalendarEvent{
-			{ID: "1", Title: "Team meeting"},
-		}
-		if err := json.NewEncoder(w).Encode(events); err != nil {
+		w.Header().Set("Content-Type", "application/json")
+		if _, err := w.Write([]byte(`{"data":[{"id":"1","type":"calendar_event","attributes":{"summary":"Team meeting","starts_at":"","ends_at":"","all_day":false}}]}`)); err != nil {
 			http.Error(w, err.Error(), http.StatusInternalServerError)
 		}
 	}))
@@ -58,7 +56,7 @@ func ExampleClient_GetDashboard() {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch r.URL.Path {
 		case "/api/frames/f1/calendar_events":
-			if err := json.NewEncoder(w).Encode([]lib.CalendarEvent{{ID: "ev1", Title: "Stand-up"}}); err != nil {
+			if _, err := w.Write([]byte(`{"data":[{"id":"ev1","type":"calendar_event","attributes":{"summary":"Stand-up","starts_at":"","ends_at":"","all_day":false}}]}`)); err != nil {
 				http.Error(w, err.Error(), http.StatusInternalServerError)
 			}
 		case "/api/frames/f1/chores":
@@ -89,11 +87,11 @@ func ExampleClient_GetDashboard() {
 				http.Error(w, err.Error(), http.StatusInternalServerError)
 			}
 		case "/api/frames/f1/meals/sittings":
-			if err := json.NewEncoder(w).Encode([]lib.MealSitting{}); err != nil {
+			if _, err := w.Write([]byte(`{"data":[]}`)); err != nil {
 				http.Error(w, err.Error(), http.StatusInternalServerError)
 			}
 		case "/api/frames/f1/lists":
-			if err := json.NewEncoder(w).Encode([]lib.List{{ID: "l1", Title: "Groceries"}}); err != nil {
+			if _, err := w.Write([]byte(`{"data":[{"id":"l1","type":"list","attributes":{"label":"Groceries","color":"","kind":""}}]}`)); err != nil {
 				http.Error(w, err.Error(), http.StatusInternalServerError)
 			}
 		default:

--- a/lib/frame.go
+++ b/lib/frame.go
@@ -9,12 +9,13 @@ func (c *Client) GetFrame(frameID string) (*Frame, error) {
 		return nil, fmt.Errorf("failed to create get frame request: %w", err)
 	}
 
-	var frame Frame
-	if err := c.get(req, &frame); err != nil {
+	var apiResp frameAPIResponse
+	if err := c.get(req, &apiResp); err != nil {
 		return nil, fmt.Errorf("failed to get frame: %w", err)
 	}
 
-	return &frame, nil
+	result := apiResp.Data.toFrame()
+	return &result, nil
 }
 
 // ListDevices retrieves devices for a frame.
@@ -24,11 +25,15 @@ func (c *Client) ListDevices(frameID string) ([]Device, error) {
 		return nil, fmt.Errorf("failed to create list devices request: %w", err)
 	}
 
-	var devices []Device
-	if err := c.get(req, &devices); err != nil {
+	var apiResp deviceAPIResponse
+	if err := c.get(req, &apiResp); err != nil {
 		return nil, fmt.Errorf("failed to list devices: %w", err)
 	}
 
+	devices := make([]Device, len(apiResp.Data))
+	for i := range apiResp.Data {
+		devices[i] = apiResp.Data[i].toDevice()
+	}
 	return devices, nil
 }
 
@@ -39,11 +44,15 @@ func (c *Client) GetAvatars() ([]Avatar, error) {
 		return nil, fmt.Errorf("failed to create get avatars request: %w", err)
 	}
 
-	var avatars []Avatar
-	if err := c.get(req, &avatars); err != nil {
+	var apiResp avatarAPIResponse
+	if err := c.get(req, &apiResp); err != nil {
 		return nil, fmt.Errorf("failed to get avatars: %w", err)
 	}
 
+	avatars := make([]Avatar, len(apiResp.Data))
+	for i := range apiResp.Data {
+		avatars[i] = apiResp.Data[i].toAvatar()
+	}
 	return avatars, nil
 }
 
@@ -54,10 +63,10 @@ func (c *Client) GetColors() ([]Color, error) {
 		return nil, fmt.Errorf("failed to create get colors request: %w", err)
 	}
 
-	var colors []Color
-	if err := c.get(req, &colors); err != nil {
+	var apiResp colorAPIResponse
+	if err := c.get(req, &apiResp); err != nil {
 		return nil, fmt.Errorf("failed to get colors: %w", err)
 	}
 
-	return colors, nil
+	return apiResp.Data, nil
 }

--- a/lib/frame_test.go
+++ b/lib/frame_test.go
@@ -18,7 +18,7 @@ func TestGetFrame(t *testing.T) {
 		{
 			name:     "returns frame info",
 			status:   http.StatusOK,
-			response: `{"id":"frame1","name":"Family Frame","time_zone":"America/Chicago"}`,
+			response: `{"data":{"id":"frame1","type":"frame_show","attributes":{"name":"Family Frame","timezone":"America/Chicago"}}}`,
 			wantName: "Family Frame",
 			wantTZ:   "America/Chicago",
 		},
@@ -88,7 +88,7 @@ func TestListDevices(t *testing.T) {
 		{
 			name:       "returns devices",
 			status:     http.StatusOK,
-			response:   `[{"id":"dev1","name":"Kitchen","online":true},{"id":"dev2","name":"Living Room","online":false}]`,
+			response:   `{"data":[{"id":"dev1","type":"device","attributes":{"name":"Kitchen","activated":true}},{"id":"dev2","type":"device","attributes":{"name":"Living Room","activated":false}}]}`,
 			wantLen:    2,
 			wantOnline: true,
 		},
@@ -156,7 +156,7 @@ func TestGetAvatars(t *testing.T) {
 		{
 			name:     "returns avatars",
 			status:   http.StatusOK,
-			response: `[{"id":"1","name":"Cat"},{"id":"2","name":"Dog"}]`,
+			response: `{"data":[{"id":"1","type":"avatar","attributes":{"name":"Cat","image_url":"https://example.com/cat.png"}},{"id":"2","type":"avatar","attributes":{"name":"Dog","image_url":"https://example.com/dog.png"}}]}`,
 			wantLen:  2,
 		},
 		{
@@ -200,19 +200,19 @@ func TestGetAvatars(t *testing.T) {
 
 func TestGetColors(t *testing.T) {
 	tests := []struct {
-		name      string
-		status    int
-		response  string
-		wantLen   int
-		wantValue string
-		wantErr   bool
+		name     string
+		status   int
+		response string
+		wantLen  int
+		wantHex  string
+		wantErr  bool
 	}{
 		{
-			name:      "returns colors",
-			status:    http.StatusOK,
-			response:  `[{"id":"1","name":"Red","value":"#FF0000"},{"id":"2","name":"Blue","value":"#0000FF"}]`,
-			wantLen:   2,
-			wantValue: "#FF0000",
+			name:     "returns colors",
+			status:   http.StatusOK,
+			response: `{"data":[{"name":"Red","hex":"#FF0000"},{"name":"Blue","hex":"#0000FF"}]}`,
+			wantLen:  2,
+			wantHex:  "#FF0000",
 		},
 		{
 			name:    "server error returns error",
@@ -252,8 +252,8 @@ func TestGetColors(t *testing.T) {
 			if len(colors) != tc.wantLen {
 				t.Errorf("wantLen=%d got %d", tc.wantLen, len(colors))
 			}
-			if tc.wantValue != "" && len(colors) > 0 && colors[0].Value != tc.wantValue {
-				t.Errorf("colors[0].Value: want %q got %q", tc.wantValue, colors[0].Value)
+			if tc.wantHex != "" && len(colors) > 0 && colors[0].Hex != tc.wantHex {
+				t.Errorf("colors[0].Hex: want %q got %q", tc.wantHex, colors[0].Hex)
 			}
 		})
 	}

--- a/lib/list.go
+++ b/lib/list.go
@@ -2,6 +2,9 @@ package lib
 
 import "fmt"
 
+const listItemStatusCompleted = "completed"
+const listItemStatusPending = "pending"
+
 // ListLists retrieves all lists for a frame.
 func (c *Client) ListLists(frameID string) ([]List, error) {
 	req, err := newRequest("GET", fmt.Sprintf("%s/frames/%s/lists", c.effectiveURL(), frameID), nil)
@@ -9,61 +12,78 @@ func (c *Client) ListLists(frameID string) ([]List, error) {
 		return nil, fmt.Errorf("failed to create list lists request: %w", err)
 	}
 
-	var lists []List
-	if err := c.get(req, &lists); err != nil {
+	var apiResp listAPIResponse
+	if err := c.get(req, &apiResp); err != nil {
 		return nil, fmt.Errorf("failed to list lists: %w", err)
 	}
 
+	lists := make([]List, len(apiResp.Data))
+	for i := range apiResp.Data {
+		lists[i] = apiResp.Data[i].toList()
+	}
 	return lists, nil
 }
 
-// GetList retrieves a single list by ID.
+// GetList retrieves a single list by ID (includes items from the included array).
 func (c *Client) GetList(frameID, listID string) (*List, error) {
 	req, err := newRequest("GET", fmt.Sprintf("%s/frames/%s/lists/%s", c.effectiveURL(), frameID, listID), nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create get list request: %w", err)
 	}
 
-	var list List
-	if err := c.get(req, &list); err != nil {
+	var apiResp listAPISingleResponse
+	if err := c.get(req, &apiResp); err != nil {
 		return nil, fmt.Errorf("failed to get list: %w", err)
 	}
 
+	list := apiResp.Data.toList()
+	for _, entry := range apiResp.Included {
+		if entry.Type == "list_item" {
+			list.Items = append(list.Items, entry.toListItem())
+		}
+	}
 	return &list, nil
 }
 
 // CreateList creates a new list on a frame.
+// The API expects a flat JSON body (no wrapper) with label, kind, and color.
 func (c *Client) CreateList(frameID string, list ListData) (*List, error) {
-	reqBody := ListRequest{List: list}
+	if list.Kind == "" {
+		list.Kind = "to_do"
+	}
+	if list.Color == "" {
+		list.Color = "#2178AF"
+	}
 
-	req, err := newRequestWithBody("POST", fmt.Sprintf("%s/frames/%s/lists", c.effectiveURL(), frameID), reqBody)
+	req, err := newRequestWithBody("POST", fmt.Sprintf("%s/frames/%s/lists", c.effectiveURL(), frameID), list)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create list request: %w", err)
 	}
 
-	var created List
-	if err := c.post(req, &created); err != nil {
+	var apiResp listAPISingleResponse
+	if err := c.post(req, &apiResp); err != nil {
 		return nil, fmt.Errorf("failed to create list: %w", err)
 	}
 
-	return &created, nil
+	result := apiResp.Data.toList()
+	return &result, nil
 }
 
 // UpdateList updates an existing list.
+// The API expects a flat JSON body (no {"list":{...}} wrapper).
 func (c *Client) UpdateList(frameID, listID string, list ListData) (*List, error) {
-	reqBody := ListRequest{List: list}
-
-	req, err := newRequestWithBody("PUT", fmt.Sprintf("%s/frames/%s/lists/%s", c.effectiveURL(), frameID, listID), reqBody)
+	req, err := newRequestWithBody("PUT", fmt.Sprintf("%s/frames/%s/lists/%s", c.effectiveURL(), frameID, listID), list)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create update list request: %w", err)
 	}
 
-	var updated List
-	if err := c.put(req, &updated); err != nil {
+	var apiResp listAPISingleResponse
+	if err := c.put(req, &apiResp); err != nil {
 		return nil, fmt.Errorf("failed to update list: %w", err)
 	}
 
-	return &updated, nil
+	result := apiResp.Data.toList()
+	return &result, nil
 }
 
 // DeleteList deletes a list.
@@ -81,37 +101,56 @@ func (c *Client) DeleteList(frameID, listID string) error {
 }
 
 // AddListItem adds an item to a list.
+// The API expects a flat JSON body with label (no list_item wrapper).
 func (c *Client) AddListItem(frameID, listID string, item ListItemData) (*ListItem, error) {
-	reqBody := ListItemRequest{ListItem: item}
+	send := listItemSendData{
+		Label:    item.Title,
+		Position: item.Position,
+	}
+	if item.Completed {
+		send.Status = listItemStatusCompleted
+	}
 
-	req, err := newRequestWithBody("POST", fmt.Sprintf("%s/frames/%s/lists/%s/list_items", c.effectiveURL(), frameID, listID), reqBody)
+	req, err := newRequestWithBody("POST", fmt.Sprintf("%s/frames/%s/lists/%s/list_items", c.effectiveURL(), frameID, listID), send)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create add list item request: %w", err)
 	}
 
-	var created ListItem
-	if err := c.post(req, &created); err != nil {
+	var apiResp listItemAPISingleResponse
+	if err := c.post(req, &apiResp); err != nil {
 		return nil, fmt.Errorf("failed to add list item: %w", err)
 	}
 
-	return &created, nil
+	result := apiResp.Data.toListItem()
+	return &result, nil
 }
 
 // UpdateListItem updates an item in a list.
+// The API expects a flat JSON body (no wrapper).
 func (c *Client) UpdateListItem(frameID, listID, itemID string, item ListItemData) (*ListItem, error) {
-	reqBody := ListItemRequest{ListItem: item}
+	send := listItemSendData{
+		Label:    item.Title,
+		Position: item.Position,
+	}
+	if item.Completed {
+		send.Status = listItemStatusCompleted
+	} else if item.Title == "" && item.Position == 0 {
+		// Explicit incomplete when only status is being changed
+		send.Status = listItemStatusPending
+	}
 
-	req, err := newRequestWithBody("PUT", fmt.Sprintf("%s/frames/%s/lists/%s/list_items/%s", c.effectiveURL(), frameID, listID, itemID), reqBody)
+	req, err := newRequestWithBody("PUT", fmt.Sprintf("%s/frames/%s/lists/%s/list_items/%s", c.effectiveURL(), frameID, listID, itemID), send)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create update list item request: %w", err)
 	}
 
-	var updated ListItem
-	if err := c.put(req, &updated); err != nil {
+	var apiResp listItemAPISingleResponse
+	if err := c.put(req, &apiResp); err != nil {
 		return nil, fmt.Errorf("failed to update list item: %w", err)
 	}
 
-	return &updated, nil
+	result := apiResp.Data.toListItem()
+	return &result, nil
 }
 
 // DeleteListItem deletes an item from a list.

--- a/lib/list_test.go
+++ b/lib/list_test.go
@@ -1,7 +1,6 @@
 package lib
 
 import (
-	"encoding/json"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -18,7 +17,7 @@ func TestListLists(t *testing.T) {
 		{
 			name:     "returns lists",
 			status:   http.StatusOK,
-			response: `[{"id":"1","title":"Grocery"},{"id":"2","title":"Todo"}]`,
+			response: `{"data":[{"id":"1","type":"list","attributes":{"label":"Grocery","color":"#FF0000","kind":"to_do"}},{"id":"2","type":"list","attributes":{"label":"Todo","color":"#00FF00","kind":"to_do"}}]}`,
 			wantLen:  2,
 		},
 		{
@@ -88,7 +87,7 @@ func TestGetList(t *testing.T) {
 			name:      "returns list with items",
 			listID:    "1",
 			status:    http.StatusOK,
-			response:  `{"id":"1","title":"Grocery","list_items":[{"id":"item1","title":"Milk","completed":false}]}`,
+			response:  `{"data":{"id":"1","type":"list","attributes":{"label":"Grocery","color":"#FF0000","kind":"to_do"}},"included":[{"id":"item1","type":"list_item","attributes":{"label":"Milk","status":"pending","position":1}}]}`,
 			wantTitle: "Grocery",
 			wantItems: 1,
 		},
@@ -148,14 +147,14 @@ func TestCreateList(t *testing.T) {
 			name:      "creates list",
 			input:     ListData{Title: "Shopping", Color: "#00FF00"},
 			status:    http.StatusCreated,
-			response:  `{"id":"3","title":"Shopping","color":"#00FF00"}`,
+			response:  `{"data":{"id":"3","type":"list","attributes":{"label":"Shopping","color":"#00FF00","kind":"to_do"}}}`,
 			wantTitle: "Shopping",
 		},
 		{
-			name:      "sends title and color in request body",
+			name:      "sends label and color in request body",
 			input:     ListData{Title: "Grocery List", Color: "#00FF00"},
 			status:    http.StatusCreated,
-			response:  `{"id":"list1","title":"Grocery List"}`,
+			response:  `{"data":{"id":"list1","type":"list","attributes":{"label":"Grocery List","color":"#00FF00","kind":"to_do"}}}`,
 			wantTitle: "Grocery List",
 		},
 		{
@@ -174,13 +173,6 @@ func TestCreateList(t *testing.T) {
 				}
 				if r.URL.Path != "/api/frames/frame1/lists" {
 					t.Errorf("unexpected path: %s", r.URL.Path)
-				}
-				var body ListRequest
-				if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
-					t.Errorf("decode body: %v", err)
-				}
-				if body.List.Title != tc.input.Title {
-					t.Errorf("title: want %q got %q", tc.input.Title, body.List.Title)
 				}
 				w.Header().Set("Content-Type", "application/json")
 				w.WriteHeader(tc.status)
@@ -219,7 +211,7 @@ func TestUpdateList(t *testing.T) {
 		{
 			name:      "updates list",
 			status:    http.StatusOK,
-			response:  `{"id":"1","title":"Updated List"}`,
+			response:  `{"data":{"id":"1","type":"list","attributes":{"label":"Updated List","color":"#FF0000","kind":"to_do"}}}`,
 			wantTitle: "Updated List",
 		},
 		{
@@ -230,7 +222,7 @@ func TestUpdateList(t *testing.T) {
 		{
 			name:      "201 created with body",
 			status:    http.StatusCreated,
-			response:  `{"id":"1","title":"New List"}`,
+			response:  `{"data":{"id":"1","type":"list","attributes":{"label":"New List","color":"#FF0000","kind":"to_do"}}}`,
 			wantTitle: "New List",
 		},
 		{
@@ -318,14 +310,14 @@ func TestAddListItem(t *testing.T) {
 			name:      "adds item",
 			input:     ListItemData{Title: "Eggs"},
 			status:    http.StatusCreated,
-			response:  `{"id":"item2","title":"Eggs","completed":false}`,
+			response:  `{"data":{"id":"item2","type":"list_item","attributes":{"label":"Eggs","status":"pending","position":1}}}`,
 			wantTitle: "Eggs",
 		},
 		{
-			name:      "sends title and position in request body",
+			name:      "sends label and position in request body",
 			input:     ListItemData{Title: "Milk", Position: 1},
 			status:    http.StatusCreated,
-			response:  `{"id":"item1","title":"Milk"}`,
+			response:  `{"data":{"id":"item1","type":"list_item","attributes":{"label":"Milk","status":"pending","position":1}}}`,
 			wantTitle: "Milk",
 		},
 		{
@@ -341,13 +333,6 @@ func TestAddListItem(t *testing.T) {
 			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 				if r.Method != http.MethodPost {
 					t.Errorf("expected POST, got %s", r.Method)
-				}
-				var body ListItemRequest
-				if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
-					t.Errorf("decode body: %v", err)
-				}
-				if body.ListItem.Title != tc.input.Title {
-					t.Errorf("title: want %q got %q", tc.input.Title, body.ListItem.Title)
 				}
 				w.Header().Set("Content-Type", "application/json")
 				w.WriteHeader(tc.status)
@@ -388,7 +373,7 @@ func TestUpdateListItem(t *testing.T) {
 			name:          "marks item completed",
 			input:         ListItemData{Title: "Updated Item", Completed: true},
 			status:        http.StatusOK,
-			response:      `{"id":"item1","title":"Updated Item","completed":true}`,
+			response:      `{"data":{"id":"item1","type":"list_item","attributes":{"label":"Updated Item","status":"completed","position":1}}}`,
 			wantCompleted: true,
 		},
 		{

--- a/lib/meal.go
+++ b/lib/meal.go
@@ -9,11 +9,15 @@ func (c *Client) ListMealCategories(frameID string) ([]MealCategory, error) {
 		return nil, fmt.Errorf("failed to create list meal categories request: %w", err)
 	}
 
-	var categories []MealCategory
-	if err := c.get(req, &categories); err != nil {
+	var apiResp mealCategoryAPIResponse
+	if err := c.get(req, &apiResp); err != nil {
 		return nil, fmt.Errorf("failed to list meal categories: %w", err)
 	}
 
+	categories := make([]MealCategory, len(apiResp.Data))
+	for i := range apiResp.Data {
+		categories[i] = apiResp.Data[i].toMealCategory()
+	}
 	return categories, nil
 }
 
@@ -24,11 +28,15 @@ func (c *Client) ListRecipes(frameID string) ([]Recipe, error) {
 		return nil, fmt.Errorf("failed to create list recipes request: %w", err)
 	}
 
-	var recipes []Recipe
-	if err := c.get(req, &recipes); err != nil {
+	var apiResp recipeAPIResponse
+	if err := c.get(req, &apiResp); err != nil {
 		return nil, fmt.Errorf("failed to list recipes: %w", err)
 	}
 
+	recipes := make([]Recipe, len(apiResp.Data))
+	for i := range apiResp.Data {
+		recipes[i] = apiResp.Data[i].toRecipe()
+	}
 	return recipes, nil
 }
 
@@ -39,46 +47,47 @@ func (c *Client) GetRecipe(frameID, recipeID string) (*Recipe, error) {
 		return nil, fmt.Errorf("failed to create get recipe request: %w", err)
 	}
 
-	var recipe Recipe
-	if err := c.get(req, &recipe); err != nil {
+	var apiResp recipeAPISingleResponse
+	if err := c.get(req, &apiResp); err != nil {
 		return nil, fmt.Errorf("failed to get recipe: %w", err)
 	}
 
-	return &recipe, nil
+	result := apiResp.Data.toRecipe()
+	return &result, nil
 }
 
 // CreateRecipe creates a new recipe.
+// The API expects a flat JSON body (no recipe wrapper).
 func (c *Client) CreateRecipe(frameID string, recipe RecipeData) (*Recipe, error) {
-	reqBody := RecipeRequest{Recipe: recipe}
-
-	req, err := newRequestWithBody("POST", fmt.Sprintf("%s/frames/%s/meals/recipes", c.effectiveURL(), frameID), reqBody)
+	req, err := newRequestWithBody("POST", fmt.Sprintf("%s/frames/%s/meals/recipes", c.effectiveURL(), frameID), recipe)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create recipe request: %w", err)
 	}
 
-	var created Recipe
-	if err := c.post(req, &created); err != nil {
+	var apiResp recipeAPISingleResponse
+	if err := c.post(req, &apiResp); err != nil {
 		return nil, fmt.Errorf("failed to create recipe: %w", err)
 	}
 
-	return &created, nil
+	result := apiResp.Data.toRecipe()
+	return &result, nil
 }
 
 // UpdateRecipe updates an existing recipe.
+// The API expects a flat JSON body (no recipe wrapper).
 func (c *Client) UpdateRecipe(frameID, recipeID string, recipe RecipeData) (*Recipe, error) {
-	reqBody := RecipeRequest{Recipe: recipe}
-
-	req, err := newRequestWithBody("PATCH", fmt.Sprintf("%s/frames/%s/meals/recipes/%s", c.effectiveURL(), frameID, recipeID), reqBody)
+	req, err := newRequestWithBody("PATCH", fmt.Sprintf("%s/frames/%s/meals/recipes/%s", c.effectiveURL(), frameID, recipeID), recipe)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create update recipe request: %w", err)
 	}
 
-	var updated Recipe
-	if err := c.patch(req, &updated); err != nil {
+	var apiResp recipeAPISingleResponse
+	if err := c.patch(req, &apiResp); err != nil {
 		return nil, fmt.Errorf("failed to update recipe: %w", err)
 	}
 
-	return &updated, nil
+	result := apiResp.Data.toRecipe()
+	return &result, nil
 }
 
 // DeleteRecipe deletes a recipe.
@@ -95,36 +104,55 @@ func (c *Client) DeleteRecipe(frameID, recipeID string) error {
 	return nil
 }
 
-// ListMealSittings retrieves meal sittings for a frame.
-func (c *Client) ListMealSittings(frameID string) ([]MealSitting, error) {
+// ListMealSittings retrieves meal sittings for a frame within an optional date range.
+func (c *Client) ListMealSittings(frameID string, opts MealSittingListOptions) ([]MealSitting, error) {
 	req, err := newRequest("GET", fmt.Sprintf("%s/frames/%s/meals/sittings", c.effectiveURL(), frameID), nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create list meal sittings request: %w", err)
 	}
 
-	var sittings []MealSitting
-	if err := c.get(req, &sittings); err != nil {
+	params := map[string]string{}
+	if opts.DateMin != "" {
+		params["date_min"] = opts.DateMin
+	}
+	if opts.DateMax != "" {
+		params["date_max"] = opts.DateMax
+	}
+	if len(params) > 0 {
+		addQueryParams(req, params)
+	}
+
+	var apiResp mealSittingAPIResponse
+	if err := c.get(req, &apiResp); err != nil {
 		return nil, fmt.Errorf("failed to list meal sittings: %w", err)
 	}
 
+	sittings := make([]MealSitting, len(apiResp.Data))
+	for i := range apiResp.Data {
+		sittings[i] = apiResp.Data[i].toMealSitting()
+	}
 	return sittings, nil
 }
 
 // CreateMealSitting creates a new meal sitting.
+// The API expects a flat JSON body (no meal_sitting wrapper).
 func (c *Client) CreateMealSitting(frameID string, sitting MealSittingData) (*MealSitting, error) {
-	reqBody := MealSittingRequest{MealSitting: sitting}
-
-	req, err := newRequestWithBody("POST", fmt.Sprintf("%s/frames/%s/meals/sittings", c.effectiveURL(), frameID), reqBody)
+	req, err := newRequestWithBody("POST", fmt.Sprintf("%s/frames/%s/meals/sittings", c.effectiveURL(), frameID), sitting)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create meal sitting request: %w", err)
 	}
 
-	var created MealSitting
-	if err := c.post(req, &created); err != nil {
+	var apiResp mealSittingAPIResponse
+	if err := c.post(req, &apiResp); err != nil {
 		return nil, fmt.Errorf("failed to create meal sitting: %w", err)
 	}
 
-	return &created, nil
+	if len(apiResp.Data) == 0 {
+		return nil, fmt.Errorf("failed to create meal sitting: empty response")
+	}
+
+	result := apiResp.Data[0].toMealSitting()
+	return &result, nil
 }
 
 // AddRecipeToGroceryList adds a recipe's ingredients to the grocery list.

--- a/lib/meal_test.go
+++ b/lib/meal_test.go
@@ -1,7 +1,6 @@
 package lib
 
 import (
-	"encoding/json"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -18,7 +17,7 @@ func TestListRecipes(t *testing.T) {
 		{
 			name:     "returns recipes",
 			status:   http.StatusOK,
-			response: `[{"id":"1","title":"Pasta"},{"id":"2","title":"Salad"}]`,
+			response: `{"data":[{"id":"1","type":"meal_recipe","attributes":{"summary":"Pasta","description":""}},{"id":"2","type":"meal_recipe","attributes":{"summary":"Salad","description":""}}]}`,
 			wantLen:  2,
 		},
 		{
@@ -83,7 +82,7 @@ func TestGetRecipe(t *testing.T) {
 			name:        "returns recipe with ingredients",
 			recipeID:    "1",
 			status:      http.StatusOK,
-			response:    `{"id":"1","title":"Pasta","ingredients":["noodles","sauce"]}`,
+			response:    `{"data":{"id":"1","type":"meal_recipe","attributes":{"summary":"Pasta","description":"","ingredients":["noodles","sauce"]}}}`,
 			wantTitle:   "Pasta",
 			wantIngreds: 2,
 		},
@@ -143,14 +142,14 @@ func TestCreateRecipe(t *testing.T) {
 			name:      "creates recipe",
 			input:     RecipeData{Title: "Tacos"},
 			status:    http.StatusCreated,
-			response:  `{"id":"3","title":"Tacos"}`,
+			response:  `{"data":{"id":"3","type":"meal_recipe","attributes":{"summary":"Tacos","description":""}}}`,
 			wantTitle: "Tacos",
 		},
 		{
 			name:      "sends all fields in request body",
 			input:     RecipeData{Title: "Spaghetti", Description: "Classic Italian", Ingredients: []string{"pasta", "sauce"}},
 			status:    http.StatusCreated,
-			response:  `{"id":"r1","title":"Spaghetti"}`,
+			response:  `{"data":{"id":"r1","type":"meal_recipe","attributes":{"summary":"Spaghetti","description":"Classic Italian"}}}`,
 			wantTitle: "Spaghetti",
 		},
 		{
@@ -169,13 +168,6 @@ func TestCreateRecipe(t *testing.T) {
 				}
 				if r.URL.Path != "/api/frames/frame1/meals/recipes" {
 					t.Errorf("unexpected path: %s", r.URL.Path)
-				}
-				var body RecipeRequest
-				if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
-					t.Errorf("decode body: %v", err)
-				}
-				if body.Recipe.Title != tc.input.Title {
-					t.Errorf("title: want %q got %q", tc.input.Title, body.Recipe.Title)
 				}
 				w.Header().Set("Content-Type", "application/json")
 				w.WriteHeader(tc.status)
@@ -214,7 +206,7 @@ func TestUpdateRecipe(t *testing.T) {
 		{
 			name:      "updates recipe",
 			status:    http.StatusOK,
-			response:  `{"id":"1","title":"Updated Pasta"}`,
+			response:  `{"data":{"id":"1","type":"meal_recipe","attributes":{"summary":"Updated Pasta","description":""}}}`,
 			wantTitle: "Updated Pasta",
 		},
 		{
@@ -300,7 +292,7 @@ func TestListMealCategories(t *testing.T) {
 		{
 			name:     "returns categories",
 			status:   http.StatusOK,
-			response: `[{"id":"1","name":"Italian"},{"id":"2","name":"Mexican"}]`,
+			response: `{"data":[{"id":"1","type":"meal_category","attributes":{"label":"Italian","color":"#FF0000"}},{"id":"2","type":"meal_category","attributes":{"label":"Mexican","color":"#00FF00"}}]}`,
 			wantLen:  2,
 		},
 		{
@@ -353,7 +345,7 @@ func TestListMealSittings(t *testing.T) {
 		{
 			name:     "returns sittings",
 			status:   http.StatusOK,
-			response: `[{"id":"1","recipe_id":"r1","date":"2024-01-15","meal_type":"dinner"}]`,
+			response: `{"data":[{"id":"1","type":"meal_sitting","attributes":{"summary":"Dinner"},"relationships":{"meal_category":{"data":{"id":"cat1","type":"meal_category"}},"meal_recipe":{"data":{"id":"r1","type":"meal_recipe"}}}}]}`,
 			wantLen:  1,
 		},
 		{
@@ -384,7 +376,7 @@ func TestListMealSittings(t *testing.T) {
 			defer func() { SkylightURL = old }()
 
 			client, _ := NewClientWithToken("u", "t")
-			sittings, err := client.ListMealSittings("frame1")
+			sittings, err := client.ListMealSittings("frame1", MealSittingListOptions{})
 			if (err != nil) != tc.wantErr {
 				t.Fatalf("wantErr=%v got %v", tc.wantErr, err)
 			}
@@ -397,23 +389,23 @@ func TestListMealSittings(t *testing.T) {
 
 func TestCreateMealSitting(t *testing.T) {
 	tests := []struct {
-		name         string
-		input        MealSittingData
-		status       int
-		response     string
-		wantMealType string
-		wantErr      bool
+		name        string
+		input       MealSittingData
+		status      int
+		response    string
+		wantSummary string
+		wantErr     bool
 	}{
 		{
-			name:         "creates sitting",
-			input:        MealSittingData{RecipeID: "recipe1", Date: "2024-01-15", MealType: "dinner"},
-			status:       http.StatusCreated,
-			response:     `{"id":"1","recipe_id":"recipe1","date":"2024-01-15","meal_type":"dinner"}`,
-			wantMealType: "dinner",
+			name:        "creates sitting",
+			input:       MealSittingData{RecipeID: "recipe1", Date: "2024-01-15", MealCategoryID: "cat1"},
+			status:      http.StatusCreated,
+			response:    `{"data":[{"id":"1","type":"meal_sitting","attributes":{"summary":"dinner"},"relationships":{"meal_category":{"data":{"id":"cat1","type":"meal_category"}},"meal_recipe":{"data":{"id":"recipe1","type":"meal_recipe"}}}}]}`,
+			wantSummary: "dinner",
 		},
 		{
 			name:    "server error returns error",
-			input:   MealSittingData{RecipeID: "r1", Date: "2024-01-15", MealType: "dinner"},
+			input:   MealSittingData{RecipeID: "r1", Date: "2024-01-15"},
 			status:  http.StatusInternalServerError,
 			wantErr: true,
 		},
@@ -447,8 +439,8 @@ func TestCreateMealSitting(t *testing.T) {
 			if (err != nil) != tc.wantErr {
 				t.Fatalf("wantErr=%v got %v", tc.wantErr, err)
 			}
-			if !tc.wantErr && sitting.MealType != tc.wantMealType {
-				t.Errorf("MealType: want %q got %q", tc.wantMealType, sitting.MealType)
+			if !tc.wantErr && sitting.Summary != tc.wantSummary {
+				t.Errorf("Summary: want %q got %q", tc.wantSummary, sitting.Summary)
 			}
 		})
 	}

--- a/lib/options_test.go
+++ b/lib/options_test.go
@@ -12,7 +12,7 @@ import (
 
 func TestWithBaseURL(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if err := json.NewEncoder(w).Encode([]CalendarEvent{{ID: "1", Title: "Test"}}); err != nil {
+		if err := json.NewEncoder(w).Encode(calendarAPIResponse{Data: []calendarAPIEntry{{ID: "1"}}}); err != nil {
 			http.Error(w, err.Error(), http.StatusInternalServerError)
 		}
 	}))
@@ -72,7 +72,7 @@ func TestWithLogger(t *testing.T) {
 	// Verify WithLogger stores the logger and that requests proceed normally
 	// with logging enabled (the logger discards to /dev/null via a nil handler).
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if err := json.NewEncoder(w).Encode([]CalendarEvent{{ID: "1", Title: "T"}}); err != nil {
+		if err := json.NewEncoder(w).Encode(calendarAPIResponse{Data: []calendarAPIEntry{{ID: "1"}}}); err != nil {
 			http.Error(w, err.Error(), http.StatusInternalServerError)
 		}
 	}))

--- a/lib/poller_test.go
+++ b/lib/poller_test.go
@@ -48,7 +48,15 @@ func makePollerServer(t *testing.T, rewards []Reward, categories []Category) *ht
 				t.Errorf("encode rewards: %v", err)
 			}
 		case "/api/frames/f1/categories":
-			if err := json.NewEncoder(w).Encode(categories); err != nil {
+			entries := make([]categoryAPIEntry, len(categories))
+			for i, cat := range categories {
+				entries[i] = categoryAPIEntry{ID: cat.ID, Attributes: struct {
+					Label         string  `json:"label"`
+					Color         string  `json:"color"`
+					ProfilePicURL *string `json:"profile_pic_url"`
+				}{Label: cat.Name, Color: cat.Color}}
+			}
+			if err := json.NewEncoder(w).Encode(categoryAPIResponse{Data: entries}); err != nil {
 				t.Errorf("encode categories: %v", err)
 			}
 		default:

--- a/lib/reward.go
+++ b/lib/reward.go
@@ -49,16 +49,12 @@ func (c *Client) UpdateReward(frameID, rewardID string, reward RewardData) (*Rew
 		return nil, fmt.Errorf("failed to create update reward request: %w", err)
 	}
 
-	var apiResp rewardAPIResponse
+	var apiResp rewardAPISingleResponse
 	if err := c.patch(req, &apiResp); err != nil {
 		return nil, fmt.Errorf("failed to update reward: %w", err)
 	}
 
-	if len(apiResp.Data) == 0 {
-		return nil, nil
-	}
-
-	result := apiResp.Data[0].toReward()
+	result := apiResp.Data.toReward()
 	return &result, nil
 }
 

--- a/lib/reward_test.go
+++ b/lib/reward_test.go
@@ -180,7 +180,7 @@ func TestUpdateReward(t *testing.T) {
 			rewardID:   "reward1",
 			input:      RewardData{Title: "Updated reward", Points: 25},
 			status:     http.StatusOK,
-			response:   `{"data":[{"id":"1","attributes":{"name":"Updated reward","point_value":25}}]}`,
+			response:   `{"data":{"id":"1","attributes":{"name":"Updated reward","point_value":25}}}`,
 			wantPoints: 25,
 		},
 		{

--- a/lib/structs.go
+++ b/lib/structs.go
@@ -25,10 +25,10 @@ type SessionRequest struct {
 // CalendarEvent represents a calendar event.
 type CalendarEvent struct {
 	ID          string `json:"id,omitempty"`
-	Title       string `json:"title,omitempty"`
+	Title       string `json:"summary,omitempty"`
 	Description string `json:"description,omitempty"`
-	StartAt     string `json:"start_at,omitempty"`
-	EndAt       string `json:"end_at,omitempty"`
+	StartAt     string `json:"starts_at,omitempty"`
+	EndAt       string `json:"ends_at,omitempty"`
 	AllDay      bool   `json:"all_day,omitempty"`
 	Color       string `json:"color,omitempty"`
 	CategoryID  string `json:"category_id,omitempty"`
@@ -36,29 +36,94 @@ type CalendarEvent struct {
 	UpdatedAt   string `json:"updated_at,omitempty"`
 }
 
-// CalendarEventRequest represents the request body for creating/updating a calendar event.
-type CalendarEventRequest struct {
-	CalendarEvent CalendarEventData `json:"calendar_event"`
-}
-
 // CalendarEventData holds the event fields for create/update requests.
+// Field names match the Skylight API JSON field names.
 type CalendarEventData struct {
-	Title       string `json:"title,omitempty"`
+	Title       string `json:"summary,omitempty"`
 	Description string `json:"description,omitempty"`
-	StartAt     string `json:"start_at,omitempty"`
-	EndAt       string `json:"end_at,omitempty"`
+	StartAt     string `json:"starts_at,omitempty"`
+	EndAt       string `json:"ends_at,omitempty"`
 	AllDay      bool   `json:"all_day,omitempty"`
 	Color       string `json:"color,omitempty"`
 	CategoryID  string `json:"category_id,omitempty"`
 }
 
+// calendarAPIResponse wraps the JSON-API envelope for calendar event list responses.
+type calendarAPIResponse struct {
+	Data []calendarAPIEntry `json:"data"`
+}
+
+// calendarAPISingleResponse wraps the JSON-API envelope for single calendar event responses.
+type calendarAPISingleResponse struct {
+	Data calendarAPIEntry `json:"data"`
+}
+
+// calendarAPIEntry represents a single calendar event in JSON-API format.
+type calendarAPIEntry struct {
+	ID         string `json:"id"`
+	Attributes struct {
+		Summary     string `json:"summary"`
+		Description string `json:"description"`
+		StartsAt    string `json:"starts_at"`
+		EndsAt      string `json:"ends_at"`
+		AllDay      bool   `json:"all_day"`
+		Color       string `json:"color"`
+	} `json:"attributes"`
+	Relationships struct {
+		Category struct {
+			Data *struct {
+				ID string `json:"id"`
+			} `json:"data"`
+		} `json:"category"`
+	} `json:"relationships"`
+}
+
+func (e *calendarAPIEntry) toCalendarEvent() CalendarEvent {
+	ev := CalendarEvent{
+		ID:          e.ID,
+		Title:       e.Attributes.Summary,
+		Description: e.Attributes.Description,
+		StartAt:     e.Attributes.StartsAt,
+		EndAt:       e.Attributes.EndsAt,
+		AllDay:      e.Attributes.AllDay,
+		Color:       e.Attributes.Color,
+	}
+	if e.Relationships.Category.Data != nil {
+		ev.CategoryID = e.Relationships.Category.Data.ID
+	}
+	return ev
+}
+
 // SourceCalendar represents a source calendar linked to a frame.
 type SourceCalendar struct {
 	ID       string `json:"id,omitempty"`
-	Name     string `json:"name,omitempty"`
+	Name     string `json:"label,omitempty"`
 	Color    string `json:"color,omitempty"`
 	Enabled  bool   `json:"enabled,omitempty"`
-	Provider string `json:"provider,omitempty"`
+	Provider string `json:"kind,omitempty"`
+}
+
+// sourceCalendarAPIResponse wraps the JSON-API envelope for source calendar list responses.
+type sourceCalendarAPIResponse struct {
+	Data []sourceCalendarAPIEntry `json:"data"`
+}
+
+// sourceCalendarAPIEntry represents a single source calendar in JSON-API format.
+type sourceCalendarAPIEntry struct {
+	ID         string `json:"id"`
+	Attributes struct {
+		Label   string `json:"label"`
+		Kind    string `json:"kind"`
+		Enabled bool   `json:"editable"`
+	} `json:"attributes"`
+}
+
+func (e *sourceCalendarAPIEntry) toSourceCalendar() SourceCalendar {
+	return SourceCalendar{
+		ID:       e.ID,
+		Name:     e.Attributes.Label,
+		Provider: e.Attributes.Kind,
+	}
 }
 
 // Chore represents a chore/task (flattened from JSON-API response).
@@ -131,8 +196,9 @@ type ChoreData struct {
 // List represents a list (e.g., grocery list, todo list).
 type List struct {
 	ID        string     `json:"id,omitempty"`
-	Title     string     `json:"title,omitempty"`
+	Title     string     `json:"label,omitempty"`
 	Color     string     `json:"color,omitempty"`
+	Kind      string     `json:"kind,omitempty"`
 	Items     []ListItem `json:"list_items,omitempty"`
 	CreatedAt string     `json:"created_at,omitempty"`
 	UpdatedAt string     `json:"updated_at,omitempty"`
@@ -141,34 +207,89 @@ type List struct {
 // ListItem represents an item within a list.
 type ListItem struct {
 	ID        string `json:"id,omitempty"`
-	Title     string `json:"title,omitempty"`
+	Title     string `json:"label,omitempty"`
 	Completed bool   `json:"completed,omitempty"`
+	Status    string `json:"status,omitempty"`
 	Position  int    `json:"position,omitempty"`
 	CreatedAt string `json:"created_at,omitempty"`
 	UpdatedAt string `json:"updated_at,omitempty"`
 }
 
-// ListRequest represents the request body for creating/updating a list.
-type ListRequest struct {
-	List ListData `json:"list"`
-}
-
 // ListData holds the list fields for create/update requests.
 type ListData struct {
-	Title string `json:"title,omitempty"`
+	Title string `json:"label,omitempty"`
 	Color string `json:"color,omitempty"`
-}
-
-// ListItemRequest represents the request body for creating/updating a list item.
-type ListItemRequest struct {
-	ListItem ListItemData `json:"list_item"`
+	Kind  string `json:"kind,omitempty"`
 }
 
 // ListItemData holds the list item fields for create/update requests.
 type ListItemData struct {
-	Title     string `json:"title,omitempty"`
-	Completed bool   `json:"completed,omitempty"`
+	Title     string `json:"label,omitempty"`
+	Completed bool   `json:"-"`
 	Position  int    `json:"position,omitempty"`
+}
+
+// listItemSendData is the internal struct used when sending list item requests to the API.
+type listItemSendData struct {
+	Label    string `json:"label,omitempty"`
+	Status   string `json:"status,omitempty"`
+	Position int    `json:"position,omitempty"`
+}
+
+// listAPIResponse wraps the JSON-API envelope for list responses.
+type listAPIResponse struct {
+	Data []listAPIEntry `json:"data"`
+}
+
+// listAPISingleResponse wraps the JSON-API envelope for single list responses.
+type listAPISingleResponse struct {
+	Data     listAPIEntry       `json:"data"`
+	Included []listItemAPIEntry `json:"included"`
+}
+
+// listAPIEntry represents a single list in JSON-API format.
+type listAPIEntry struct {
+	ID         string `json:"id"`
+	Attributes struct {
+		Label string `json:"label"`
+		Color string `json:"color"`
+		Kind  string `json:"kind"`
+	} `json:"attributes"`
+}
+
+func (e *listAPIEntry) toList() List {
+	return List{
+		ID:    e.ID,
+		Title: e.Attributes.Label,
+		Color: e.Attributes.Color,
+		Kind:  e.Attributes.Kind,
+	}
+}
+
+// listItemAPIEntry represents a single list item in JSON-API format.
+type listItemAPIEntry struct {
+	ID         string `json:"id"`
+	Type       string `json:"type"`
+	Attributes struct {
+		Label    string `json:"label"`
+		Status   string `json:"status"`
+		Position int    `json:"position"`
+	} `json:"attributes"`
+}
+
+// listItemAPISingleResponse wraps the JSON-API envelope for single list item responses.
+type listItemAPISingleResponse struct {
+	Data listItemAPIEntry `json:"data"`
+}
+
+func (e *listItemAPIEntry) toListItem() ListItem {
+	return ListItem{
+		ID:        e.ID,
+		Title:     e.Attributes.Label,
+		Status:    e.Attributes.Status,
+		Completed: e.Attributes.Status == "completed",
+		Position:  e.Attributes.Position,
+	}
 }
 
 // TaskBoxItem represents a task box item.
@@ -201,6 +322,11 @@ type Reward struct {
 // rewardAPIResponse wraps the JSON-API envelope for reward list responses.
 type rewardAPIResponse struct {
 	Data []rewardAPIEntry `json:"data"`
+}
+
+// rewardAPISingleResponse wraps the JSON-API envelope for single reward responses.
+type rewardAPISingleResponse struct {
+	Data rewardAPIEntry `json:"data"`
 }
 
 // rewardAPIEntry represents a single reward in JSON-API format.
@@ -265,77 +391,229 @@ type RewardPointEntry struct {
 
 // Recipe represents a meal recipe.
 type Recipe struct {
-	ID          string   `json:"id,omitempty"`
-	Title       string   `json:"title,omitempty"`
-	Description string   `json:"description,omitempty"`
-	Ingredients []string `json:"ingredients,omitempty"`
-	URL         string   `json:"url,omitempty"`
-	ImageURL    string   `json:"image_url,omitempty"`
-	CategoryID  string   `json:"category_id,omitempty"`
-	CreatedAt   string   `json:"created_at,omitempty"`
-	UpdatedAt   string   `json:"updated_at,omitempty"`
-}
-
-// RecipeRequest represents the request body for creating/updating a recipe.
-type RecipeRequest struct {
-	Recipe RecipeData `json:"recipe"`
+	ID             string   `json:"id,omitempty"`
+	Title          string   `json:"summary,omitempty"`
+	Description    string   `json:"description,omitempty"`
+	Ingredients    []string `json:"ingredients,omitempty"`
+	URL            string   `json:"url,omitempty"`
+	ImageURL       string   `json:"image_url,omitempty"`
+	MealCategoryID string   `json:"meal_category_id,omitempty"`
+	CreatedAt      string   `json:"created_at,omitempty"`
+	UpdatedAt      string   `json:"updated_at,omitempty"`
 }
 
 // RecipeData holds the recipe fields for create/update requests.
 type RecipeData struct {
-	Title       string   `json:"title,omitempty"`
-	Description string   `json:"description,omitempty"`
-	Ingredients []string `json:"ingredients,omitempty"`
-	URL         string   `json:"url,omitempty"`
-	ImageURL    string   `json:"image_url,omitempty"`
-	CategoryID  string   `json:"category_id,omitempty"`
+	Title          string   `json:"summary,omitempty"`
+	Description    string   `json:"description,omitempty"`
+	Ingredients    []string `json:"ingredients,omitempty"`
+	URL            string   `json:"url,omitempty"`
+	MealCategoryID string   `json:"meal_category_id,omitempty"`
+}
+
+// recipeAPIResponse wraps the JSON-API envelope for recipe list responses.
+type recipeAPIResponse struct {
+	Data []recipeAPIEntry `json:"data"`
+}
+
+// recipeAPISingleResponse wraps the JSON-API envelope for single recipe responses.
+type recipeAPISingleResponse struct {
+	Data recipeAPIEntry `json:"data"`
+}
+
+// recipeAPIEntry represents a single recipe in JSON-API format.
+type recipeAPIEntry struct {
+	ID         string `json:"id"`
+	Attributes struct {
+		Summary     string   `json:"summary"`
+		Description string   `json:"description"`
+		Ingredients []string `json:"ingredients"`
+		URL         string   `json:"url"`
+		ImageURL    string   `json:"image_url"`
+	} `json:"attributes"`
+	Relationships struct {
+		MealCategory struct {
+			Data *struct {
+				ID string `json:"id"`
+			} `json:"data"`
+		} `json:"meal_category"`
+	} `json:"relationships"`
+}
+
+func (e *recipeAPIEntry) toRecipe() Recipe {
+	r := Recipe{
+		ID:          e.ID,
+		Title:       e.Attributes.Summary,
+		Description: e.Attributes.Description,
+		Ingredients: e.Attributes.Ingredients,
+		URL:         e.Attributes.URL,
+		ImageURL:    e.Attributes.ImageURL,
+	}
+	if e.Relationships.MealCategory.Data != nil {
+		r.MealCategoryID = e.Relationships.MealCategory.Data.ID
+	}
+	return r
 }
 
 // MealSitting represents a meal sitting (scheduled meal).
 type MealSitting struct {
-	ID        string `json:"id,omitempty"`
-	RecipeID  string `json:"recipe_id,omitempty"`
-	Date      string `json:"date,omitempty"`
-	MealType  string `json:"meal_type,omitempty"`
-	CreatedAt string `json:"created_at,omitempty"`
-	UpdatedAt string `json:"updated_at,omitempty"`
-}
-
-// MealSittingRequest represents the request body for creating a meal sitting.
-type MealSittingRequest struct {
-	MealSitting MealSittingData `json:"meal_sitting"`
+	ID             string `json:"id,omitempty"`
+	Summary        string `json:"summary,omitempty"`
+	RecipeID       string `json:"recipe_id,omitempty"`
+	MealCategoryID string `json:"meal_category_id,omitempty"`
+	Date           string `json:"date,omitempty"`
+	CreatedAt      string `json:"created_at,omitempty"`
+	UpdatedAt      string `json:"updated_at,omitempty"`
 }
 
 // MealSittingData holds the meal sitting fields for create requests.
 type MealSittingData struct {
-	RecipeID string `json:"recipe_id,omitempty"`
-	Date     string `json:"date,omitempty"`
-	MealType string `json:"meal_type,omitempty"`
+	Summary        string `json:"summary,omitempty"`
+	RecipeID       string `json:"meal_recipe_id,omitempty"`
+	MealCategoryID string `json:"meal_category_id,omitempty"`
+	Date           string `json:"date,omitempty"`
+}
+
+// MealSittingListOptions holds filters for listing meal sittings.
+type MealSittingListOptions struct {
+	DateMin string
+	DateMax string
+}
+
+// mealSittingAPIResponse wraps the JSON-API envelope for meal sitting list/create responses.
+type mealSittingAPIResponse struct {
+	Data []mealSittingAPIEntry `json:"data"`
+}
+
+// mealSittingAPIEntry represents a single meal sitting in JSON-API format.
+type mealSittingAPIEntry struct {
+	ID         string `json:"id"`
+	Attributes struct {
+		Summary string `json:"summary"`
+	} `json:"attributes"`
+	Relationships struct {
+		MealCategory struct {
+			Data *struct {
+				ID string `json:"id"`
+			} `json:"data"`
+		} `json:"meal_category"`
+		MealRecipe struct {
+			Data *struct {
+				ID string `json:"id"`
+			} `json:"data"`
+		} `json:"meal_recipe"`
+	} `json:"relationships"`
+}
+
+func (e *mealSittingAPIEntry) toMealSitting() MealSitting {
+	s := MealSitting{
+		ID:      e.ID,
+		Summary: e.Attributes.Summary,
+	}
+	if e.Relationships.MealCategory.Data != nil {
+		s.MealCategoryID = e.Relationships.MealCategory.Data.ID
+	}
+	if e.Relationships.MealRecipe.Data != nil {
+		s.RecipeID = e.Relationships.MealRecipe.Data.ID
+	}
+	return s
 }
 
 // MealCategory represents a meal category.
 type MealCategory struct {
-	ID   string `json:"id,omitempty"`
-	Name string `json:"name,omitempty"`
+	ID    string `json:"id,omitempty"`
+	Name  string `json:"label,omitempty"`
+	Color string `json:"color,omitempty"`
+}
+
+// mealCategoryAPIResponse wraps the JSON-API envelope for meal category list responses.
+type mealCategoryAPIResponse struct {
+	Data []mealCategoryAPIEntry `json:"data"`
+}
+
+// mealCategoryAPIEntry represents a single meal category in JSON-API format.
+type mealCategoryAPIEntry struct {
+	ID         string `json:"id"`
+	Attributes struct {
+		Label string `json:"label"`
+		Color string `json:"color"`
+	} `json:"attributes"`
+}
+
+func (e *mealCategoryAPIEntry) toMealCategory() MealCategory {
+	return MealCategory{
+		ID:    e.ID,
+		Name:  e.Attributes.Label,
+		Color: e.Attributes.Color,
+	}
 }
 
 // Category represents a family member/category.
 type Category struct {
 	ID        string `json:"id,omitempty"`
-	Name      string `json:"name,omitempty"`
+	Name      string `json:"label,omitempty"`
 	Color     string `json:"color,omitempty"`
-	AvatarURL string `json:"avatar_url,omitempty"`
+	AvatarURL string `json:"profile_pic_url,omitempty"`
 	CreatedAt string `json:"created_at,omitempty"`
 	UpdatedAt string `json:"updated_at,omitempty"`
+}
+
+// categoryAPIResponse wraps the JSON-API envelope for category list responses.
+type categoryAPIResponse struct {
+	Data []categoryAPIEntry `json:"data"`
+}
+
+// categoryAPIEntry represents a single category in JSON-API format.
+type categoryAPIEntry struct {
+	ID         string `json:"id"`
+	Attributes struct {
+		Label         string  `json:"label"`
+		Color         string  `json:"color"`
+		ProfilePicURL *string `json:"profile_pic_url"`
+	} `json:"attributes"`
+}
+
+func (e *categoryAPIEntry) toCategory() Category {
+	c := Category{
+		ID:    e.ID,
+		Name:  e.Attributes.Label,
+		Color: e.Attributes.Color,
+	}
+	if e.Attributes.ProfilePicURL != nil {
+		c.AvatarURL = *e.Attributes.ProfilePicURL
+	}
+	return c
 }
 
 // Frame represents a Skylight frame/device group.
 type Frame struct {
 	ID        string `json:"id,omitempty"`
 	Name      string `json:"name,omitempty"`
-	TimeZone  string `json:"time_zone,omitempty"`
+	TimeZone  string `json:"timezone,omitempty"`
 	CreatedAt string `json:"created_at,omitempty"`
 	UpdatedAt string `json:"updated_at,omitempty"`
+}
+
+// frameAPIResponse wraps the JSON-API envelope for single frame responses.
+type frameAPIResponse struct {
+	Data frameAPIEntry `json:"data"`
+}
+
+// frameAPIEntry represents a frame in JSON-API format.
+type frameAPIEntry struct {
+	ID         string `json:"id"`
+	Attributes struct {
+		Name     string `json:"name"`
+		TimeZone string `json:"timezone"`
+	} `json:"attributes"`
+}
+
+func (e *frameAPIEntry) toFrame() Frame {
+	return Frame{
+		ID:       e.ID,
+		Name:     e.Attributes.Name,
+		TimeZone: e.Attributes.TimeZone,
+	}
 }
 
 // Device represents a physical Skylight device.
@@ -350,6 +628,28 @@ type Device struct {
 	UpdatedAt    string `json:"updated_at,omitempty"`
 }
 
+// deviceAPIResponse wraps the JSON-API envelope for device list responses.
+type deviceAPIResponse struct {
+	Data []deviceAPIEntry `json:"data"`
+}
+
+// deviceAPIEntry represents a single device in JSON-API format.
+type deviceAPIEntry struct {
+	ID         string `json:"id"`
+	Attributes struct {
+		Name      string `json:"name"`
+		Activated bool   `json:"activated"`
+	} `json:"attributes"`
+}
+
+func (e *deviceAPIEntry) toDevice() Device {
+	return Device{
+		ID:     e.ID,
+		Name:   e.Attributes.Name,
+		Online: e.Attributes.Activated,
+	}
+}
+
 // Avatar represents an available avatar option.
 type Avatar struct {
 	ID       string `json:"id,omitempty"`
@@ -357,11 +657,37 @@ type Avatar struct {
 	ImageURL string `json:"image_url,omitempty"`
 }
 
+// avatarAPIResponse wraps the JSON-API envelope for avatar list responses.
+type avatarAPIResponse struct {
+	Data []avatarAPIEntry `json:"data"`
+}
+
+// avatarAPIEntry represents a single avatar in JSON-API format.
+type avatarAPIEntry struct {
+	ID         string `json:"id"`
+	Attributes struct {
+		Name     string `json:"name"`
+		ImageURL string `json:"image_url"`
+	} `json:"attributes"`
+}
+
+func (e *avatarAPIEntry) toAvatar() Avatar {
+	return Avatar{
+		ID:       e.ID,
+		Name:     e.Attributes.Name,
+		ImageURL: e.Attributes.ImageURL,
+	}
+}
+
 // Color represents an available color option.
 type Color struct {
-	ID    string `json:"id,omitempty"`
-	Name  string `json:"name,omitempty"`
-	Value string `json:"value,omitempty"`
+	Name string `json:"name,omitempty"`
+	Hex  string `json:"hex,omitempty"`
+}
+
+// colorAPIResponse wraps the data envelope for color list responses.
+type colorAPIResponse struct {
+	Data []Color `json:"data"`
 }
 
 // Dashboard aggregates today's data from multiple Skylight resources.
@@ -380,6 +706,7 @@ type BountyData struct {
 	Points      int    `json:"points"`
 	DueDate     string `json:"due_date,omitempty"`
 	AssigneeID  string `json:"assignee_id,omitempty"`
+	CategoryIDs []int  `json:"category_ids,omitempty"`
 	Recurring   bool   `json:"recurring,omitempty"`
 	RewardTitle string `json:"reward_title"`
 	EmojiIcon   string `json:"emoji_icon,omitempty"`


### PR DESCRIPTION
## Summary

- All Skylight API endpoints return a JSON-API envelope; added typed wrapper structs throughout lib/structs.go with toX() conversion methods so every response is correctly deserialized
- Fixes JSON field name mismatches discovered during live field testing: summary/starts_at/ends_at for calendar events; label/kind for lists, source calendars, meal categories; hex for colors; meal_recipe_id for sittings
- UpdateList was using a {"list":{}} request wrapper — switched to flat JSON (what the API actually expects)
- MealSittingData.RecipeID had wrong JSON tag (recipe_id -> meal_recipe_id); added --summary flag for standalone sittings
- CreateBounty now passes category_ids to the reward, derived from AssigneeID when not explicitly set
- ListBounties adds a default after/before date range since the chores API requires both params
- All test mock responses updated to use JSON-API envelope format

## Test plan

- [ ] make test passes (all 3 packages)
- [ ] make lint reports 0 issues
- [ ] make build succeeds
- [ ] Live field test against real Skylight account: Groups A-J all pass