### PR TITLE
test: improve coverage from 86.4% to 92.0%

### DIFF
--- a/cmd/alpaca-trigger/alpaca_test.go
+++ b/cmd/alpaca-trigger/alpaca_test.go
@@ -98,6 +98,93 @@ func TestBuyVOOServerError(t *testing.T) {
 	}
 }
 
+func TestBuyVOOConnectionRefused(t *testing.T) {
+	client := NewAlpacaClient("http://localhost:1", "key", "secret")
+	_, err := client.BuyVOO(context.Background(), "1.00")
+	if err == nil {
+		t.Fatal("expected error for unreachable server")
+	}
+}
+
+func TestBuyVOOInvalidJSON(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		if _, err := w.Write([]byte(`not json`)); err != nil {
+			t.Errorf("write: %v", err)
+		}
+	}))
+	defer srv.Close()
+
+	client := NewAlpacaClient(srv.URL, "key", "secret")
+	_, err := client.BuyVOO(context.Background(), "1.00")
+	if err == nil {
+		t.Fatal("expected error for invalid JSON response")
+	}
+}
+
+func TestConfigFromEnvMissingAPISecret(t *testing.T) {
+	t.Setenv("ALPACA_API_KEY", "key")
+	t.Setenv("ALPACA_API_SECRET", "")
+	t.Setenv("SKYLIGHT_USER_ID", "uid")
+	t.Setenv("SKYLIGHT_TOKEN", "tok")
+	t.Setenv("SKYLIGHT_FRAME_ID", "fid")
+
+	_, err := configFromEnv()
+	if err == nil {
+		t.Error("expected error for missing ALPACA_API_SECRET")
+	}
+}
+
+func TestConfigFromEnvMissingSkylight(t *testing.T) {
+	tests := []struct {
+		name    string
+		setEnvs map[string]string
+	}{
+		{
+			name: "missing SKYLIGHT_USER_ID",
+			setEnvs: map[string]string{
+				"ALPACA_API_KEY":    "key",
+				"ALPACA_API_SECRET": "secret",
+				"SKYLIGHT_USER_ID":  "",
+				"SKYLIGHT_TOKEN":    "tok",
+				"SKYLIGHT_FRAME_ID": "fid",
+			},
+		},
+		{
+			name: "missing SKYLIGHT_TOKEN",
+			setEnvs: map[string]string{
+				"ALPACA_API_KEY":    "key",
+				"ALPACA_API_SECRET": "secret",
+				"SKYLIGHT_USER_ID":  "uid",
+				"SKYLIGHT_TOKEN":    "",
+				"SKYLIGHT_FRAME_ID": "fid",
+			},
+		},
+		{
+			name: "missing SKYLIGHT_FRAME_ID",
+			setEnvs: map[string]string{
+				"ALPACA_API_KEY":    "key",
+				"ALPACA_API_SECRET": "secret",
+				"SKYLIGHT_USER_ID":  "uid",
+				"SKYLIGHT_TOKEN":    "tok",
+				"SKYLIGHT_FRAME_ID": "",
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			for k, v := range tc.setEnvs {
+				t.Setenv(k, v)
+			}
+			_, err := configFromEnv()
+			if err == nil {
+				t.Error("expected error")
+			}
+		})
+	}
+}
+
 func TestConfigFromEnv(t *testing.T) {
 	t.Run("missing required vars", func(t *testing.T) {
 		t.Setenv("ALPACA_API_KEY", "")

--- a/cmd/config_test.go
+++ b/cmd/config_test.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 )
 
@@ -124,6 +125,71 @@ func TestLoadConfigMissingFile(t *testing.T) {
 
 	if email != "" {
 		t.Errorf("email should be empty when config file is missing")
+	}
+
+	configPath = ""
+}
+
+func TestSaveConfigMkdirAllError(t *testing.T) {
+	// Create a file where a directory should be
+	dir := t.TempDir()
+	blocker := filepath.Join(dir, "blocker")
+	if err := os.WriteFile(blocker, []byte("x"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	configPath = filepath.Join(blocker, "subdir", "config")
+	err := saveConfig(map[string]string{"KEY": "VALUE"})
+	if err == nil {
+		t.Error("expected error when MkdirAll fails")
+	}
+	configPath = ""
+}
+
+func TestSaveConfigWriteError(t *testing.T) {
+	dir := t.TempDir()
+	readonlyDir := filepath.Join(dir, "readonly")
+	if err := os.MkdirAll(readonlyDir, 0o500); err != nil {
+		t.Fatal(err)
+	}
+	configPath = filepath.Join(readonlyDir, "config")
+	err := saveConfig(map[string]string{"KEY": "VALUE"})
+	if err == nil {
+		t.Error("expected error when file cannot be written")
+	}
+	configPath = ""
+}
+
+func TestSaveConfigMergesExistingKeys(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config")
+	// Write initial config
+	if err := os.WriteFile(path, []byte("EXISTING_KEY=old_value\nSKYLIGHT_EMAIL=test@test.com\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	configPath = path
+
+	err := saveConfig(map[string]string{"SKYLIGHT_TOKEN": "newtok"})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	content := string(data)
+
+	// EXISTING_KEY should be preserved
+	if !strings.Contains(content, "EXISTING_KEY=old_value") {
+		t.Error("existing key should be preserved")
+	}
+	// New key should be added
+	if !strings.Contains(content, "SKYLIGHT_TOKEN=newtok") {
+		t.Error("new key should be added")
+	}
+	// Original key should be preserved
+	if !strings.Contains(content, "SKYLIGHT_EMAIL=test@test.com") {
+		t.Error("original SKYLIGHT_EMAIL should be preserved")
 	}
 
 	configPath = ""

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -6,6 +6,22 @@ import (
 	"github.com/spf13/cobra"
 )
 
+func TestSetVersion(t *testing.T) {
+	SetVersion("1.2.3")
+	if rootCmd.Version != "1.2.3" {
+		t.Errorf("rootCmd.Version = %q, want %q", rootCmd.Version, "1.2.3")
+	}
+	// Reset for other tests
+	SetVersion("dev")
+}
+
+func TestExecuteHelp(t *testing.T) {
+	rootCmd.SetArgs([]string{"--help"})
+	if err := Execute(); err != nil {
+		t.Errorf("Execute --help failed: %v", err)
+	}
+}
+
 func TestRootCommandExists(t *testing.T) {
 	if rootCmd == nil {
 		t.Fatal("rootCmd should not be nil")

--- a/lib/bounty_test.go
+++ b/lib/bounty_test.go
@@ -248,6 +248,122 @@ func TestCreateBountyCleanupOnRewardFailure(t *testing.T) {
 	}
 }
 
+func TestCreateBountyChoreFailure(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+		if _, err := w.Write([]byte(`{"error":"fail"}`)); err != nil {
+			t.Errorf("write: %v", err)
+		}
+	}))
+	defer srv.Close()
+
+	old := SkylightURL
+	SkylightURL = srv.URL + "/api"
+	defer func() { SkylightURL = old }()
+
+	client, _ := NewClientWithToken("u", "t")
+	_, err := client.CreateBounty("frame1", BountyData{Title: "Test", Points: 5, RewardTitle: "Prize"})
+	if err == nil {
+		t.Fatal("expected error when CreateChore fails")
+	}
+}
+
+func TestCreateBountyInvalidAssigneeID(t *testing.T) {
+	var deleteCount atomic.Int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch {
+		case r.Method == http.MethodPost && r.URL.Path == "/api/frames/frame1/chores":
+			w.WriteHeader(http.StatusCreated)
+			if err := json.NewEncoder(w).Encode(choreAPISingleResponse{
+				Data: choreAPIEntry{ID: "ch1"},
+			}); err != nil {
+				http.Error(w, err.Error(), http.StatusInternalServerError)
+			}
+		case r.Method == http.MethodDelete:
+			deleteCount.Add(1)
+			w.WriteHeader(http.StatusNoContent)
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer srv.Close()
+
+	old := SkylightURL
+	SkylightURL = srv.URL + "/api"
+	defer func() { SkylightURL = old }()
+
+	client, _ := NewClientWithToken("u", "t")
+	_, err := client.CreateBounty("frame1", BountyData{
+		Title:       "Test",
+		Points:      5,
+		RewardTitle: "Prize",
+		AssigneeID:  "not-a-number",
+	})
+	if err == nil {
+		t.Fatal("expected error for invalid AssigneeID")
+	}
+	if deleteCount.Load() != 1 {
+		t.Errorf("expected 1 cleanup DELETE, got %d", deleteCount.Load())
+	}
+}
+
+func TestListBountiesChoreError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Path {
+		case "/api/frames/frame1/chores":
+			w.WriteHeader(http.StatusInternalServerError)
+			if _, err := w.Write([]byte(`{"error":"fail"}`)); err != nil {
+				t.Errorf("write: %v", err)
+			}
+		case "/api/frames/frame1/rewards":
+			if err := json.NewEncoder(w).Encode(rewardAPIResponse{}); err != nil {
+				http.Error(w, err.Error(), http.StatusInternalServerError)
+			}
+		}
+	}))
+	defer srv.Close()
+
+	old := SkylightURL
+	SkylightURL = srv.URL + "/api"
+	defer func() { SkylightURL = old }()
+
+	client, _ := NewClientWithToken("u", "t")
+	_, err := client.ListBounties("frame1")
+	if err == nil {
+		t.Fatal("expected error when ListChores fails")
+	}
+}
+
+func TestListBountiesRewardError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Path {
+		case "/api/frames/frame1/chores":
+			if err := json.NewEncoder(w).Encode(choreAPIResponse{}); err != nil {
+				http.Error(w, err.Error(), http.StatusInternalServerError)
+			}
+		case "/api/frames/frame1/rewards":
+			w.WriteHeader(http.StatusInternalServerError)
+			if _, err := w.Write([]byte(`{"error":"fail"}`)); err != nil {
+				t.Errorf("write: %v", err)
+			}
+		}
+	}))
+	defer srv.Close()
+
+	old := SkylightURL
+	SkylightURL = srv.URL + "/api"
+	defer func() { SkylightURL = old }()
+
+	client, _ := NewClientWithToken("u", "t")
+	_, err := client.ListBounties("frame1")
+	if err == nil {
+		t.Fatal("expected error when ListRewards fails")
+	}
+}
+
 func TestListBounties(t *testing.T) {
 	tests := []struct {
 		name       string

--- a/lib/client_test.go
+++ b/lib/client_test.go
@@ -2,6 +2,8 @@ package lib
 
 import (
 	"encoding/json"
+	"io"
+	"log/slog"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -456,6 +458,56 @@ func TestBadURLNewRequestErrors(t *testing.T) {
 				t.Errorf("expected error with bad URL, got nil")
 			}
 		})
+	}
+}
+
+func TestEffectiveURLFallback(t *testing.T) {
+	client, _ := NewClientWithToken("u", "t")
+	// Client created without WithBaseURL — baseURL is set to default
+	// Clear it to test the fallback branch
+	client.baseURL = ""
+	got := client.effectiveURL()
+	if got != SkylightURL {
+		t.Errorf("effectiveURL = %q, want %q", got, SkylightURL)
+	}
+}
+
+func TestDoWithLogger(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if err := json.NewEncoder(w).Encode(categoryAPIResponse{}); err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+		}
+	}))
+	defer srv.Close()
+
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	client, _ := NewClientWithToken("u", "t", WithBaseURL(srv.URL+"/api"), WithLogger(logger))
+
+	// Make a request that exercises both logger.Debug branches in do()
+	_, err := client.ListCategories("frame1")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestDoDeleteErrorResponse(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusForbidden)
+		if _, err := w.Write([]byte(`{"error":"forbidden"}`)); err != nil {
+			t.Errorf("write: %v", err)
+		}
+	}))
+	defer srv.Close()
+
+	old := SkylightURL
+	SkylightURL = srv.URL + "/api"
+	defer func() { SkylightURL = old }()
+
+	client, _ := NewClientWithToken("u", "t")
+	err := client.DeleteChore("frame1", "ch1")
+	if err == nil {
+		t.Error("expected error for 403 response, got nil")
 	}
 }
 

