### PR TITLE
feat: add Photos API (list, upload, delete) to lib and CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,6 +154,14 @@ go-skylight get meal create-sitting --recipe-id ID --date DATE
 go-skylight get meal add-to-grocery --recipe-id ID
 ```
 
+### Photos
+
+```bash
+go-skylight get photo list [--page-token TOKEN]
+go-skylight get photo upload --file PATH [--caption TEXT]
+go-skylight get photo delete --message-id ID [--message-id ID ...]
+```
+
 ### Bounties & Rotations
 
 ```bash
@@ -231,6 +239,7 @@ if errors.As(err, &authErr) {
 | Recipes | ✓ | ✓ | ✓ | ✓ | sittings, grocery |
 | Categories | ✓ | — | — | — | family members |
 | Frame | — | — | — | — | info, devices, avatars, colors |
+| Photos | ✓ | ✓ | — | ✓ | paginated list, upload (S3), bulk delete |
 | Bounties | ✓ | ✓ | — | — | chore + reward pairs |
 | Rotations | — | ✓ | — | — | rotating assignments |
 | Dashboard | — | — | — | — | today aggregate |

--- a/cmd/photo.go
+++ b/cmd/photo.go
@@ -1,0 +1,120 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+
+	"github.com/sebrandon1/go-skylight/lib"
+	"github.com/spf13/cobra"
+)
+
+var (
+	photoPageToken string
+	photoFile      string
+	photoCaption   string
+	photoMessageID []string
+)
+
+var photoCmd = &cobra.Command{
+	Use:   "photo",
+	Short: "Photo management commands",
+}
+
+var photoListCmd = &cobra.Command{
+	Use:   "list",
+	Short: "List photos on a frame",
+	Run: func(cmd *cobra.Command, args []string) {
+		requireFrameID()
+
+		client := getClient()
+
+		photos, nextToken, err := client.ListPhotos(frameID, lib.PhotoListOptions{
+			PageToken: photoPageToken,
+		})
+		if err != nil {
+			fmt.Printf("Error listing photos: %v\n", err)
+			os.Exit(1)
+		}
+
+		printJSON(photos)
+
+		if nextToken != "" {
+			fmt.Fprintf(os.Stderr, "Next page token: %s\n", nextToken)
+		}
+	},
+}
+
+var photoUploadCmd = &cobra.Command{
+	Use:   "upload",
+	Short: "Upload a photo to a frame",
+	Run: func(cmd *cobra.Command, args []string) {
+		requireFrameID()
+
+		data, err := os.ReadFile(photoFile)
+		if err != nil {
+			fmt.Printf("Error reading file: %v\n", err)
+			os.Exit(1)
+		}
+
+		ext := strings.TrimPrefix(filepath.Ext(photoFile), ".")
+		if ext == "" {
+			ext = "jpg"
+		}
+
+		client := getClient()
+
+		result, err := client.UploadPhoto(frameID, ext, data, photoCaption)
+		if err != nil {
+			fmt.Printf("Error uploading photo: %v\n", err)
+			os.Exit(1)
+		}
+
+		printJSON(result)
+	},
+}
+
+var photoDeleteCmd = &cobra.Command{
+	Use:   "delete",
+	Short: "Delete one or more photos by message ID",
+	Run: func(cmd *cobra.Command, args []string) {
+		requireFrameID()
+
+		ids := make([]int, 0, len(photoMessageID))
+		for _, s := range photoMessageID {
+			id, err := strconv.Atoi(s)
+			if err != nil {
+				fmt.Printf("Invalid message ID %q: %v\n", s, err)
+				os.Exit(1)
+			}
+			ids = append(ids, id)
+		}
+
+		client := getClient()
+
+		err := client.DeletePhotos(frameID, ids)
+		if err != nil {
+			fmt.Printf("Error deleting photos: %v\n", err)
+			os.Exit(1)
+		}
+
+		fmt.Println("Photos deleted successfully")
+	},
+}
+
+func init() {
+	photoCmd.AddCommand(photoListCmd)
+	photoCmd.AddCommand(photoUploadCmd)
+	photoCmd.AddCommand(photoDeleteCmd)
+
+	photoListCmd.Flags().StringVar(&photoPageToken, "page-token", "", "Pagination token (omit to start from beginning)")
+
+	photoUploadCmd.Flags().StringVar(&photoFile, "file", "", "Path to image file to upload")
+	photoUploadCmd.Flags().StringVar(&photoCaption, "caption", "", "Optional caption for the photo")
+	photoUploadCmd.MarkFlagRequired("file") //nolint:errcheck
+
+	photoDeleteCmd.Flags().StringArrayVar(&photoMessageID, "message-id", nil, "Message ID to delete (repeatable)")
+	photoDeleteCmd.MarkFlagRequired("message-id") //nolint:errcheck
+}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -78,6 +78,7 @@ func init() {
 	getCmd.AddCommand(mealCmd)
 	getCmd.AddCommand(categoryCmd)
 	getCmd.AddCommand(frameCmd)
+	getCmd.AddCommand(photoCmd)
 }
 
 func requireFrameID() {

--- a/lib/photo.go
+++ b/lib/photo.go
@@ -1,0 +1,127 @@
+package lib
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"net/http"
+	"path/filepath"
+	"strings"
+)
+
+// ListPhotos retrieves photos (and videos) for a frame with optional pagination.
+// Pass PageToken "__START__" (or empty string) to start from the beginning.
+// Returns the photos, the next page token (empty when no more pages), and any error.
+func (c *Client) ListPhotos(frameID string, opts PhotoListOptions) ([]Photo, string, error) {
+	req, err := newRequest("GET", fmt.Sprintf("%s/frames/%s/messages", c.effectiveURL(), frameID))
+	if err != nil {
+		return nil, "", fmt.Errorf("failed to create list photos request: %w", err)
+	}
+
+	pageToken := opts.PageToken
+	if pageToken == "" {
+		pageToken = "__START__"
+	}
+	addQueryParams(req, map[string]string{"page_token": pageToken})
+
+	var apiResp photoAPIResponse
+	if err := c.get(req, &apiResp); err != nil {
+		return nil, "", fmt.Errorf("failed to list photos: %w", err)
+	}
+
+	photos := make([]Photo, len(apiResp.Data))
+	for i := range apiResp.Data {
+		photos[i] = apiResp.Data[i].toPhoto()
+	}
+
+	var nextToken string
+	if apiResp.Meta != nil {
+		nextToken = apiResp.Meta.NextPageToken
+	}
+
+	return photos, nextToken, nil
+}
+
+// UploadPhoto uploads an image to a Skylight frame using a two-step S3 presign flow.
+// ext is the file extension without the dot (e.g. "jpg", "png").
+// imageData is the raw image bytes. caption is optional.
+func (c *Client) UploadPhoto(frameID string, ext string, imageData []byte, caption string) (*PhotoUploadResponse, error) {
+	// Step 1: request a presigned S3 upload URL
+	uploadReq := photoUploadURLRequest{
+		Ext:      strings.TrimPrefix(strings.ToLower(ext), "."),
+		FrameIDs: []string{frameID},
+		Caption:  caption,
+	}
+	req, err := newRequestWithBody("POST", fmt.Sprintf("%s/upload_url", c.effectiveURL()), uploadReq)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create upload URL request: %w", err)
+	}
+
+	var urlResp photoUploadURLResponse
+	if err := c.post(req, &urlResp); err != nil {
+		return nil, fmt.Errorf("failed to get upload URL: %w", err)
+	}
+
+	presignedURL := urlResp.Data.UploadURL
+	if presignedURL == "" {
+		return nil, fmt.Errorf("empty upload URL in response")
+	}
+
+	// Step 2: PUT the raw bytes directly to the presigned S3 URL
+	putReq, err := http.NewRequest("PUT", presignedURL, bytes.NewReader(imageData))
+	if err != nil {
+		return nil, fmt.Errorf("failed to create S3 PUT request: %w", err)
+	}
+	contentType := extToContentType(ext)
+	putReq.Header.Set("Content-Type", contentType)
+
+	resp, err := c.HTTPClient.Do(putReq)
+	if err != nil {
+		return nil, fmt.Errorf("failed to upload photo to S3: %w", err)
+	}
+	defer resp.Body.Close()
+	io.Copy(io.Discard, resp.Body) //nolint:errcheck
+
+	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusNoContent {
+		return nil, fmt.Errorf("S3 upload failed with status %d", resp.StatusCode)
+	}
+
+	result := urlResp.Data
+	return &result, nil
+}
+
+// DeletePhotos deletes one or more photos by their message IDs.
+func (c *Client) DeletePhotos(frameID string, messageIDs []int) error {
+	req, err := newRequestWithBody(
+		"DELETE",
+		fmt.Sprintf("%s/frames/%s/messages/destroy_multiple", c.effectiveURL(), frameID),
+		photoDeleteRequest{MessageIDs: messageIDs},
+	)
+	if err != nil {
+		return fmt.Errorf("failed to create delete photos request: %w", err)
+	}
+
+	if err := c.doDelete(req); err != nil {
+		return fmt.Errorf("failed to delete photos: %w", err)
+	}
+
+	return nil
+}
+
+// extToContentType maps a file extension to a MIME content type.
+func extToContentType(ext string) string {
+	switch strings.ToLower(strings.TrimPrefix(filepath.Ext("."+ext), ".")) {
+	case "png":
+		return "image/png"
+	case "gif":
+		return "image/gif"
+	case "webp":
+		return "image/webp"
+	case "mp4":
+		return "video/mp4"
+	case "mov":
+		return "video/quicktime"
+	default:
+		return "image/jpeg"
+	}
+}

