### PR TITLE
refactor: simplify lib — named relationship type, parallel API calls, surface strconv error

### DIFF
--- a/lib/bounty.go
+++ b/lib/bounty.go
@@ -3,6 +3,7 @@ package lib
 import (
 	"fmt"
 	"strconv"
+	"sync"
 	"time"
 )
 
@@ -22,9 +23,12 @@ func (c *Client) CreateBounty(frameID string, data BountyData) (*Bounty, error) 
 
 	categoryIDs := data.CategoryIDs
 	if len(categoryIDs) == 0 && data.AssigneeID != "" {
-		if id, err := strconv.Atoi(data.AssigneeID); err == nil {
-			categoryIDs = []int{id}
+		id, err := strconv.Atoi(data.AssigneeID)
+		if err != nil {
+			_ = c.DeleteChore(frameID, chore.ID)
+			return nil, fmt.Errorf("assignee_id %q is not a valid numeric category ID: %w", data.AssigneeID, err)
 		}
+		categoryIDs = []int{id}
 	}
 	reward, err := c.CreateReward(frameID, RewardData{
 		Title:       data.RewardTitle,
@@ -48,18 +52,35 @@ func (c *Client) CreateBounty(frameID string, data BountyData) (*Bounty, error) 
 // matching them by point value as a heuristic.
 func (c *Client) ListBounties(frameID string) ([]Bounty, error) {
 	today := time.Now()
-	chores, err := c.ListChores(frameID, ChoreListOptions{
-		Status: "pending",
-		After:  today.AddDate(0, 0, -1).Format(DateFormat),
-		Before: today.AddDate(0, 1, 0).Format(DateFormat),
-	})
-	if err != nil {
-		return nil, fmt.Errorf("failed to list bounty chores: %w", err)
-	}
 
-	rewards, err := c.ListRewards(frameID)
-	if err != nil {
-		return nil, fmt.Errorf("failed to list bounty rewards: %w", err)
+	var (
+		chores    []Chore
+		rewards   []Reward
+		choreErr  error
+		rewardErr error
+		wg        sync.WaitGroup
+	)
+
+	wg.Add(2)
+	go func() {
+		defer wg.Done()
+		chores, choreErr = c.ListChores(frameID, ChoreListOptions{
+			Status: choreStatusPending,
+			After:  today.AddDate(0, 0, -1).Format(DateFormat),
+			Before: today.AddDate(0, 1, 0).Format(DateFormat),
+		})
+	}()
+	go func() {
+		defer wg.Done()
+		rewards, rewardErr = c.ListRewards(frameID)
+	}()
+	wg.Wait()
+
+	if choreErr != nil {
+		return nil, fmt.Errorf("failed to list bounty chores: %w", choreErr)
+	}
+	if rewardErr != nil {
+		return nil, fmt.Errorf("failed to list bounty rewards: %w", rewardErr)
 	}
 
 	// Index unredeemed rewards by point value

--- a/lib/chore.go
+++ b/lib/chore.go
@@ -2,6 +2,8 @@ package lib
 
 import "fmt"
 
+const choreStatusPending = "pending"
+
 // ListChores retrieves chores for a frame with optional filters.
 func (c *Client) ListChores(frameID string, opts ChoreListOptions) ([]Chore, error) {
 	req, err := newRequest("GET", fmt.Sprintf("%s/frames/%s/chores", c.effectiveURL(), frameID), nil)

--- a/lib/dashboard.go
+++ b/lib/dashboard.go
@@ -1,6 +1,7 @@
 package lib
 
 import (
+	"sync"
 	"time"
 )
 
@@ -11,38 +12,50 @@ const DateFormat = "2006-01-02"
 func (c *Client) GetDashboard(frameID string) (*Dashboard, error) {
 	today := time.Now().Format(DateFormat)
 
-	events, err := c.ListCalendarEvents(frameID, today, today)
-	if err != nil {
-		return nil, err
-	}
+	var (
+		events   []CalendarEvent
+		chores   []Chore
+		points   []RewardPointEntry
+		sittings []MealSitting
+		lists    []List
+		errs     [5]error
+		wg       sync.WaitGroup
+	)
 
-	chores, err := c.ListChores(frameID, ChoreListOptions{
-		Date:        today,
-		Status:      "pending",
-		IncludeLate: true,
-	})
-	if err != nil {
-		return nil, err
-	}
+	wg.Add(5)
+	go func() {
+		defer wg.Done()
+		events, errs[0] = c.ListCalendarEvents(frameID, today, today)
+	}()
+	go func() {
+		defer wg.Done()
+		chores, errs[1] = c.ListChores(frameID, ChoreListOptions{
+			Date:        today,
+			Status:      choreStatusPending,
+			IncludeLate: true,
+		})
+	}()
+	go func() {
+		defer wg.Done()
+		points, errs[2] = c.GetRewardPoints(frameID)
+	}()
+	go func() {
+		defer wg.Done()
+		sittings, errs[3] = c.ListMealSittings(frameID, MealSittingListOptions{
+			DateMin: today,
+			DateMax: today,
+		})
+	}()
+	go func() {
+		defer wg.Done()
+		lists, errs[4] = c.ListLists(frameID)
+	}()
+	wg.Wait()
 
-	points, err := c.GetRewardPoints(frameID)
-	if err != nil {
-		return nil, err
-	}
-
-	allSittings, err := c.ListMealSittings(frameID, MealSittingListOptions{
-		DateMin: today,
-		DateMax: today,
-	})
-	if err != nil {
-		return nil, err
-	}
-
-	todaySittings := allSittings
-
-	lists, err := c.ListLists(frameID)
-	if err != nil {
-		return nil, err
+	for _, err := range errs {
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	return &Dashboard{
@@ -50,7 +63,7 @@ func (c *Client) GetDashboard(frameID string) (*Dashboard, error) {
 		Events:       events,
 		Chores:       chores,
 		Points:       points,
-		MealSittings: todaySittings,
+		MealSittings: sittings,
 		Lists:        lists,
 	}, nil
 }

--- a/lib/poller_test.go
+++ b/lib/poller_test.go
@@ -39,9 +39,7 @@ func makePollerServer(t *testing.T, rewards []Reward, categories []Category) *ht
 					},
 				}
 				if rw.CategoryID != "" {
-					entries[i].Relationships.Category.Data = &struct {
-						ID string `json:"id"`
-					}{ID: rw.CategoryID}
+					entries[i].Relationships.Category.Data = &apiRelationshipData{ID: rw.CategoryID}
 				}
 			}
 			if err := json.NewEncoder(w).Encode(rewardAPIResponse{Data: entries}); err != nil {

--- a/lib/structs.go
+++ b/lib/structs.go
@@ -1,5 +1,10 @@
 package lib
 
+// apiRelationshipData is the JSON-API "data" object inside a to-one relationship.
+type apiRelationshipData struct {
+	ID string `json:"id"`
+}
+
 // Session holds the authenticated user credentials extracted from login.
 type Session struct {
 	UserID   string
@@ -71,9 +76,7 @@ type calendarAPIEntry struct {
 	} `json:"attributes"`
 	Relationships struct {
 		Category struct {
-			Data *struct {
-				ID string `json:"id"`
-			} `json:"data"`
+			Data *apiRelationshipData `json:"data"`
 		} `json:"category"`
 	} `json:"relationships"`
 }
@@ -154,9 +157,7 @@ type choreAPIEntry struct {
 	} `json:"attributes"`
 	Relationships struct {
 		Category struct {
-			Data *struct {
-				ID string `json:"id"`
-			} `json:"data"`
+			Data *apiRelationshipData `json:"data"`
 		} `json:"category"`
 	} `json:"relationships"`
 }
@@ -341,9 +342,7 @@ type rewardAPIEntry struct {
 	} `json:"attributes"`
 	Relationships struct {
 		Category struct {
-			Data *struct {
-				ID string `json:"id"`
-			} `json:"data"`
+			Data *apiRelationshipData `json:"data"`
 		} `json:"category"`
 	} `json:"relationships"`
 }
@@ -433,9 +432,7 @@ type recipeAPIEntry struct {
 	} `json:"attributes"`
 	Relationships struct {
 		MealCategory struct {
-			Data *struct {
-				ID string `json:"id"`
-			} `json:"data"`
+			Data *apiRelationshipData `json:"data"`
 		} `json:"meal_category"`
 	} `json:"relationships"`
 }
@@ -493,14 +490,10 @@ type mealSittingAPIEntry struct {
 	} `json:"attributes"`
 	Relationships struct {
 		MealCategory struct {
-			Data *struct {
-				ID string `json:"id"`
-			} `json:"data"`
+			Data *apiRelationshipData `json:"data"`
 		} `json:"meal_category"`
 		MealRecipe struct {
-			Data *struct {
-				ID string `json:"id"`
-			} `json:"data"`
+			Data *apiRelationshipData `json:"data"`
 		} `json:"meal_recipe"`
 	} `json:"relationships"`
 }


### PR DESCRIPTION
## Summary

- **`structs.go`**: Extracted `apiRelationshipData` named type to replace 6 identical anonymous `*struct{ ID string }` fields across JSON-API relationship structs. Also updated `poller_test.go` to use the new type.
- **`chore.go`**: Added `choreStatusPending` constant; replaced raw `"pending"` literals in `dashboard.go` and `bounty.go`.
- **`dashboard.go`**: Parallelized all 5 independent API calls in `GetDashboard` with goroutines + `sync.WaitGroup`, reducing wall-clock time from the sum of 5 latencies to the max. Removed redundant `todaySittings` alias.
- **`bounty.go`**: Parallelized the chore + reward fetches in `ListBounties`. Surfaced `strconv.Atoi` failure in `CreateBounty` (previously silent — non-numeric `AssigneeID` now returns an error instead of silently sending no `category_ids`).

## Test plan

- [x] `make test` — all tests pass
- [x] `make lint` — 0 issues