### PR TITLE
test: add unit test coverage for JSON-API alignment behavior

### DIFF
--- a/lib/bounty_test.go
+++ b/lib/bounty_test.go
@@ -6,6 +6,7 @@ import (
 	"net/http/httptest"
 	"sync/atomic"
 	"testing"
+	"time"
 )
 
 func TestCreateBounty(t *testing.T) {
@@ -19,6 +20,107 @@ func TestCreateBounty(t *testing.T) {
 		wantDeleteN int32
 		wantErr     bool
 	}{
+		{
+			name:  "derives category_ids from AssigneeID",
+			input: BountyData{Title: "Task", Points: 5, RewardTitle: "Prize", AssigneeID: "6750947"},
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				switch {
+				case r.Method == http.MethodPost && r.URL.Path == "/api/frames/frame1/chores":
+					w.WriteHeader(http.StatusCreated)
+					if err := json.NewEncoder(w).Encode(choreAPISingleResponse{
+						Data: choreAPIEntry{ID: "ch1", Attributes: struct {
+							Summary      string `json:"summary"`
+							Status       string `json:"status"`
+							Start        string `json:"start"`
+							RewardPoints int    `json:"reward_points"`
+							Recurring    bool   `json:"recurring"`
+						}{Summary: "Task", RewardPoints: 5}},
+					}); err != nil {
+						http.Error(w, err.Error(), http.StatusInternalServerError)
+					}
+				case r.Method == http.MethodPost && r.URL.Path == "/api/frames/frame1/rewards":
+					var body map[string]any
+					if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+						http.Error(w, err.Error(), http.StatusInternalServerError)
+						return
+					}
+					catIDs, ok := body["category_ids"]
+					if !ok {
+						t.Error("reward request body missing category_ids")
+					} else {
+						ids, _ := catIDs.([]any)
+						if len(ids) != 1 || ids[0] != float64(6750947) {
+							t.Errorf("category_ids: want [6750947], got %v", catIDs)
+						}
+					}
+					w.WriteHeader(http.StatusCreated)
+					if err := json.NewEncoder(w).Encode(rewardAPIResponse{
+						Data: []rewardAPIEntry{{ID: "rw1", Attributes: struct {
+							Name                string  `json:"name"`
+							EmojiIcon           string  `json:"emoji_icon"`
+							PointValue          int     `json:"point_value"`
+							RespawnOnRedemption bool    `json:"respawn_on_redemption"`
+							RedeemedAt          *string `json:"redeemed_at"`
+						}{Name: "Prize", PointValue: 5}}},
+					}); err != nil {
+						http.Error(w, err.Error(), http.StatusInternalServerError)
+					}
+				}
+			},
+			wantChore:  "Task",
+			wantReward: "Prize",
+			wantPoints: 5,
+		},
+		{
+			name:  "no category_ids when AssigneeID empty",
+			input: BountyData{Title: "Task", Points: 5, RewardTitle: "Prize"},
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				switch {
+				case r.Method == http.MethodPost && r.URL.Path == "/api/frames/frame1/chores":
+					w.WriteHeader(http.StatusCreated)
+					if err := json.NewEncoder(w).Encode(choreAPISingleResponse{
+						Data: choreAPIEntry{ID: "ch1", Attributes: struct {
+							Summary      string `json:"summary"`
+							Status       string `json:"status"`
+							Start        string `json:"start"`
+							RewardPoints int    `json:"reward_points"`
+							Recurring    bool   `json:"recurring"`
+						}{Summary: "Task", RewardPoints: 5}},
+					}); err != nil {
+						http.Error(w, err.Error(), http.StatusInternalServerError)
+					}
+				case r.Method == http.MethodPost && r.URL.Path == "/api/frames/frame1/rewards":
+					var body map[string]any
+					if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+						http.Error(w, err.Error(), http.StatusInternalServerError)
+						return
+					}
+					if catIDs, ok := body["category_ids"]; ok {
+						ids, _ := catIDs.([]any)
+						if len(ids) > 0 {
+							t.Errorf("expected no category_ids, got %v", catIDs)
+						}
+					}
+					w.WriteHeader(http.StatusCreated)
+					if err := json.NewEncoder(w).Encode(rewardAPIResponse{
+						Data: []rewardAPIEntry{{ID: "rw1", Attributes: struct {
+							Name                string  `json:"name"`
+							EmojiIcon           string  `json:"emoji_icon"`
+							PointValue          int     `json:"point_value"`
+							RespawnOnRedemption bool    `json:"respawn_on_redemption"`
+							RedeemedAt          *string `json:"redeemed_at"`
+						}{Name: "Prize", PointValue: 5}}},
+					}); err != nil {
+						http.Error(w, err.Error(), http.StatusInternalServerError)
+					}
+				}
+			},
+			wantChore:  "Task",
+			wantReward: "Prize",
+			wantPoints: 5,
+		},
 		{
 			name:  "creates chore and reward",
 			input: BountyData{Title: "Do dishes", Points: 10, RewardTitle: "Ice cream", EmojiIcon: "🍦"},
@@ -231,5 +333,55 @@ func TestListBounties(t *testing.T) {
 				}
 			}
 		})
