### PR TITLE
Handle all silenced errors and remove unused parameter

### DIFF
--- a/lib/calendar.go
+++ b/lib/calendar.go
@@ -4,7 +4,7 @@ import "fmt"
 
 // ListCalendarEvents retrieves calendar events for a frame within a date range.
 func (c *Client) ListCalendarEvents(frameID, startDate, endDate string) ([]CalendarEvent, error) {
-	req, err := newRequest("GET", fmt.Sprintf("%s/frames/%s/calendar_events", c.effectiveURL(), frameID), nil)
+	req, err := newRequest("GET", fmt.Sprintf("%s/frames/%s/calendar_events", c.effectiveURL(), frameID))
 	if err != nil {
 		return nil, fmt.Errorf("failed to create list calendar events request: %w", err)
 	}
@@ -66,7 +66,7 @@ func (c *Client) UpdateCalendarEvent(frameID, eventID string, event CalendarEven
 
 // DeleteCalendarEvent deletes a calendar event.
 func (c *Client) DeleteCalendarEvent(frameID, eventID string) error {
-	req, err := newRequest("DELETE", fmt.Sprintf("%s/frames/%s/calendar_events/%s", c.effectiveURL(), frameID, eventID), nil)
+	req, err := newRequest("DELETE", fmt.Sprintf("%s/frames/%s/calendar_events/%s", c.effectiveURL(), frameID, eventID))
 	if err != nil {
 		return fmt.Errorf("failed to create delete calendar event request: %w", err)
 	}
@@ -80,7 +80,7 @@ func (c *Client) DeleteCalendarEvent(frameID, eventID string) error {
 
 // ListSourceCalendars retrieves source calendars for a frame.
 func (c *Client) ListSourceCalendars(frameID string) ([]SourceCalendar, error) {
-	req, err := newRequest("GET", fmt.Sprintf("%s/frames/%s/source_calendars", c.effectiveURL(), frameID), nil)
+	req, err := newRequest("GET", fmt.Sprintf("%s/frames/%s/source_calendars", c.effectiveURL(), frameID))
 	if err != nil {
 		return nil, fmt.Errorf("failed to create list source calendars request: %w", err)
 	}

--- a/lib/category.go
+++ b/lib/category.go
@@ -4,7 +4,7 @@ import "fmt"
 
 // ListCategories retrieves categories (family members) for a frame.
 func (c *Client) ListCategories(frameID string) ([]Category, error) {
-	req, err := newRequest("GET", fmt.Sprintf("%s/frames/%s/categories", c.effectiveURL(), frameID), nil)
+	req, err := newRequest("GET", fmt.Sprintf("%s/frames/%s/categories", c.effectiveURL(), frameID))
 	if err != nil {
 		return nil, fmt.Errorf("failed to create list categories request: %w", err)
 	}

--- a/lib/chore.go
+++ b/lib/chore.go
@@ -6,7 +6,7 @@ const choreStatusPending = "pending"
 
 // ListChores retrieves chores for a frame with optional filters.
 func (c *Client) ListChores(frameID string, opts ChoreListOptions) ([]Chore, error) {
-	req, err := newRequest("GET", fmt.Sprintf("%s/frames/%s/chores", c.effectiveURL(), frameID), nil)
+	req, err := newRequest("GET", fmt.Sprintf("%s/frames/%s/chores", c.effectiveURL(), frameID))
 	if err != nil {
 		return nil, fmt.Errorf("failed to create list chores request: %w", err)
 	}
@@ -81,7 +81,7 @@ func (c *Client) UpdateChore(frameID, choreID string, chore ChoreData) (*Chore, 
 
 // DeleteChore deletes a chore.
 func (c *Client) DeleteChore(frameID, choreID string) error {
-	req, err := newRequest("DELETE", fmt.Sprintf("%s/frames/%s/chores/%s", c.effectiveURL(), frameID, choreID), nil)
+	req, err := newRequest("DELETE", fmt.Sprintf("%s/frames/%s/chores/%s", c.effectiveURL(), frameID, choreID))
 	if err != nil {
 		return fmt.Errorf("failed to create delete chore request: %w", err)
 	}

--- a/lib/client.go
+++ b/lib/client.go
@@ -156,7 +156,10 @@ func (c *Client) get(req *http.Request, v any) error {
 	}
 	defer resp.Body.Close()
 
-	body, _ := io.ReadAll(resp.Body)
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return fmt.Errorf("failed to read response body: %w", err)
+	}
 	if err := checkStatus(resp, body); err != nil {
 		return err
 	}
@@ -170,7 +173,10 @@ func (c *Client) post(req *http.Request, v any) error {
 	}
 	defer resp.Body.Close()
 
-	body, _ := io.ReadAll(resp.Body)
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return fmt.Errorf("failed to read response body: %w", err)
+	}
 	if resp.StatusCode != http.StatusCreated && resp.StatusCode != http.StatusOK {
 		return checkStatus(resp, body)
 	}
@@ -191,7 +197,10 @@ func (c *Client) put(req *http.Request, v any) error {
 		return nil
 	}
 
-	body, _ := io.ReadAll(resp.Body)
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return fmt.Errorf("failed to read response body: %w", err)
+	}
 	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusCreated {
 		return checkStatus(resp, body)
 	}
@@ -212,7 +221,10 @@ func (c *Client) patch(req *http.Request, v any) error {
 		return nil
 	}
 
-	body, _ := io.ReadAll(resp.Body)
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return fmt.Errorf("failed to read response body: %w", err)
+	}
 	if resp.StatusCode != http.StatusOK {
 		return checkStatus(resp, body)
 	}
@@ -232,7 +244,10 @@ func (c *Client) doDelete(req *http.Request) error {
 	if resp.StatusCode == http.StatusNoContent || resp.StatusCode == http.StatusOK {
 		return nil
 	}
-	body, _ := io.ReadAll(resp.Body)
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return fmt.Errorf("failed to read response body: %w", err)
+	}
 	return checkStatus(resp, body)
 }
 
@@ -244,9 +259,8 @@ func addQueryParams(req *http.Request, params map[string]string) {
 	req.URL.RawQuery = q.Encode()
 }
 
-//nolint:unparam
-func newRequest(method, url string, body io.Reader) (*http.Request, error) {
-	return http.NewRequest(method, url, body)
+func newRequest(method, url string) (*http.Request, error) {
+	return http.NewRequest(method, url, nil)
 }
 
 func newRequestWithBody(method, url string, body any) (*http.Request, error) {

--- a/lib/frame.go
+++ b/lib/frame.go
@@ -4,7 +4,7 @@ import "fmt"
 
 // GetFrame retrieves frame information.
 func (c *Client) GetFrame(frameID string) (*Frame, error) {
-	req, err := newRequest("GET", fmt.Sprintf("%s/frames/%s", c.effectiveURL(), frameID), nil)
+	req, err := newRequest("GET", fmt.Sprintf("%s/frames/%s", c.effectiveURL(), frameID))
 	if err != nil {
 		return nil, fmt.Errorf("failed to create get frame request: %w", err)
 	}
@@ -20,7 +20,7 @@ func (c *Client) GetFrame(frameID string) (*Frame, error) {
 
 // ListDevices retrieves devices for a frame.
 func (c *Client) ListDevices(frameID string) ([]Device, error) {
-	req, err := newRequest("GET", fmt.Sprintf("%s/frames/%s/devices", c.effectiveURL(), frameID), nil)
+	req, err := newRequest("GET", fmt.Sprintf("%s/frames/%s/devices", c.effectiveURL(), frameID))
 	if err != nil {
 		return nil, fmt.Errorf("failed to create list devices request: %w", err)
 	}
@@ -39,7 +39,7 @@ func (c *Client) ListDevices(frameID string) ([]Device, error) {
 
 // GetAvatars retrieves available avatars.
 func (c *Client) GetAvatars() ([]Avatar, error) {
-	req, err := newRequest("GET", fmt.Sprintf("%s/avatars", c.effectiveURL()), nil)
+	req, err := newRequest("GET", fmt.Sprintf("%s/avatars", c.effectiveURL()))
 	if err != nil {
 		return nil, fmt.Errorf("failed to create get avatars request: %w", err)
 	}
@@ -58,7 +58,7 @@ func (c *Client) GetAvatars() ([]Avatar, error) {
 
 // GetColors retrieves available colors.
 func (c *Client) GetColors() ([]Color, error) {
-	req, err := newRequest("GET", fmt.Sprintf("%s/colors", c.effectiveURL()), nil)
+	req, err := newRequest("GET", fmt.Sprintf("%s/colors", c.effectiveURL()))
 	if err != nil {
 		return nil, fmt.Errorf("failed to create get colors request: %w", err)
 	}

--- a/lib/list.go
+++ b/lib/list.go
@@ -7,7 +7,7 @@ const listItemStatusPending = "pending"
 
 // ListLists retrieves all lists for a frame.
 func (c *Client) ListLists(frameID string) ([]List, error) {
-	req, err := newRequest("GET", fmt.Sprintf("%s/frames/%s/lists", c.effectiveURL(), frameID), nil)
+	req, err := newRequest("GET", fmt.Sprintf("%s/frames/%s/lists", c.effectiveURL(), frameID))
 	if err != nil {
 		return nil, fmt.Errorf("failed to create list lists request: %w", err)
 	}
@@ -26,7 +26,7 @@ func (c *Client) ListLists(frameID string) ([]List, error) {
 
 // GetList retrieves a single list by ID (includes items from the included array).
 func (c *Client) GetList(frameID, listID string) (*List, error) {
-	req, err := newRequest("GET", fmt.Sprintf("%s/frames/%s/lists/%s", c.effectiveURL(), frameID, listID), nil)
+	req, err := newRequest("GET", fmt.Sprintf("%s/frames/%s/lists/%s", c.effectiveURL(), frameID, listID))
 	if err != nil {
 		return nil, fmt.Errorf("failed to create get list request: %w", err)
 	}
@@ -88,7 +88,7 @@ func (c *Client) UpdateList(frameID, listID string, list ListData) (*List, error
 
 // DeleteList deletes a list.
 func (c *Client) DeleteList(frameID, listID string) error {
-	req, err := newRequest("DELETE", fmt.Sprintf("%s/frames/%s/lists/%s", c.effectiveURL(), frameID, listID), nil)
+	req, err := newRequest("DELETE", fmt.Sprintf("%s/frames/%s/lists/%s", c.effectiveURL(), frameID, listID))
 	if err != nil {
 		return fmt.Errorf("failed to create delete list request: %w", err)
 	}
@@ -155,7 +155,7 @@ func (c *Client) UpdateListItem(frameID, listID, itemID string, item ListItemDat
 
 // DeleteListItem deletes an item from a list.
 func (c *Client) DeleteListItem(frameID, listID, itemID string) error {
-	req, err := newRequest("DELETE", fmt.Sprintf("%s/frames/%s/lists/%s/list_items/%s", c.effectiveURL(), frameID, listID, itemID), nil)
+	req, err := newRequest("DELETE", fmt.Sprintf("%s/frames/%s/lists/%s/list_items/%s", c.effectiveURL(), frameID, listID, itemID))
 	if err != nil {
 		return fmt.Errorf("failed to create delete list item request: %w", err)
 	}

--- a/lib/meal.go
+++ b/lib/meal.go
@@ -4,7 +4,7 @@ import "fmt"
 
 // ListMealCategories retrieves meal categories for a frame.
 func (c *Client) ListMealCategories(frameID string) ([]MealCategory, error) {
-	req, err := newRequest("GET", fmt.Sprintf("%s/frames/%s/meals/categories", c.effectiveURL(), frameID), nil)
+	req, err := newRequest("GET", fmt.Sprintf("%s/frames/%s/meals/categories", c.effectiveURL(), frameID))
 	if err != nil {
 		return nil, fmt.Errorf("failed to create list meal categories request: %w", err)
 	}
@@ -23,7 +23,7 @@ func (c *Client) ListMealCategories(frameID string) ([]MealCategory, error) {
 
 // ListRecipes retrieves recipes for a frame.
 func (c *Client) ListRecipes(frameID string) ([]Recipe, error) {
-	req, err := newRequest("GET", fmt.Sprintf("%s/frames/%s/meals/recipes", c.effectiveURL(), frameID), nil)
+	req, err := newRequest("GET", fmt.Sprintf("%s/frames/%s/meals/recipes", c.effectiveURL(), frameID))
 	if err != nil {
 		return nil, fmt.Errorf("failed to create list recipes request: %w", err)
 	}
@@ -42,7 +42,7 @@ func (c *Client) ListRecipes(frameID string) ([]Recipe, error) {
 
 // GetRecipe retrieves a single recipe by ID.
 func (c *Client) GetRecipe(frameID, recipeID string) (*Recipe, error) {
-	req, err := newRequest("GET", fmt.Sprintf("%s/frames/%s/meals/recipes/%s", c.effectiveURL(), frameID, recipeID), nil)
+	req, err := newRequest("GET", fmt.Sprintf("%s/frames/%s/meals/recipes/%s", c.effectiveURL(), frameID, recipeID))
 	if err != nil {
 		return nil, fmt.Errorf("failed to create get recipe request: %w", err)
 	}
@@ -92,7 +92,7 @@ func (c *Client) UpdateRecipe(frameID, recipeID string, recipe RecipeData) (*Rec
 
 // DeleteRecipe deletes a recipe.
 func (c *Client) DeleteRecipe(frameID, recipeID string) error {
-	req, err := newRequest("DELETE", fmt.Sprintf("%s/frames/%s/meals/recipes/%s", c.effectiveURL(), frameID, recipeID), nil)
+	req, err := newRequest("DELETE", fmt.Sprintf("%s/frames/%s/meals/recipes/%s", c.effectiveURL(), frameID, recipeID))
 	if err != nil {
 		return fmt.Errorf("failed to create delete recipe request: %w", err)
 	}
@@ -106,7 +106,7 @@ func (c *Client) DeleteRecipe(frameID, recipeID string) error {
 
 // ListMealSittings retrieves meal sittings for a frame within an optional date range.
 func (c *Client) ListMealSittings(frameID string, opts MealSittingListOptions) ([]MealSitting, error) {
-	req, err := newRequest("GET", fmt.Sprintf("%s/frames/%s/meals/sittings", c.effectiveURL(), frameID), nil)
+	req, err := newRequest("GET", fmt.Sprintf("%s/frames/%s/meals/sittings", c.effectiveURL(), frameID))
 	if err != nil {
 		return nil, fmt.Errorf("failed to create list meal sittings request: %w", err)
 	}
@@ -157,7 +157,7 @@ func (c *Client) CreateMealSitting(frameID string, sitting MealSittingData) (*Me
 
 // AddRecipeToGroceryList adds a recipe's ingredients to the grocery list.
 func (c *Client) AddRecipeToGroceryList(frameID, recipeID string) error {
-	req, err := newRequest("POST", fmt.Sprintf("%s/frames/%s/meals/recipes/%s/add_to_grocery_list", c.effectiveURL(), frameID, recipeID), nil)
+	req, err := newRequest("POST", fmt.Sprintf("%s/frames/%s/meals/recipes/%s/add_to_grocery_list", c.effectiveURL(), frameID, recipeID))
 	if err != nil {
 		return fmt.Errorf("failed to create add to grocery list request: %w", err)
 	}

--- a/lib/poller.go
+++ b/lib/poller.go
@@ -220,11 +220,21 @@ func (p *RewardsPoller) saveState() {
 	state := pollerState{SeenRewardIDs: ids}
 	data, err := json.Marshal(state)
 	if err != nil {
+		if p.logger != nil {
+			p.logger.Warn("poller: failed to marshal state", slog.String("error", err.Error()))
+		}
 		return
 	}
 
 	if err := os.MkdirAll(filepath.Dir(p.stateFile), 0o700); err != nil {
+		if p.logger != nil {
+			p.logger.Warn("poller: failed to create state directory", slog.String("path", filepath.Dir(p.stateFile)), slog.String("error", err.Error()))
+		}
 		return
 	}
-	_ = os.WriteFile(p.stateFile, data, 0o600)
+	if err := os.WriteFile(p.stateFile, data, 0o600); err != nil {
+		if p.logger != nil {
+			p.logger.Warn("poller: failed to write state file", slog.String("path", p.stateFile), slog.String("error", err.Error()))
+		}
+	}
 }

--- a/lib/retry.go
+++ b/lib/retry.go
@@ -136,7 +136,11 @@ func backoffDelay(base, max time.Duration, attempt int) time.Duration {
 		return exp
 	}
 	var b [8]byte
-	_, _ = rand.Read(b[:])
+	// crypto/rand.Read is guaranteed to return len(b) bytes on supported
+	// platforms; an error here would indicate a broken OS entropy source.
+	if _, err := rand.Read(b[:]); err != nil {
+		return exp
+	}
 	n := binary.LittleEndian.Uint64(b[:]) % half
 	return time.Duration(n) + exp/2 //nolint:gosec
 }

--- a/lib/reward.go
+++ b/lib/reward.go
@@ -4,7 +4,7 @@ import "fmt"
 
 // ListRewards retrieves rewards for a frame.
 func (c *Client) ListRewards(frameID string) ([]Reward, error) {
-	req, err := newRequest("GET", fmt.Sprintf("%s/frames/%s/rewards", c.effectiveURL(), frameID), nil)
+	req, err := newRequest("GET", fmt.Sprintf("%s/frames/%s/rewards", c.effectiveURL(), frameID))
 	if err != nil {
 		return nil, fmt.Errorf("failed to create list rewards request: %w", err)
 	}
@@ -60,7 +60,7 @@ func (c *Client) UpdateReward(frameID, rewardID string, reward RewardData) (*Rew
 
 // DeleteReward deletes a reward.
 func (c *Client) DeleteReward(frameID, rewardID string) error {
-	req, err := newRequest("DELETE", fmt.Sprintf("%s/frames/%s/rewards/%s", c.effectiveURL(), frameID, rewardID), nil)
+	req, err := newRequest("DELETE", fmt.Sprintf("%s/frames/%s/rewards/%s", c.effectiveURL(), frameID, rewardID))
 	if err != nil {
 		return fmt.Errorf("failed to create delete reward request: %w", err)
 	}
@@ -74,7 +74,7 @@ func (c *Client) DeleteReward(frameID, rewardID string) error {
 
 // RedeemReward redeems a reward.
 func (c *Client) RedeemReward(frameID, rewardID string) error {
-	req, err := newRequest("POST", fmt.Sprintf("%s/frames/%s/rewards/%s/redeem", c.effectiveURL(), frameID, rewardID), nil)
+	req, err := newRequest("POST", fmt.Sprintf("%s/frames/%s/rewards/%s/redeem", c.effectiveURL(), frameID, rewardID))
 	if err != nil {
 		return fmt.Errorf("failed to create redeem reward request: %w", err)
 	}
@@ -88,7 +88,7 @@ func (c *Client) RedeemReward(frameID, rewardID string) error {
 
 // UnredeemReward unredeems a reward.
 func (c *Client) UnredeemReward(frameID, rewardID string) error {
-	req, err := newRequest("POST", fmt.Sprintf("%s/frames/%s/rewards/%s/unredeem", c.effectiveURL(), frameID, rewardID), nil)
+	req, err := newRequest("POST", fmt.Sprintf("%s/frames/%s/rewards/%s/unredeem", c.effectiveURL(), frameID, rewardID))
 	if err != nil {
 		return fmt.Errorf("failed to create unredeem reward request: %w", err)
 	}
@@ -102,7 +102,7 @@ func (c *Client) UnredeemReward(frameID, rewardID string) error {
 
 // GetRewardPoints retrieves reward points for a frame.
 func (c *Client) GetRewardPoints(frameID string) ([]RewardPointEntry, error) {
-	req, err := newRequest("GET", fmt.Sprintf("%s/frames/%s/reward_points", c.effectiveURL(), frameID), nil)
+	req, err := newRequest("GET", fmt.Sprintf("%s/frames/%s/reward_points", c.effectiveURL(), frameID))
 	if err != nil {
 		return nil, fmt.Errorf("failed to create get reward points request: %w", err)
 	}


### PR DESCRIPTION
## Summary
- Handle `io.ReadAll` errors in all 5 HTTP methods (`get`, `post`, `put`, `patch`, `doDelete`) instead of discarding with `_`
- Log poller `saveState()` errors (`json.Marshal`, `os.MkdirAll`, `os.WriteFile`) via `slog.Warn` instead of silently returning
- Handle `crypto/rand.Read` error in `backoffDelay` with graceful fallback to non-jittered delay
- Remove unused `body io.Reader` parameter from `newRequest()` and update all 25 call sites

## Test plan
- [x] `go build ./...` compiles cleanly
- [x] `go test ./... -count=1` all pass
- [x] `golangci-lint run ./...` zero issues
- [x] No public API changes — all fixes are internal