--- a/lib/photo.go
+++ b/lib/photo.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"io"
 	"net/http"
-	"path/filepath"
 	"strings"
 )
 
@@ -48,7 +47,7 @@ func (c *Client) ListPhotos(frameID string, opts PhotoListOptions) ([]Photo, str
 func (c *Client) UploadPhoto(frameID string, ext string, imageData []byte, caption string) (*PhotoUploadResponse, error) {
 	// Step 1: request a presigned S3 upload URL
 	uploadReq := photoUploadURLRequest{
-		Ext:      strings.TrimPrefix(strings.ToLower(ext), "."),
+		Ext:      strings.ToLower(ext),
 		FrameIDs: []string{frameID},
 		Caption:  caption,
 	}
@@ -110,7 +109,7 @@ func (c *Client) DeletePhotos(frameID string, messageIDs []int) error {
 
 // extToContentType maps a file extension to a MIME content type.
 func extToContentType(ext string) string {
-	switch strings.ToLower(strings.TrimPrefix(filepath.Ext("."+ext), ".")) {
+	switch strings.ToLower(ext) {
 	case "png":
 		return "image/png"
 	case "gif":

--- a/lib/structs.go
+++ b/lib/structs.go
@@ -729,3 +729,87 @@ type RotationData struct {
 type RotationResult struct {
 	Chores []Chore `json:"chores"`
 }
+
+// Photo represents a photo (or video) message on a Skylight frame.
+type Photo struct {
+	ID           string `json:"id"`
+	Status       string `json:"status"`
+	AssetType    string `json:"asset_type"`
+	CreatedAt    string `json:"created_at"`
+	UpdatedAt    string `json:"updated_at"`
+	ThumbnailURL string `json:"thumbnail_url"`
+	AssetURL     string `json:"asset_url"`
+	SenderID     int    `json:"sender_id"`
+}
+
+// PhotoListOptions holds optional filters for listing photos.
+type PhotoListOptions struct {
+	// PageToken controls pagination. Use "__START__" for the first page.
+	PageToken string
+}
+
+// PhotoUploadResponse holds the result of a successful upload URL request.
+type PhotoUploadResponse struct {
+	// UploadURL is the presigned S3 PUT URL to upload the image bytes to.
+	UploadURL  string   `json:"url"`
+	Key        string   `json:"key"`
+	GetURL     string   `json:"get_url"`
+	MessageIDs []int    `json:"message_ids"`
+	FrameNames []string `json:"frame_names"`
+}
+
+// photoAPIResponse is the JSON-API envelope for messages list responses.
+type photoAPIResponse struct {
+	Data []photoAPIEntry `json:"data"`
+	Meta *photoMeta      `json:"meta"`
+}
+
+// photoMeta holds pagination tokens returned by the messages endpoint.
+type photoMeta struct {
+	NextPageToken string `json:"next_page_token"`
+	SyncToken     string `json:"sync_token"`
+}
+
+// photoAPIEntry is a single message_status item in JSON-API format.
+type photoAPIEntry struct {
+	ID         string `json:"id"`
+	Attributes struct {
+		Status       string `json:"status"`
+		AssetType    string `json:"asset_type"`
+		CreatedAt    string `json:"created_at"`
+		UpdatedAt    string `json:"updated_at"`
+		ThumbnailURL string `json:"thumbnail_url"`
+		AssetURL     string `json:"asset_url"`
+		SenderID     int    `json:"sender_id"`
+	} `json:"attributes"`
+}
+
+func (e photoAPIEntry) toPhoto() Photo {
+	return Photo{
+		ID:           e.ID,
+		Status:       e.Attributes.Status,
+		AssetType:    e.Attributes.AssetType,
+		CreatedAt:    e.Attributes.CreatedAt,
+		UpdatedAt:    e.Attributes.UpdatedAt,
+		ThumbnailURL: e.Attributes.ThumbnailURL,
+		AssetURL:     e.Attributes.AssetURL,
+		SenderID:     e.Attributes.SenderID,
+	}
+}
+
+// photoUploadURLRequest is the request body for POST /api/upload_url.
+type photoUploadURLRequest struct {
+	Ext      string   `json:"ext"`
+	FrameIDs []string `json:"frame_ids"`
+	Caption  string   `json:"caption,omitempty"`
+}
+
+// photoUploadURLResponse is the API response for POST /api/upload_url.
+type photoUploadURLResponse struct {
+	Data PhotoUploadResponse `json:"data"`
+}
+
+// photoDeleteRequest is the body for DELETE /messages/destroy_multiple.
+type photoDeleteRequest struct {
+	MessageIDs []int `json:"message_ids"`
+}


### PR DESCRIPTION
## Summary

Adds Photos ("Send Some Love") API support to go-skylight — the only major Skylight feature not yet covered.

- `lib/photo.go` — `ListPhotos`, `UploadPhoto`, `DeletePhotos`
- `lib/structs.go` — `Photo`, `PhotoListOptions`, `PhotoUploadResponse` + internal JSON-API types
- `cmd/photo.go` — `get photo list`, `get photo upload`, `get photo delete`
- README — Photos section in CLI reference + API coverage table

### Upload flow
Photos use a two-step S3 presign flow:
1. `POST /api/upload_url` — returns a presigned S3 PUT URL + message ID
2. `PUT <presigned_url>` — upload raw bytes directly to S3

### Usage
```bash
# List photos on a frame
go-skylight get photo list --user-id UID --token TOK --frame-id FID

# Upload a photo
go-skylight get photo upload --user-id UID --token TOK --frame-id FID \
  --file ./photo.jpg --caption "From the CLI"

# Delete photos by message ID
go-skylight get photo delete --user-id UID --token TOK --frame-id FID \
  --message-id 1234567 --message-id 1234568
```