### PR TITLE
refactor: flatten get command to top-level resource commands

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -98,6 +98,17 @@ func init() {
 	rootCmd.AddCommand(bountyCmd)
 	rootCmd.AddCommand(rotationCmd)
 
+	// Top-level resource commands (flattened from get prefix)
+	rootCmd.AddCommand(calendarCmd)
+	rootCmd.AddCommand(choreCmd)
+	rootCmd.AddCommand(listCmd)
+	rootCmd.AddCommand(rewardCmd)
+	rootCmd.AddCommand(mealCmd)
+	rootCmd.AddCommand(categoryCmd)
+	rootCmd.AddCommand(frameCmd)
+	rootCmd.AddCommand(photoCmd)
+
+	// Backward compatibility: keep get subcommands but hide them
 	getCmd.AddCommand(calendarCmd)
 	getCmd.AddCommand(choreCmd)
 	getCmd.AddCommand(listCmd)
@@ -106,6 +117,7 @@ func init() {
 	getCmd.AddCommand(categoryCmd)
 	getCmd.AddCommand(frameCmd)
 	getCmd.AddCommand(photoCmd)
+	getCmd.Hidden = true
 }
 
 func requireFrameID() {


### PR DESCRIPTION
Implements issue #45 - flatten resource commands from get prefix to top-level.\n\n## Changes\n- Adds resource commands to root level: calendar, chore, list, reward, meal, category, frame, photo\n- Hides get subcommands (getCmd.Hidden = true) for backward compatibility\n- After one release cycle, get can be removed entirely\n\n## Example usage\n\nBefore (deprecated but still works during transition):\n`\nskylight get chore list\n`\n\nAfter (new flat syntax):\n`\nskylight chore list\n`\n\nRefs: #45