### PR TITLE
fix: correct root command name from "skylight" to "go-skylight"

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -22,7 +22,7 @@ var (
 var version = "dev"
 
 var rootCmd = &cobra.Command{
-	Use:     "skylight",
+	Use:     "go-skylight",
 	Short:   "Skylight CLI interacts with the Skylight Calendar API",
 	Version: version,
 }

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -26,8 +26,8 @@ func TestRootCommandExists(t *testing.T) {
 	if rootCmd == nil {
 		t.Fatal("rootCmd should not be nil")
 	}
-	if rootCmd.Use != "skylight" {
-		t.Errorf("Expected Use 'skylight', got '%s'", rootCmd.Use)
+	if rootCmd.Use != "go-skylight" {
+		t.Errorf("Expected Use 'go-skylight', got '%s'", rootCmd.Use)
 	}
 }
 

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -785,19 +785,19 @@ func TestResourceCommandsAtRootLevel(t *testing.T) {
 
 // TestResourceCommandPaths guards against the Cobra dual-parent bug where
 // adding the same *cobra.Command instance to two parents causes CommandPath()
-// to reflect the wrong ancestor (e.g. "skylight get chore" instead of "skylight chore").
+// to reflect the wrong ancestor (e.g. "go-skylight get chore" instead of "go-skylight chore").
 func TestResourceCommandPaths(t *testing.T) {
 	tests := []struct {
 		wantPath string
 		cmd      *cobra.Command
 	}{
-		{"skylight calendar", calendarCmd},
-		{"skylight chore", choreCmd},
-		{"skylight list", listCmd},
-		{"skylight reward", rewardCmd},
-		{"skylight meal", mealCmd},
-		{"skylight category", categoryCmd},
-		{"skylight frame", frameCmd},
+		{"go-skylight calendar", calendarCmd},
+		{"go-skylight chore", choreCmd},
+		{"go-skylight list", listCmd},
+		{"go-skylight reward", rewardCmd},
+		{"go-skylight meal", mealCmd},
+		{"go-skylight category", categoryCmd},
+		{"go-skylight frame", frameCmd},
 	}
 	for _, tt := range tests {
 		t.Run(tt.wantPath, func(t *testing.T) {


### PR DESCRIPTION
## Summary

- Changes `Use` field in `cmd/root.go` from `"skylight"` to `"go-skylight"` to match the built binary name
- Updates the corresponding test assertion in `cmd/root_test.go`

## Problem

Shell completion scripts and help text referenced `skylight` as the command name, but the binary is built and installed as `go-skylight`. This caused generated completions to be non-functional.

**Before:**
```
Usage:
  skylight [command]
```

**After:**
```
Usage:
  go-skylight [command]
```

## Test plan
- [x] `make build` succeeds
- [x] `./go-skylight --help` shows `go-skylight` in Usage line
- [x] `make test` — all tests pass
- [x] `make lint` — 0 issues

Closes #39