+	}
+}
+
+func TestListBountiesDateRange(t *testing.T) {
+	var gotAfter, gotBefore string
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Path {
+		case "/api/frames/frame1/chores":
+			gotAfter = r.URL.Query().Get("after")
+			gotBefore = r.URL.Query().Get("before")
+			if err := json.NewEncoder(w).Encode(choreAPIResponse{}); err != nil {
+				http.Error(w, err.Error(), http.StatusInternalServerError)
+			}
+		case "/api/frames/frame1/rewards":
+			if err := json.NewEncoder(w).Encode(rewardAPIResponse{}); err != nil {
+				http.Error(w, err.Error(), http.StatusInternalServerError)
+			}
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer srv.Close()
+
+	old := SkylightURL
+	SkylightURL = srv.URL + "/api"
+	defer func() { SkylightURL = old }()
+
+	client, _ := NewClientWithToken("u", "t")
+	if _, err := client.ListBounties("frame1"); err != nil {
+		t.Fatalf("ListBounties: %v", err)
+	}
+
+	if gotAfter == "" {
+		t.Error("expected non-empty after query param")
+	}
+	if gotBefore == "" {
+		t.Error("expected non-empty before query param")
+	}
+	afterT, err := time.Parse(DateFormat, gotAfter)
+	if err != nil {
+		t.Errorf("after=%q is not a valid date: %v", gotAfter, err)
+	}
+	beforeT, err := time.Parse(DateFormat, gotBefore)
+	if err != nil {
+		t.Errorf("before=%q is not a valid date: %v", gotBefore, err)
+	}
+	if !beforeT.After(afterT) {
+		t.Errorf("expected before (%s) > after (%s)", gotBefore, gotAfter)
 	}
 }

--- a/lib/list_test.go
+++ b/lib/list_test.go
@@ -1,6 +1,7 @@
 package lib
 
 import (
+	"encoding/json"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -446,6 +447,35 @@ func TestDeleteListItem(t *testing.T) {
 				t.Fatalf("wantErr=%v got %v", tc.wantErr, err)
 			}
 		})
+	}
+}
+
+func TestUpdateListFlatJSON(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPut {
+			t.Errorf("expected PUT, got %s", r.Method)
+		}
+		var body map[string]any
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			t.Errorf("decode body: %v", err)
+		}
+		if _, hasWrapper := body["list"]; hasWrapper {
+			t.Error(`request body must not have a "list" wrapper key`)
+		}
+		if _, hasLabel := body["label"]; !hasLabel {
+			t.Error(`request body must have a top-level "label" key`)
+		}
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer srv.Close()
+
+	old := SkylightURL
+	SkylightURL = srv.URL + "/api"
+	defer func() { SkylightURL = old }()
+
+	client, _ := NewClientWithToken("u", "t")
+	if _, err := client.UpdateList("frame1", "1", ListData{Title: "Renamed"}); err != nil {
+		t.Fatalf("UpdateList: %v", err)
 	}
 }
 

