### PR TITLE
feat: add Dockerfile and Docker Hub publish workflow

### DIFF
--- a/.github/workflows/docker-publish.yaml
+++ b/.github/workflows/docker-publish.yaml
@@ -1,0 +1,46 @@
+name: Publish Docker Image
+
+on:
+  release:
+    types: [published]
+
+permissions:
+  contents: read
+
+jobs:
+  docker:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Extract metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: sebrandon1/go-skylight
+          tags: |
+            type=semver,pattern={{version}}
+            type=raw,value=latest
+
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          build-args: VERSION=${{ github.ref_name }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,13 @@
+FROM golang:1.26 AS builder
+
+ARG VERSION=dev
+WORKDIR /src
+COPY go.mod go.sum ./
+RUN go mod download
+COPY . .
+RUN CGO_ENABLED=0 go build -ldflags "-X main.Version=${VERSION}" -o /go-skylight .
+
+FROM alpine:3
+
+COPY --from=builder /go-skylight /usr/local/bin/go-skylight
+ENTRYPOINT ["go-skylight"]

--- a/README.md
+++ b/README.md
@@ -42,6 +42,34 @@ Go CLI and client library for the [Skylight Calendar](https://app.ourskylight.co
 go install github.com/sebrandon1/go-skylight@latest
 ```
 
+### Docker
+
+No Go toolchain required — pull the image and run any command directly:
+
+```bash
+docker run --rm \
+  sebrandon1/go-skylight:latest \
+  get chore create \
+  --user-id YOUR_UID \
+  --token YOUR_TOKEN \
+  --frame-id FRAME_ID \
+  --title "Take out the trash" \
+  --points 5
+```
+
+Pass credentials via environment variables to keep the command tidy:
+
+```bash
+docker run --rm \
+  -e SKYLIGHT_USER_ID=YOUR_UID \
+  -e SKYLIGHT_TOKEN=YOUR_TOKEN \
+  -e SKYLIGHT_FRAME_ID=FRAME_ID \
+  sebrandon1/go-skylight:latest \
+  get chore create --title "Take out the trash" --points 5
+```
+
+Images are published to [Docker Hub](https://hub.docker.com/r/sebrandon1/go-skylight) on every release for `linux/amd64` and `linux/arm64`.
+
 ### Authenticate
 
 ```bash


### PR DESCRIPTION
## Summary

- Adds a multi-stage `Dockerfile` that builds a static binary and packages it in an `alpine:3` image
- Adds `.github/workflows/docker-publish.yaml` that triggers on release publication, builds for `linux/amd64` and `linux/arm64`, and pushes to `sebrandon1/go-skylight` on Docker Hub with both a semver tag and `latest`
- Uses the existing `DOCKERHUB_USERNAME` and `DOCKERHUB_TOKEN` secrets — no new secrets needed

## Usage

```bash
docker run --rm sebrandon1/go-skylight:latest --help
```