--- a/lib/options_test.go
+++ b/lib/options_test.go
@@ -2,6 +2,8 @@ package lib
 
 import (
 	"encoding/json"
+	"io"
+	"log/slog"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -69,8 +71,6 @@ func TestWithRetry(t *testing.T) {
 }
 
 func TestWithLogger(t *testing.T) {
-	// Verify WithLogger stores the logger and that requests proceed normally
-	// with logging enabled (the logger discards to /dev/null via a nil handler).
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if err := json.NewEncoder(w).Encode(calendarAPIResponse{Data: []calendarAPIEntry{{ID: "1"}}}); err != nil {
 			http.Error(w, err.Error(), http.StatusInternalServerError)
@@ -78,11 +78,16 @@ func TestWithLogger(t *testing.T) {
 	}))
 	defer srv.Close()
 
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
 	client, err := NewClientWithToken("u", "t",
 		WithBaseURL(srv.URL+"/api"),
+		WithLogger(logger),
 	)
 	if err != nil {
 		t.Fatalf("NewClientWithToken: %v", err)
+	}
+	if client.logger != logger {
+		t.Error("logger not set on client")
 	}
 	if _, err = client.ListCalendarEvents("f1", "", ""); err != nil {
 		t.Fatalf("ListCalendarEvents: %v", err)

--- a/lib/poller_test.go
+++ b/lib/poller_test.go
@@ -1,8 +1,11 @@
 package lib
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
+	"fmt"
+	"log/slog"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -188,6 +191,198 @@ func TestRewardsPollerStatePersistence(t *testing.T) {
 		// Good — no duplicate event.
 	}
 	p2.Stop()
+}
+
+func TestNewRewardsPollerDefaultStatePath(t *testing.T) {
+	old := SkylightURL
+	SkylightURL = "http://localhost:1/api"
+	defer func() { SkylightURL = old }()
+
+	client, _ := NewClientWithToken("u", "t")
+	p := NewRewardsPoller(client, "f1", time.Hour, "")
+	if p.stateFile == "" {
+		t.Error("stateFile should default to non-empty path")
+	}
+	if !filepath.IsAbs(p.stateFile) {
+		t.Errorf("stateFile should be absolute, got %q", p.stateFile)
+	}
+}
+
+func TestLoadStateCorruptJSON(t *testing.T) {
+	dir := t.TempDir()
+	stateFile := filepath.Join(dir, "state.json")
+	if err := os.WriteFile(stateFile, []byte(`{corrupt`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	var buf bytes.Buffer
+	logger := slog.New(slog.NewTextHandler(&buf, nil))
+
+	old := SkylightURL
+	SkylightURL = "http://localhost:1/api"
+	defer func() { SkylightURL = old }()
+
+	client, _ := NewClientWithToken("u", "t", WithLogger(logger))
+	p := NewRewardsPoller(client, "f1", time.Hour, stateFile)
+	if len(p.seen) != 0 {
+		t.Errorf("seen should be empty after corrupt state, got %d", len(p.seen))
+	}
+	if !bytes.Contains(buf.Bytes(), []byte("corrupt state file")) {
+		t.Error("expected warning about corrupt state file in logs")
+	}
+}
+
+func TestLoadStateReadErrorNonErrNotExist(t *testing.T) {
+	// Use a directory as the state file path to trigger a non-ErrNotExist read error
+	dir := t.TempDir()
+
+	var buf bytes.Buffer
+	logger := slog.New(slog.NewTextHandler(&buf, nil))
+
+	old := SkylightURL
+	SkylightURL = "http://localhost:1/api"
+	defer func() { SkylightURL = old }()
+
+	client, _ := NewClientWithToken("u", "t", WithLogger(logger))
+	p := NewRewardsPoller(client, "f1", time.Hour, dir)
+	if len(p.seen) != 0 {
+		t.Errorf("seen should be empty, got %d", len(p.seen))
+	}
+	if !bytes.Contains(buf.Bytes(), []byte("could not read state file")) {
+		t.Error("expected warning about read error in logs")
+	}
+}
+
+func TestSaveStateMkdirAllError(t *testing.T) {
+	// Create a file where a directory should be to cause MkdirAll failure
+	dir := t.TempDir()
+	blocker := filepath.Join(dir, "blocker")
+	if err := os.WriteFile(blocker, []byte("x"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	stateFile := filepath.Join(blocker, "subdir", "state.json")
+
+	var buf bytes.Buffer
+	logger := slog.New(slog.NewTextHandler(&buf, nil))
+
+	old := SkylightURL
+	SkylightURL = "http://localhost:1/api"
+	defer func() { SkylightURL = old }()
+
+	client, _ := NewClientWithToken("u", "t", WithLogger(logger))
+	p := NewRewardsPoller(client, "f1", time.Hour, filepath.Join(t.TempDir(), "clean-state.json"))
+	p.stateFile = stateFile
+	p.logger = logger
+	p.seen["test"] = struct{}{}
+	p.saveState()
+	if !bytes.Contains(buf.Bytes(), []byte("failed to create state directory")) {
+		t.Error("expected warning about MkdirAll failure")
+	}
+}
+
+func TestSaveStateWriteError(t *testing.T) {
+	// Create a read-only directory to prevent writing
+	dir := t.TempDir()
+	stateDir := filepath.Join(dir, "readonly")
+	if err := os.MkdirAll(stateDir, 0o500); err != nil {
+		t.Fatal(err)
+	}
+	stateFile := filepath.Join(stateDir, "state.json")
+
+	var buf bytes.Buffer
+	logger := slog.New(slog.NewTextHandler(&buf, nil))
+
+	old := SkylightURL
+	SkylightURL = "http://localhost:1/api"
+	defer func() { SkylightURL = old }()
+
+	client, _ := NewClientWithToken("u", "t", WithLogger(logger))
+	p := NewRewardsPoller(client, "f1", time.Hour, filepath.Join(t.TempDir(), "clean-state.json"))
+	p.stateFile = stateFile
+	p.logger = logger
+	p.seen["test"] = struct{}{}
+	p.saveState()
+	if !bytes.Contains(buf.Bytes(), []byte("failed to write state file")) {
+		t.Error("expected warning about write failure")
+	}
+}
+
+func TestPollerListRewardsError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Path {
+		case "/api/frames/f1/categories":
+			if err := json.NewEncoder(w).Encode(categoryAPIResponse{}); err != nil {
+				t.Errorf("encode: %v", err)
+			}
+		case "/api/frames/f1/rewards":
+			w.WriteHeader(http.StatusInternalServerError)
+			if _, err := w.Write([]byte(`{"error":"fail"}`)); err != nil {
+				t.Errorf("write: %v", err)
+			}
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer srv.Close()
+
+	var buf bytes.Buffer
+	logger := slog.New(slog.NewTextHandler(&buf, nil))
+
+	old := SkylightURL
+	SkylightURL = srv.URL + "/api"
+	defer func() { SkylightURL = old }()
+
+	client, _ := NewClientWithToken("u", "t", WithLogger(logger))
+	p := NewRewardsPoller(client, "f1", time.Hour, filepath.Join(t.TempDir(), "state.json"))
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	p.Start(ctx)
+
+	time.Sleep(200 * time.Millisecond)
+	p.Stop()
+
+	if !bytes.Contains(buf.Bytes(), []byte("ListRewards failed")) {
+		t.Error("expected warning about ListRewards failure")
+	}
+}
+
+func TestPollerEventChannelFull(t *testing.T) {
+	// Create many redeemed rewards to overflow the 64-buffer channel
+	rewards := make([]Reward, 70)
+	for i := range rewards {
+		rewards[i] = Reward{
+			ID:       fmt.Sprintf("rw%d", i),
+			Title:    fmt.Sprintf("Prize %d", i),
+			Points:   1,
+			Redeemed: true,
+		}
+	}
+
+	srv := makePollerServer(t, rewards, nil)
+	defer srv.Close()
+
+	var buf bytes.Buffer
+	logger := slog.New(slog.NewTextHandler(&buf, nil))
+
+	old := SkylightURL
+	SkylightURL = srv.URL + "/api"
+	defer func() { SkylightURL = old }()
+
+	client, _ := NewClientWithToken("u", "t", WithLogger(logger))
+	p := NewRewardsPoller(client, "f1", time.Hour, filepath.Join(t.TempDir(), "state.json"))
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	p.Start(ctx)
+
+	time.Sleep(500 * time.Millisecond)
+	p.Stop()
+
+	if !bytes.Contains(buf.Bytes(), []byte("event channel full")) {
+		t.Error("expected warning about channel full")
+	}
 }
 
 func TestRewardsPollerStop(t *testing.T) {

--- a/lib/retry_test.go
+++ b/lib/retry_test.go
@@ -3,11 +3,15 @@ package lib
 import (
 	"context"
 	"errors"
+	"io"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"sync/atomic"
 	"testing"
 	"time"
+
+	"golang.org/x/time/rate"
 )
 
 func TestBackoffDelay(t *testing.T) {
@@ -109,6 +113,132 @@ func TestDoWithRetryRespects429RetryAfter(t *testing.T) {
 	resp.Body.Close()
 	if calls.Load() != 2 {
 		t.Errorf("want 2 calls (1 retry after 429), got %d", calls.Load())
+	}
+}
+
+func TestBackoffDelayMaxClamping(t *testing.T) {
+	base := 100 * time.Millisecond
+	max := 1 * time.Second
+	// High attempt count should clamp to max
+	d := backoffDelay(base, max, 20)
+	if d > max {
+		t.Errorf("delay %v exceeds max %v", d, max)
+	}
+	if d < max/2 {
+		t.Errorf("delay %v too low, expected at least %v", d, max/2)
+	}
+}
+
+func TestBackoffDelayHalfZero(t *testing.T) {
+	// base=1ns, max=1ns -> exp=1ns, exp/2=0 -> early return exp
+	d := backoffDelay(1*time.Nanosecond, 1*time.Nanosecond, 1)
+	if d != 1*time.Nanosecond {
+		t.Errorf("delay = %v, want 1ns", d)
+	}
+}
+
+func TestDrainAndErrorNon429(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+		if _, err := w.Write([]byte("server error body")); err != nil {
+			t.Errorf("write: %v", err)
+		}
+	}))
+	defer srv.Close()
+
+	req, _ := http.NewRequestWithContext(context.Background(), http.MethodGet, srv.URL, nil)
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	drainErr := drainAndError(context.Background(), resp)
+	if drainErr == nil {
+		t.Fatal("expected error")
+	}
+	if !strings.Contains(drainErr.Error(), "server error body") {
+		t.Errorf("error should contain body, got %q", drainErr.Error())
+	}
+}
+
+func TestDrainAndError429ContextCancelled(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Retry-After", "60")
+		w.WriteHeader(http.StatusTooManyRequests)
+	}))
+	defer srv.Close()
+
+	req, _ := http.NewRequestWithContext(context.Background(), http.MethodGet, srv.URL, nil)
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // Cancel immediately
+	drainErr := drainAndError(ctx, resp)
+	if !errors.Is(drainErr, context.Canceled) {
+		t.Errorf("expected context.Canceled, got %v", drainErr)
+	}
+}
+
+func TestDoWithRetryWithRateLimiter(t *testing.T) {
+	var calls atomic.Int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		calls.Add(1)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	limiter := rate.NewLimiter(rate.Limit(100), 10)
+	req, _ := http.NewRequestWithContext(context.Background(), http.MethodGet, srv.URL, nil)
+	cfg := retryConfig{maxAttempts: 1, baseDelay: 10 * time.Millisecond, maxDelay: 100 * time.Millisecond}
+
+	resp, err := doWithRetry(context.Background(), http.DefaultClient, limiter, cfg, req)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	resp.Body.Close()
+	if calls.Load() != 1 {
+		t.Errorf("want 1 call, got %d", calls.Load())
+	}
+}
+
+func TestBufferBodyReadError(t *testing.T) {
+	req, _ := http.NewRequest(http.MethodPost, "http://example.com", io.NopCloser(&errorReader{}))
+	_, err := bufferBody(req)
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	var ne *NetworkError
+	if !errors.As(err, &ne) {
+		t.Errorf("expected NetworkError, got %T", err)
+	}
+}
+
+type errorReader struct{}
+
+func (e *errorReader) Read([]byte) (int, error) {
+	return 0, errors.New("read error")
+}
+
+func TestDoWithRetryMaxAttemptsZero(t *testing.T) {
+	var calls atomic.Int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		calls.Add(1)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	req, _ := http.NewRequestWithContext(context.Background(), http.MethodGet, srv.URL, nil)
+	cfg := retryConfig{maxAttempts: 0, baseDelay: 10 * time.Millisecond, maxDelay: 100 * time.Millisecond}
+
+	resp, err := doWithRetry(context.Background(), http.DefaultClient, nil, cfg, req)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	resp.Body.Close()
+	if calls.Load() != 1 {
+		t.Errorf("maxAttempts=0 should default to 1, got %d calls", calls.Load())
 	}
 }
 

--- a/lib/structs_test.go
+++ b/lib/structs_test.go
@@ -1,0 +1,242 @@
+package lib
+
+import "testing"
+
+func TestToCalendarEventNilCategory(t *testing.T) {
+	entry := calendarAPIEntry{
+		ID: "e1",
+		Attributes: struct {
+			Summary     string `json:"summary"`
+			Description string `json:"description"`
+			StartsAt    string `json:"starts_at"`
+			EndsAt      string `json:"ends_at"`
+			AllDay      bool   `json:"all_day"`
+			Color       string `json:"color"`
+		}{Summary: "Test"},
+	}
+	ev := entry.toCalendarEvent()
+	if ev.CategoryID != "" {
+		t.Errorf("CategoryID should be empty, got %q", ev.CategoryID)
+	}
+	if ev.Title != "Test" {
+		t.Errorf("Title = %q, want %q", ev.Title, "Test")
+	}
+}
+
+func TestToCalendarEventWithCategory(t *testing.T) {
+	entry := calendarAPIEntry{ID: "e1"}
+	entry.Attributes.Summary = "Event"
+	entry.Relationships.Category.Data = &apiRelationshipData{ID: "cat1"}
+	ev := entry.toCalendarEvent()
+	if ev.CategoryID != "cat1" {
+		t.Errorf("CategoryID = %q, want %q", ev.CategoryID, "cat1")
+	}
+}
+
+func TestToRewardNilCategory(t *testing.T) {
+	entry := rewardAPIEntry{ID: "r1"}
+	entry.Attributes.Name = "Prize"
+	entry.Attributes.PointValue = 5
+	r := entry.toReward()
+	if r.CategoryID != "" {
+		t.Errorf("CategoryID should be empty, got %q", r.CategoryID)
+	}
+	if r.Redeemed {
+		t.Error("Redeemed should be false when RedeemedAt is nil")
+	}
+}
+
+func TestToRewardWithCategory(t *testing.T) {
+	entry := rewardAPIEntry{ID: "r1"}
+	entry.Relationships.Category.Data = &apiRelationshipData{ID: "cat2"}
+	redeemed := "2024-01-01T00:00:00Z"
+	entry.Attributes.RedeemedAt = &redeemed
+	r := entry.toReward()
+	if r.CategoryID != "cat2" {
+		t.Errorf("CategoryID = %q, want %q", r.CategoryID, "cat2")
+	}
+	if !r.Redeemed {
+		t.Error("Redeemed should be true when RedeemedAt is set")
+	}
+}
+
+func TestToRecipeNilMealCategory(t *testing.T) {
+	entry := recipeAPIEntry{ID: "rec1"}
+	entry.Attributes.Summary = "Pasta"
+	entry.Attributes.URL = "http://example.com"
+	r := entry.toRecipe()
+	if r.MealCategoryID != "" {
+		t.Errorf("MealCategoryID should be empty, got %q", r.MealCategoryID)
+	}
+	if r.Title != "Pasta" {
+		t.Errorf("Title = %q, want %q", r.Title, "Pasta")
+	}
+}
+
+func TestToRecipeWithMealCategory(t *testing.T) {
+	entry := recipeAPIEntry{ID: "rec1"}
+	entry.Relationships.MealCategory.Data = &apiRelationshipData{ID: "mc1"}
+	r := entry.toRecipe()
+	if r.MealCategoryID != "mc1" {
+		t.Errorf("MealCategoryID = %q, want %q", r.MealCategoryID, "mc1")
+	}
+}
+
+func TestToCategoryNilProfilePic(t *testing.T) {
+	entry := categoryAPIEntry{ID: "cat1"}
+	entry.Attributes.Label = "Alice"
+	entry.Attributes.Color = "blue"
+	c := entry.toCategory()
+	if c.AvatarURL != "" {
+		t.Errorf("AvatarURL should be empty, got %q", c.AvatarURL)
+	}
+}
+
+func TestToCategoryWithProfilePic(t *testing.T) {
+	entry := categoryAPIEntry{ID: "cat1"}
+	url := "http://example.com/pic.jpg"
+	entry.Attributes.ProfilePicURL = &url
+	c := entry.toCategory()
+	if c.AvatarURL != url {
+		t.Errorf("AvatarURL = %q, want %q", c.AvatarURL, url)
+	}
+}
+
+func TestToMealSittingNilRelationships(t *testing.T) {
+	entry := mealSittingAPIEntry{ID: "ms1"}
+	entry.Attributes.Summary = "Dinner"
+	s := entry.toMealSitting()
+	if s.MealCategoryID != "" {
+		t.Errorf("MealCategoryID should be empty, got %q", s.MealCategoryID)
+	}
+	if s.RecipeID != "" {
+		t.Errorf("RecipeID should be empty, got %q", s.RecipeID)
+	}
+}
+
+func TestToMealSittingWithRelationships(t *testing.T) {
+	entry := mealSittingAPIEntry{ID: "ms1"}
+	entry.Relationships.MealCategory.Data = &apiRelationshipData{ID: "mc1"}
+	entry.Relationships.MealRecipe.Data = &apiRelationshipData{ID: "rec1"}
+	s := entry.toMealSitting()
+	if s.MealCategoryID != "mc1" {
+		t.Errorf("MealCategoryID = %q, want %q", s.MealCategoryID, "mc1")
+	}
+	if s.RecipeID != "rec1" {
+		t.Errorf("RecipeID = %q, want %q", s.RecipeID, "rec1")
+	}
+}
+
+func TestToChoreNilCategory(t *testing.T) {
+	entry := choreAPIEntry{ID: "ch1"}
+	entry.Attributes.Summary = "Clean"
+	c := entry.toChore()
+	if c.AssigneeID != "" {
+		t.Errorf("AssigneeID should be empty, got %q", c.AssigneeID)
+	}
+}
+
+func TestToChoreWithCategory(t *testing.T) {
+	entry := choreAPIEntry{ID: "ch1"}
+	entry.Relationships.Category.Data = &apiRelationshipData{ID: "cat1"}
+	c := entry.toChore()
+	if c.AssigneeID != "cat1" {
+		t.Errorf("AssigneeID = %q, want %q", c.AssigneeID, "cat1")
+	}
+}
+
+func TestToListItem(t *testing.T) {
+	entry := listItemAPIEntry{ID: "li1"}
+	entry.Attributes.Label = "Milk"
+	entry.Attributes.Status = "completed"
+	entry.Attributes.Position = 3
+	item := entry.toListItem()
+	if !item.Completed {
+		t.Error("Completed should be true for status=completed")
+	}
+	if item.Position != 3 {
+		t.Errorf("Position = %d, want 3", item.Position)
+	}
+}
+
+func TestToListItemNotCompleted(t *testing.T) {
+	entry := listItemAPIEntry{ID: "li1"}
+	entry.Attributes.Status = "active"
+	item := entry.toListItem()
+	if item.Completed {
+		t.Error("Completed should be false for status=active")
+	}
+}
+
+func TestToSourceCalendar(t *testing.T) {
+	entry := sourceCalendarAPIEntry{ID: "sc1"}
+	entry.Attributes.Label = "Work"
+	entry.Attributes.Kind = "google"
+	sc := entry.toSourceCalendar()
+	if sc.Name != "Work" {
+		t.Errorf("Name = %q, want %q", sc.Name, "Work")
+	}
+	if sc.Provider != "google" {
+		t.Errorf("Provider = %q, want %q", sc.Provider, "google")
+	}
+}
+
+func TestToList(t *testing.T) {
+	entry := listAPIEntry{ID: "l1"}
+	entry.Attributes.Label = "Groceries"
+	entry.Attributes.Color = "green"
+	entry.Attributes.Kind = "shopping"
+	l := entry.toList()
+	if l.Title != "Groceries" {
+		t.Errorf("Title = %q, want %q", l.Title, "Groceries")
+	}
+	if l.Kind != "shopping" {
+		t.Errorf("Kind = %q, want %q", l.Kind, "shopping")
+	}
+}
+
+func TestToMealCategory(t *testing.T) {
+	entry := mealCategoryAPIEntry{ID: "mc1"}
+	entry.Attributes.Label = "Breakfast"
+	entry.Attributes.Color = "yellow"
+	mc := entry.toMealCategory()
+	if mc.Name != "Breakfast" {
+		t.Errorf("Name = %q, want %q", mc.Name, "Breakfast")
+	}
+}
+
+func TestToFrame(t *testing.T) {
+	entry := frameAPIEntry{ID: "f1"}
+	entry.Attributes.Name = "Living Room"
+	entry.Attributes.TimeZone = "America/Chicago"
+	f := entry.toFrame()
+	if f.Name != "Living Room" {
+		t.Errorf("Name = %q, want %q", f.Name, "Living Room")
+	}
+	if f.TimeZone != "America/Chicago" {
+		t.Errorf("TimeZone = %q, want %q", f.TimeZone, "America/Chicago")
+	}
+}
+
+func TestToDevice(t *testing.T) {
+	entry := deviceAPIEntry{ID: "d1"}
+	entry.Attributes.Name = "Frame"
+	entry.Attributes.Activated = true
+	d := entry.toDevice()
+	if !d.Online {
+		t.Error("Online should be true when Activated is true")
+	}
+}
+
+func TestToAvatar(t *testing.T) {
+	entry := avatarAPIEntry{ID: "a1"}
+	entry.Attributes.Name = "Cat"
+	entry.Attributes.ImageURL = "http://example.com/cat.png"
+	a := entry.toAvatar()
+	if a.Name != "Cat" {
+		t.Errorf("Name = %q, want %q", a.Name, "Cat")
+	}
+	if a.ImageURL != "http://example.com/cat.png" {
+		t.Errorf("ImageURL = %q, want %q", a.ImageURL, "http://example.com/cat.png")
+	}
+}


### PR DESCRIPTION
## Summary

- Add 50+ tests covering error paths, nil relationship branches, and edge cases
- lib/ coverage: 91.7% → 96.9%
- cmd/alpaca-trigger/ coverage: 51.4% → 60.0%
- cmd/ coverage: 33.3% → 35.8%
- **Overall: 86.4% → 92.0%**

### Test additions by area

| Area | Tests added |
|------|------------|
| `lib/structs_test.go` | 20 tests for all `to*()` conversion methods (nil/non-nil relationship branches) |
| `lib/poller_test.go` | 7 tests: default state path, corrupt JSON, read/write errors, channel full |
| `lib/retry_test.go` | 7 tests: backoff clamping, drain paths, rate limiter, buffer errors |
| `lib/client_test.go` | 3 tests: effectiveURL fallback, logger debug paths, doDelete error |
| `lib/bounty_test.go` | 4 tests: CreateBounty/ListBounties error paths |
| `cmd/root_test.go` | 2 tests: SetVersion, Execute |
| `cmd/config_test.go` | 3 tests: saveConfig MkdirAll/write errors, key merging |
| `cmd/alpaca-trigger/alpaca_test.go` | 4 tests: connection refused, invalid JSON, missing env vars |

## Test plan

- [x] `go test ./... -count=1` — all pass
- [x] `make lint` — zero issues
- [x] Coverage verified via `go test ./... -coverprofile`