### PR TITLE
feat: replace Basic auth with OAuth2 Bearer token flow

### DIFF
--- a/cmd/config.go
+++ b/cmd/config.go
@@ -34,11 +34,13 @@ func loadConfig() {
 	defer f.Close()
 
 	vars := map[string]*string{
-		"SKYLIGHT_EMAIL":    &email,
-		"SKYLIGHT_PASSWORD": &password,
-		"SKYLIGHT_TOKEN":    &token,
-		"SKYLIGHT_USER_ID":  &userID,
-		"SKYLIGHT_FRAME_ID": &frameID,
+		"SKYLIGHT_EMAIL":              &email,
+		"SKYLIGHT_PASSWORD":           &password,
+		"SKYLIGHT_TOKEN":              &token,
+		"SKYLIGHT_USER_ID":            &userID,
+		"SKYLIGHT_FRAME_ID":           &frameID,
+		"SKYLIGHT_REFRESH_TOKEN":      &refreshToken,
+		"SKYLIGHT_DEVICE_FINGERPRINT": &deviceFingerprint,
 	}
 
 	scanner := bufio.NewScanner(f)

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -9,12 +9,14 @@ import (
 )
 
 var (
-	email      string
-	password   string
-	token      string
-	userID     string
-	frameID    string
-	autoClient *lib.Client
+	email             string
+	password          string
+	token             string
+	userID            string
+	frameID           string
+	refreshToken      string
+	deviceFingerprint string
+	autoClient        *lib.Client
 )
 
 var version = "dev"
@@ -45,8 +47,32 @@ func init() {
 		if cmd.Name() == loginCmd.Name() || cmd.Name() == "help" {
 			return nil
 		}
-		// Auto-login if email/password set but no token/userID
+
+		// Prefer OAuth2 refresh token flow (new API).
+		if refreshToken != "" {
+			fingerprint := deviceFingerprint
+			if fingerprint == "" {
+				fingerprint = defaultFingerprint()
+			}
+			c, err := lib.NewClientWithRefreshToken(refreshToken, fingerprint)
+			if err != nil {
+				return fmt.Errorf("auto-login failed: %w", err)
+			}
+			autoClient = c
+			// Persist the rotated refresh token back to config.
+			if c.RefreshToken != "" && c.RefreshToken != refreshToken {
+				_ = saveConfig(map[string]string{
+					"SKYLIGHT_REFRESH_TOKEN":      c.RefreshToken,
+					"SKYLIGHT_DEVICE_FINGERPRINT": fingerprint,
+				})
+				refreshToken = c.RefreshToken
+			}
+			return nil
+		}
+
+		// Legacy: email/password via deprecated /api/sessions endpoint.
 		if email != "" && password != "" && (token == "" || userID == "") {
+			//nolint:staticcheck // intentional fallback for legacy callers.
 			c, err := lib.NewClient(email, password)
 			if err != nil {
 				return fmt.Errorf("auto-login failed: %w", err)
@@ -59,11 +85,13 @@ func init() {
 	}
 
 	rootCmd.PersistentFlags().StringVar(&configPath, "config", "", "Config file path (default ~/.skylight/config)")
-	rootCmd.PersistentFlags().StringVar(&email, "email", "", "Skylight account email")
-	rootCmd.PersistentFlags().StringVar(&password, "password", "", "Skylight account password")
-	rootCmd.PersistentFlags().StringVar(&token, "token", "", "API token (alternative to email/password)")
-	rootCmd.PersistentFlags().StringVar(&userID, "user-id", "", "User ID (required with --token)")
+	rootCmd.PersistentFlags().StringVar(&email, "email", "", "Skylight account email (deprecated: use --refresh-token)")
+	rootCmd.PersistentFlags().StringVar(&password, "password", "", "Skylight account password (deprecated: use --refresh-token)")
+	rootCmd.PersistentFlags().StringVar(&token, "token", "", "Bearer access token (alternative to --refresh-token)")
+	rootCmd.PersistentFlags().StringVar(&userID, "user-id", "", "User ID (used with --token)")
 	rootCmd.PersistentFlags().StringVar(&frameID, "frame-id", "", "Frame ID")
+	rootCmd.PersistentFlags().StringVar(&refreshToken, "refresh-token", "", "OAuth2 refresh token")
+	rootCmd.PersistentFlags().StringVar(&deviceFingerprint, "device-fingerprint", "", "Device fingerprint UUID (stable per device)")
 
 	rootCmd.AddCommand(getCmd)
 	rootCmd.AddCommand(loginCmd)
@@ -98,6 +126,28 @@ func getClient() *lib.Client {
 		os.Exit(1)
 	}
 	return client
+}
+
+// defaultFingerprint returns a stable UUID derived from the hostname,
+// or a fixed fallback if the hostname cannot be determined.
+func defaultFingerprint() string {
+	host, err := os.Hostname()
+	if err != nil || host == "" {
+		return "00000000-0000-0000-0000-000000000001"
+	}
+	// Derive a deterministic UUID from the hostname bytes (version 4 format,
+	// not cryptographically random, but stable across invocations).
+	h := fnv32(host)
+	return fmt.Sprintf("%08x-0000-4000-8000-%012x", h, h)
+}
+
+func fnv32(s string) uint64 {
+	var h uint64 = 14695981039346656037
+	for i := 0; i < len(s); i++ {
+		h ^= uint64(s[i])
+		h *= 1099511628211
+	}
+	return h
 }
 
 // Execute executes the root command.

--- a/cmd/session.go
+++ b/cmd/session.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"crypto/rand"
 	"fmt"
 	"os"
 
@@ -12,29 +13,39 @@ var saveCredentials bool
 
 var loginCmd = &cobra.Command{
 	Use:   "login",
-	Short: "Authenticate with Skylight and get API credentials",
+	Short: "Authenticate with Skylight and save OAuth2 credentials",
+	Long: `Performs a headless OAuth2 login using email and password, then saves
+the refresh token and device fingerprint to the config file. Use --save to
+persist the credentials so subsequent commands authenticate automatically.`,
 	Run: func(cmd *cobra.Command, args []string) {
 		if email == "" || password == "" {
 			fmt.Println("Error: --email and --password are required for login")
 			os.Exit(1)
 		}
 
-		client, err := lib.NewClient(email, password)
+		// Generate a stable device fingerprint if not provided.
+		fingerprint := deviceFingerprint
+		if fingerprint == "" {
+			fingerprint = newUUID()
+		}
+
+		fmt.Printf("Logging in as %s...\n", email)
+		tok, err := lib.LoginHeadless(email, password, fingerprint)
 		if err != nil {
 			fmt.Printf("Error logging in: %v\n", err)
 			os.Exit(1)
 		}
 
-		fmt.Printf("Login successful!\n")
-		fmt.Printf("User ID: %s\n", client.UserID)
-		fmt.Printf("API Token: %s\n", client.APIToken)
+		fmt.Println("Login successful!")
+		fmt.Printf("Access Token:  %s\n", tok.AccessToken)
+		fmt.Printf("Refresh Token: %s\n", tok.RefreshToken)
+		fmt.Printf("Fingerprint:   %s\n", fingerprint)
+		fmt.Printf("Expires In:    %d seconds\n", tok.ExpiresIn)
 
 		if saveCredentials {
 			values := map[string]string{
-				"SKYLIGHT_EMAIL":    email,
-				"SKYLIGHT_PASSWORD": password,
-				"SKYLIGHT_TOKEN":    client.APIToken,
-				"SKYLIGHT_USER_ID":  client.UserID,
+				"SKYLIGHT_REFRESH_TOKEN":      tok.RefreshToken,
+				"SKYLIGHT_DEVICE_FINGERPRINT": fingerprint,
 			}
 			if frameID != "" {
 				values["SKYLIGHT_FRAME_ID"] = frameID
@@ -53,5 +64,15 @@ var loginCmd = &cobra.Command{
 }
 
 func init() {
-	loginCmd.Flags().BoolVar(&saveCredentials, "save", false, "Save credentials to config file")
+	loginCmd.Flags().BoolVar(&saveCredentials, "save", false, "Save refresh token and fingerprint to config file")
+}
+
+// newUUID generates a random UUID v4 string.
+func newUUID() string {
+	var b [16]byte
+	_, _ = rand.Read(b[:])
+	b[6] = (b[6] & 0x0f) | 0x40 // version 4
+	b[8] = (b[8] & 0x3f) | 0x80 // variant bits
+	return fmt.Sprintf("%08x-%04x-%04x-%04x-%012x",
+		b[0:4], b[4:6], b[6:8], b[8:10], b[10:16])
 }

--- a/lib/client.go
+++ b/lib/client.go
@@ -3,7 +3,6 @@ package lib
 import (
 	"bytes"
 	"context"
-	"encoding/base64"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -22,13 +21,15 @@ var (
 	SkylightURL = "https://app.ourskylight.com/api"
 )
 
-// Client is a Skylight API client. Create one with NewClient or
-// NewClientWithToken; use With* functional options for advanced configuration.
+// Client is a Skylight API client. Create one with NewClient,
+// NewClientWithToken, or NewClientWithRefreshToken; use With* functional
+// options for advanced configuration.
 type Client struct {
-	UserID     string
-	APIToken   string
-	HTTPClient *http.Client
-	authCache  string
+	UserID       string
+	APIToken     string // Bearer access token (used for Authorization header).
+	RefreshToken string // OAuth2 refresh token; rotates on each use.
+	HTTPClient   *http.Client
+	authCache    string
 
 	baseURL string
 	logger  *slog.Logger
@@ -48,8 +49,12 @@ func newHTTPClient() *http.Client {
 	}
 }
 
-// NewClient authenticates via email/password and returns a ready-to-use client.
-// Optional ClientOption values customize HTTP client, logging, retry, etc.
+// NewClient authenticates via email/password using the legacy /api/sessions
+// endpoint and returns a ready-to-use client.
+//
+// Deprecated: Skylight no longer supports the legacy sessions endpoint. Use
+// NewClientWithRefreshToken instead, with a refresh token obtained via
+// LoginHeadless or the "skylight auth login --save" command.
 func NewClient(email, password string, opts ...ClientOption) (*Client, error) {
 	if email == "" || password == "" {
 		return nil, errors.New("email and password are required")
@@ -75,13 +80,47 @@ func NewClient(email, password string, opts ...ClientOption) (*Client, error) {
 
 	c.UserID = session.UserID
 	c.APIToken = session.APIToken
-	c.authCache = "Basic " + base64.StdEncoding.EncodeToString([]byte(c.UserID+":"+c.APIToken))
+	c.authCache = "Bearer " + c.APIToken
 
 	return c, nil
 }
 
-// NewClientWithToken creates a client from a pre-existing user ID and API token,
-// skipping the login round-trip. Optional ClientOption values apply as usual.
+// NewClientWithRefreshToken authenticates using an OAuth2 refresh token and
+// returns a ready-to-use client. The refresh token rotates on each use; the
+// caller should persist Client.RefreshToken after a successful call.
+func NewClientWithRefreshToken(refreshToken, fingerprint string, opts ...ClientOption) (*Client, error) {
+	if refreshToken == "" {
+		return nil, errors.New("refresh token is required")
+	}
+	if fingerprint == "" {
+		return nil, errors.New("device fingerprint is required")
+	}
+
+	tok, err := RefreshOAuthToken(refreshToken, fingerprint)
+	if err != nil {
+		return nil, fmt.Errorf("failed to authenticate: %w", err)
+	}
+
+	cfg := defaultClientConfig()
+	for _, o := range opts {
+		o(&cfg)
+	}
+
+	return &Client{
+		APIToken:     tok.AccessToken,
+		RefreshToken: tok.RefreshToken,
+		authCache:    "Bearer " + tok.AccessToken,
+		HTTPClient:   cfg.httpClient,
+		baseURL:      cfg.baseURL,
+		logger:       cfg.logger,
+		limiter:      cfg.limiter,
+		retry:        cfg.retry,
+	}, nil
+}
+
+// NewClientWithToken creates a client from a pre-existing user ID and Bearer
+// access token, skipping the login round-trip. Optional ClientOption values
+// apply as usual.
 func NewClientWithToken(userID, token string, opts ...ClientOption) (*Client, error) {
 	if userID == "" || token == "" {
 		return nil, errors.New("user ID and token are required")
@@ -95,7 +134,7 @@ func NewClientWithToken(userID, token string, opts ...ClientOption) (*Client, er
 	return &Client{
 		UserID:     userID,
 		APIToken:   token,
-		authCache:  "Basic " + base64.StdEncoding.EncodeToString([]byte(userID+":"+token)),
+		authCache:  "Bearer " + token,
 		HTTPClient: cfg.httpClient,
 		baseURL:    cfg.baseURL,
 		logger:     cfg.logger,
@@ -107,6 +146,7 @@ func NewClientWithToken(userID, token string, opts ...ClientOption) (*Client, er
 func (c *Client) setHeaders(req *http.Request) {
 	req.Header.Set("Authorization", c.authCache)
 	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("skylight-api-version", "2026-03-01")
 }
 
 // effectiveURL returns the client's base URL, falling back to the package-level

--- a/lib/client_test.go
+++ b/lib/client_test.go
@@ -144,6 +144,10 @@ func TestNewClient(t *testing.T) {
 				if client.APIToken != tc.wantTok {
 					t.Errorf("APIToken: want %q got %q", tc.wantTok, client.APIToken)
 				}
+				// NewClient (legacy) should still produce Bearer auth cache.
+				if client.UserID != tc.wantUID {
+					t.Errorf("UserID: want %q got %q", tc.wantUID, client.UserID)
+				}
 			}
 		})
 	}
@@ -152,9 +156,12 @@ func TestNewClient(t *testing.T) {
 func TestAuthorizationHeader(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		auth := r.Header.Get("Authorization")
-		// Basic base64("user1:token1") = "dXNlcjE6dG9rZW4x"
-		if auth != "Basic dXNlcjE6dG9rZW4x" {
-			t.Errorf("Authorization: want Basic dXNlcjE6dG9rZW4x, got %q", auth)
+		if auth != "Bearer token1" {
+			t.Errorf("Authorization: want Bearer token1, got %q", auth)
+		}
+		apiVer := r.Header.Get("skylight-api-version")
+		if apiVer != "2026-03-01" {
+			t.Errorf("skylight-api-version: want 2026-03-01, got %q", apiVer)
 		}
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)

--- a/lib/session.go
+++ b/lib/session.go
@@ -1,8 +1,212 @@
 package lib
 
-import "fmt"
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/cookiejar"
+	"net/url"
+	"regexp"
+	"time"
+)
 
-// Login authenticates with the Skylight API using email and password.
+const (
+	skylightClientID    = "skylight-mobile"
+	skylightScope       = "everything"
+	skylightRedirectURI = "https://ourskylight.com/welcome"
+)
+
+var (
+	// OAuthURL is the Skylight OAuth2 token endpoint. Override in tests.
+	OAuthURL = "https://app.ourskylight.com/oauth/token"
+
+	// AuthSessionURL is the Skylight Rails session login endpoint. Override in tests.
+	AuthSessionURL = "https://app.ourskylight.com/auth/session"
+
+	// OAuthAuthorizeURL is the Skylight OAuth2 authorize endpoint. Override in tests.
+	OAuthAuthorizeURL = "https://app.ourskylight.com/oauth/authorize"
+)
+
+// RefreshOAuthToken exchanges a refresh token for a new access token using
+// the Skylight OAuth2 refresh token grant. The refresh token rotates on each
+// use; callers must persist the new RefreshToken from the response.
+func RefreshOAuthToken(refreshToken, fingerprint string) (*OAuthTokenResponse, error) {
+	return postOAuthToken(url.Values{
+		"grant_type":                             {"refresh_token"},
+		"refresh_token":                          {refreshToken},
+		"client_id":                              {skylightClientID},
+		"skylight_api_client_device_fingerprint": {fingerprint},
+	})
+}
+
+// LoginHeadless performs a headless OAuth2 authorization-code login using
+// email and password. It returns a token response including both an access
+// token and a refresh token. The fingerprint is a stable UUID that identifies
+// this client device.
+func LoginHeadless(email, password, fingerprint string) (*OAuthTokenResponse, error) {
+	jar, err := cookiejar.New(nil)
+	if err != nil {
+		return nil, fmt.Errorf("creating cookie jar: %w", err)
+	}
+
+	hc := &http.Client{
+		Jar:     jar,
+		Timeout: 30 * time.Second,
+		CheckRedirect: func(req *http.Request, via []*http.Request) error {
+			return http.ErrUseLastResponse
+		},
+	}
+
+	// Step 1: GET login page to extract CSRF token.
+	csrfToken, err := fetchCSRFToken(hc)
+	if err != nil {
+		return nil, fmt.Errorf("fetching CSRF token: %w", err)
+	}
+
+	// Step 2: POST credentials to create a Rails session.
+	if err := postSession(hc, email, password, csrfToken); err != nil {
+		return nil, fmt.Errorf("logging in: %w", err)
+	}
+
+	// Step 3: GET OAuth authorize endpoint to receive the auth code.
+	code, err := fetchAuthCode(hc, fingerprint)
+	if err != nil {
+		return nil, fmt.Errorf("fetching auth code: %w", err)
+	}
+
+	// Step 4: Exchange auth code for tokens.
+	return exchangeAuthCode(code, fingerprint)
+}
+
+// fetchCSRFToken GETs the login page and extracts the Rails authenticity_token.
+func fetchCSRFToken(hc *http.Client) (string, error) {
+	resp, err := hc.Get(AuthSessionURL + "/new")
+	if err != nil {
+		return "", err
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return "", err
+	}
+
+	// Match <input ... name="authenticity_token" ... value="..." />
+	re := regexp.MustCompile(`name="authenticity_token"[^>]*value="([^"]+)"`)
+	if m := re.FindSubmatch(body); len(m) > 1 {
+		return string(m[1]), nil
+	}
+	// Also try value before name ordering.
+	re2 := regexp.MustCompile(`value="([^"]+)"[^>]*name="authenticity_token"`)
+	if m := re2.FindSubmatch(body); len(m) > 1 {
+		return string(m[1]), nil
+	}
+	return "", fmt.Errorf("authenticity_token not found in login page")
+}
+
+// postSession POSTs credentials to the Rails session endpoint.
+func postSession(hc *http.Client, email, password, csrfToken string) error {
+	form := url.Values{}
+	form.Set("authenticity_token", csrfToken)
+	form.Set("session[email]", email)
+	form.Set("session[password]", password)
+
+	resp, err := hc.PostForm(AuthSessionURL, form)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusFound && resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		return fmt.Errorf("login returned status %d: %s", resp.StatusCode, string(body))
+	}
+	return nil
+}
+
+// fetchAuthCode GETs the OAuth authorize endpoint and extracts the auth code
+// from the redirect Location header.
+func fetchAuthCode(hc *http.Client, fingerprint string) (string, error) {
+	params := url.Values{}
+	params.Set("client_id", skylightClientID)
+	params.Set("response_type", "code")
+	params.Set("redirect_uri", skylightRedirectURI)
+	params.Set("scope", skylightScope)
+	params.Set("skylight_api_client_device_fingerprint", fingerprint)
+
+	authorizeURL := OAuthAuthorizeURL + "?" + params.Encode()
+	resp, err := hc.Get(authorizeURL)
+	if err != nil {
+		return "", err
+	}
+	defer resp.Body.Close()
+
+	location := resp.Header.Get("Location")
+	if location == "" {
+		body, _ := io.ReadAll(resp.Body)
+		return "", fmt.Errorf("oauth authorize returned status %d with no Location: %s", resp.StatusCode, string(body))
+	}
+
+	u, err := url.Parse(location)
+	if err != nil {
+		return "", fmt.Errorf("parsing redirect URL: %w", err)
+	}
+
+	code := u.Query().Get("code")
+	if code == "" {
+		return "", fmt.Errorf("no code in redirect URL: %s", location)
+	}
+	return code, nil
+}
+
+// exchangeAuthCode exchanges an OAuth2 authorization code for tokens.
+func exchangeAuthCode(code, fingerprint string) (*OAuthTokenResponse, error) {
+	return postOAuthToken(url.Values{
+		"grant_type":                             {"authorization_code"},
+		"code":                                   {code},
+		"client_id":                              {skylightClientID},
+		"redirect_uri":                           {skylightRedirectURI},
+		"scope":                                  {skylightScope},
+		"skylight_api_client_device_fingerprint": {fingerprint},
+	})
+}
+
+// postOAuthToken posts form values to the OAuth token endpoint and returns the response.
+func postOAuthToken(data url.Values) (*OAuthTokenResponse, error) {
+	//nolint:gosec // OAuthURL is a package-level var, not user input; swappable in tests.
+	resp, err := http.PostForm(OAuthURL, data)
+	if err != nil {
+		return nil, fmt.Errorf("oauth token request failed: %w", err)
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("reading oauth response: %w", err)
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("oauth token request failed (status %d): %s", resp.StatusCode, string(body))
+	}
+
+	var token OAuthTokenResponse
+	if err := json.Unmarshal(body, &token); err != nil {
+		return nil, fmt.Errorf("parsing oauth response: %w", err)
+	}
+
+	if token.AccessToken == "" {
+		return nil, fmt.Errorf("oauth response missing access_token: %s", string(body))
+	}
+
+	return &token, nil
+}
+
+// Login authenticates with the Skylight API using email and password via the
+// legacy /api/sessions endpoint.
+//
+// Deprecated: Skylight no longer supports this endpoint. Use LoginHeadless or
+// RefreshOAuthToken instead.
 func (c *Client) Login(email, password string) (*Session, error) {
 	reqBody := SessionRequest{
 		Email:    email,

--- a/lib/structs.go
+++ b/lib/structs.go
@@ -27,6 +27,14 @@ type SessionRequest struct {
 	Password string `json:"password"`
 }
 
+// OAuthTokenResponse holds the OAuth2 token response from Skylight.
+type OAuthTokenResponse struct {
+	AccessToken  string `json:"access_token"`
+	RefreshToken string `json:"refresh_token"`
+	ExpiresIn    int    `json:"expires_in"`
+	TokenType    string `json:"token_type"`
+}
+
 // CalendarEvent represents a calendar event.
 type CalendarEvent struct {
 	ID          string `json:"id,omitempty"`

--- a/main.go
+++ b/main.go
@@ -1,10 +1,16 @@
 package main
 
-import "github.com/sebrandon1/go-skylight/cmd"
+import (
+	"os"
+
+	"github.com/sebrandon1/go-skylight/cmd"
+)
 
 var Version = "dev"
 
 func main() {
 	cmd.SetVersion(Version)
-	_ = cmd.Execute()
+	if err := cmd.Execute(); err != nil {
+		os.Exit(1)
+	}
 }


### PR DESCRIPTION
## Summary

Skylight broke all existing authentication on 2026-04-14 by switching from their legacy `/api/sessions` endpoint (HTTP Basic auth) to OAuth2 Bearer tokens. This PR updates go-skylight to support the new auth scheme.

- **New auth**: `POST /oauth/token` with `grant_type=refresh_token` or `grant_type=authorization_code`; all API requests use `Authorization: Bearer <access_token>` + `skylight-api-version: 2026-03-01` header
- **Refresh tokens rotate** on every use — the new token is auto-saved back to `~/.skylight/config`
- Fix silent exit-code bug in `main.go` (`_ = cmd.Execute()` discarded errors, causing scripts to exit 0 on auth failure)

## Changes

**`lib/structs.go`** — Add `OAuthTokenResponse` struct

**`lib/session.go`** — Replace legacy login with OAuth2 flows
- `RefreshOAuthToken(refreshToken, fingerprint)` — refresh token grant
- `LoginHeadless(email, password, fingerprint)` — full authorization-code flow (GET CSRF → POST session → GET `/oauth/authorize` → exchange code)
- Package-level URL vars (`OAuthURL`, `AuthSessionURL`, `OAuthAuthorizeURL`) overridable in tests

**`lib/client.go`** — Update auth scheme
- Auth header: `Bearer <access_token>` (was `Basic base64(userID:token)`)
- Add `skylight-api-version: 2026-03-01` on all requests
- Add `NewClientWithRefreshToken(refreshToken, fingerprint)` constructor
- Add `RefreshToken` field to `Client` struct

**`cmd/config.go`** — Add `SKYLIGHT_REFRESH_TOKEN` and `SKYLIGHT_DEVICE_FINGERPRINT` config keys

**`cmd/root.go`** — Update auth flow
- `--refresh-token` and `--device-fingerprint` persistent flags
- `PersistentPreRunE` prefers refresh token flow, auto-saves rotated token, falls back to legacy email/password

**`cmd/session.go`** — Rewrite `login` command to use `LoginHeadless`, with `--save` persisting the refresh token and fingerprint to config

**`main.go`** — Fix silent exit-code bug

## Test plan

- [ ] `go test ./...` passes
- [ ] `make lint` clean
- [ ] `skylight login --email ... --password ... --save` writes refresh token to config
- [ ] `skylight get chore list --frame-id <id>` authenticates via refresh token and auto-saves rotated token
- [ ] Non-zero exit on auth failure (verify with bad token)