### PR TITLE
test: add command registration tests for top-level resource flattening

### DIFF
--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -784,3 +784,60 @@ func TestCalendarHelpDoesNotError(t *testing.T) {
 		t.Errorf("Execute 'get calendar --help' failed: %v", err)
 	}
 }
+
+// TestResourceCommandsAtRootLevel verifies that all resource commands are
+// registered directly under rootCmd, not only nested under get.
+func TestResourceCommandsAtRootLevel(t *testing.T) {
+	expected := map[string]bool{
+		"calendar": false,
+		"chore":    false,
+		"list":     false,
+		"reward":   false,
+		"meal":     false,
+		"category": false,
+		"frame":    false,
+	}
+	for _, cmd := range rootCmd.Commands() {
+		if _, ok := expected[cmd.Use]; ok {
+			expected[cmd.Use] = true
+		}
+	}
+	for name, found := range expected {
+		if !found {
+			t.Errorf("expected '%s' as a top-level command under root", name)
+		}
+	}
+}
+
+// TestResourceCommandPaths guards against the Cobra dual-parent bug where
+// adding the same *cobra.Command instance to two parents causes CommandPath()
+// to reflect the wrong ancestor (e.g. "skylight get chore" instead of "skylight chore").
+func TestResourceCommandPaths(t *testing.T) {
+	tests := []struct {
+		wantPath string
+		cmd      *cobra.Command
+	}{
+		{"skylight calendar", calendarCmd},
+		{"skylight chore", choreCmd},
+		{"skylight list", listCmd},
+		{"skylight reward", rewardCmd},
+		{"skylight meal", mealCmd},
+		{"skylight category", categoryCmd},
+		{"skylight frame", frameCmd},
+	}
+	for _, tt := range tests {
+		t.Run(tt.wantPath, func(t *testing.T) {
+			if got := tt.cmd.CommandPath(); got != tt.wantPath {
+				t.Errorf("CommandPath() = %q, want %q", got, tt.wantPath)
+			}
+		})
+	}
+}
+
+// TestGetCommandIsHidden verifies that get is hidden now that resource commands
+// live at the top level.
+func TestGetCommandIsHidden(t *testing.T) {
+	if !getCmd.Hidden {
+		t.Error("getCmd should be hidden after flattening resource commands to top level")
+	}
+}


### PR DESCRIPTION
## Summary

- Adds `TestResourceCommandsAtRootLevel` to verify resource commands appear directly under `rootCmd`
- Adds `TestResourceCommandPaths` to assert `CommandPath()` returns the correct top-level path — this directly catches the Cobra dual-parent bug where the same `*cobra.Command` instance added to two parents causes `CommandPath()` to reflect the wrong ancestor
- Adds `TestGetCommandIsHidden` to verify `getCmd.Hidden == true` after the transition

## Context

These tests were added while reviewing PR #57, which attempts to flatten resource commands from under `get` to the top level (issue #45). PR #57 has a bug where the same command instances are registered to both `rootCmd` and `getCmd`. Cobra's `AddCommand` overwrites the `parent` field, so `choreCmd.CommandPath()` returns `"skylight get chore"` instead of `"skylight chore"`. `TestResourceCommandPaths` catches this immediately.

The three new tests will **fail on the current codebase** (pre-#45) and pass once issue #45 is correctly implemented.

## Test plan

- [ ] `go test ./cmd/... -run "TestResourceCommand|TestGetCommandIsHidden"` fails on `main` (expected — feature not yet merged)
- [ ] All other existing tests continue to pass
- [ ] Tests pass once PR #57 is corrected and merged