--- a/lib/meal_test.go
+++ b/lib/meal_test.go
@@ -1,6 +1,7 @@
 package lib
 
 import (
+	"encoding/json"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -487,6 +488,100 @@ func TestAddRecipeToGroceryList(t *testing.T) {
 			err := client.AddRecipeToGroceryList("frame1", tc.recipeID)
 			if (err != nil) != tc.wantErr {
 				t.Fatalf("wantErr=%v got %v", tc.wantErr, err)
+			}
+		})
+	}
+}
+
+func TestCreateMealSittingFieldNames(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			t.Errorf("expected POST, got %s", r.Method)
+		}
+		var body map[string]any
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			t.Errorf("decode body: %v", err)
+			w.WriteHeader(http.StatusBadRequest)
+			return
+		}
+		if _, ok := body["meal_recipe_id"]; !ok {
+			t.Error(`request body must have "meal_recipe_id" key`)
+		}
+		if _, ok := body["recipe_id"]; ok {
+			t.Error(`request body must not have "recipe_id" key`)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusCreated)
+		if _, err := w.Write([]byte(`{"data":[{"id":"s1","type":"meal_sitting","attributes":{"summary":""},"relationships":{"meal_category":{"data":null},"meal_recipe":{"data":{"id":"recipe1","type":"meal_recipe"}}}}]}`)); err != nil {
+			t.Errorf("write: %v", err)
+		}
+	}))
+	defer srv.Close()
+
+	old := SkylightURL
+	SkylightURL = srv.URL + "/api"
+	defer func() { SkylightURL = old }()
+
+	client, _ := NewClientWithToken("u", "t")
+	if _, err := client.CreateMealSitting("frame1", MealSittingData{RecipeID: "recipe1", Date: "2024-01-15"}); err != nil {
+		t.Fatalf("CreateMealSitting: %v", err)
+	}
+}
+
+func TestCreateMealSittingSummary(t *testing.T) {
+	tests := []struct {
+		name        string
+		input       MealSittingData
+		wantSummary string
+		wantAbsent  bool
+	}{
+		{
+			name:        "sends summary when provided",
+			input:       MealSittingData{Summary: "Pasta Night", Date: "2024-01-15"},
+			wantSummary: "Pasta Night",
+		},
+		{
+			name:       "omits summary when empty",
+			input:      MealSittingData{Date: "2024-01-15"},
+			wantAbsent: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				var body map[string]any
+				if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+					t.Errorf("decode body: %v", err)
+					w.WriteHeader(http.StatusBadRequest)
+					return
+				}
+				val, present := body["summary"]
+				if tc.wantAbsent && present {
+					t.Errorf("expected summary to be absent, got %v", val)
+				}
+				if !tc.wantAbsent {
+					if !present {
+						t.Error("expected summary to be present")
+					} else if val != tc.wantSummary {
+						t.Errorf("summary: want %q got %v", tc.wantSummary, val)
+					}
+				}
+				w.Header().Set("Content-Type", "application/json")
+				w.WriteHeader(http.StatusCreated)
+				if _, err := w.Write([]byte(`{"data":[{"id":"s1","type":"meal_sitting","attributes":{"summary":""},"relationships":{"meal_category":{"data":null},"meal_recipe":{"data":null}}}]}`)); err != nil {
+					t.Errorf("write: %v", err)
+				}
+			}))
+			defer srv.Close()
+
+			old := SkylightURL
+			SkylightURL = srv.URL + "/api"
+			defer func() { SkylightURL = old }()
+
+			client, _ := NewClientWithToken("u", "t")
+			if _, err := client.CreateMealSitting("frame1", tc.input); err != nil {
+				t.Fatalf("CreateMealSitting: %v", err)
 			}
 		})
 	}


### PR DESCRIPTION
## Summary

- `TestUpdateListFlatJSON`: verifies `UpdateList` sends a flat JSON body (no `{"list":{}}` wrapper) as required by the Skylight API
- `TestCreateBounty/derives_category_ids_from_AssigneeID`: verifies `CreateBounty` converts `AssigneeID` to `category_ids` in the reward request
- `TestCreateBounty/no_category_ids_when_AssigneeID_empty`: verifies no `category_ids` are sent when `AssigneeID` is not set
- `TestListBountiesDateRange`: verifies `ListBounties` passes valid `after`/`before` query params to the chores endpoint
- `TestCreateMealSittingFieldNames`: verifies `CreateMealSitting` uses `meal_recipe_id` (not `recipe_id`) in the request body
- `TestCreateMealSittingSummary`: verifies `summary` is sent when provided and omitted (via `omitempty`) when empty

## Test plan

- [x] `make test` — all tests pass
- [x] `make lint` — 0 issues