### PR TITLE
chore: add major version tag updater workflow

### DIFF
--- a/.github/workflows/update-major-tag.yaml
+++ b/.github/workflows/update-major-tag.yaml
@@ -1,0 +1,47 @@
+name: Update Major Version Tag
+
+on:
+  release:
+    types: [published]
+
+permissions: read-all
+
+jobs:
+  update-major-tag:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Update major version tag
+        run: |
+          # Get the release tag (e.g., v0.1.2)
+          TAG_NAME="${GITHUB_REF#refs/tags/}"
+          echo "Release tag: $TAG_NAME"
+
+          # Extract major version (e.g., v0 from v0.1.2)
+          if [[ $TAG_NAME =~ ^v([0-9]+)\. ]]; then
+            MAJOR_VERSION="v${BASH_REMATCH[1]}"
+            echo "Major version: $MAJOR_VERSION"
+
+            # Configure git
+            git config user.name "github-actions[bot]"
+            git config user.email "github-actions[bot]@users.noreply.github.com"
+
+            # Delete the major version tag locally if it exists
+            git tag -d "$MAJOR_VERSION" 2>/dev/null || true
+
+            # Create/update the major version tag to point to the release tag
+            git tag -fa "$MAJOR_VERSION" -m "Update $MAJOR_VERSION to $TAG_NAME"
+
+            # Force push the major version tag
+            git push origin "$MAJOR_VERSION" --force
+
+            echo "Successfully updated $MAJOR_VERSION tag to point to $TAG_NAME"
+          else
+            echo "Tag $TAG_NAME does not match expected format (vX.Y.Z), skipping major version update"
+          fi


### PR DESCRIPTION
## Summary

- Adds a workflow that automatically moves the major version tag (e.g., `v0`) to point to the latest release tag whenever a new release is published
- Mirrors the approach used in [quick-ocp](https://github.com/palmsoftware/quick-ocp/blob/main/.github/workflows/update-major-tag.yml)

## Test plan

- [ ] Merge and create a new release to verify the `v0` tag is created/updated