### PR TITLE
feat: add frame list CLI command

### DIFF
--- a/cmd/frame.go
+++ b/cmd/frame.go
@@ -12,6 +12,22 @@ var frameCmd = &cobra.Command{
 	Short: "Frame and device info commands",
 }
 
+var frameListCmd = &cobra.Command{
+	Use:   "list",
+	Short: "List all frames",
+	Run: func(cmd *cobra.Command, args []string) {
+		client := getClient()
+
+		frames, err := client.ListFrames()
+		if err != nil {
+			fmt.Printf("Error listing frames: %v\n", err)
+			os.Exit(1)
+		}
+
+		printJSON(frames)
+	},
+}
+
 var frameInfoCmd = &cobra.Command{
 	Use:   "info",
 	Short: "Get frame information",
@@ -81,6 +97,7 @@ var frameColorsCmd = &cobra.Command{
 }
 
 func init() {
+	frameCmd.AddCommand(frameListCmd)
 	frameCmd.AddCommand(frameInfoCmd)
 	frameCmd.AddCommand(frameDevicesCmd)
 	frameCmd.AddCommand(frameAvatarsCmd)


### PR DESCRIPTION
## Summary

- Adds `go-skylight get frame list` that calls `lib.ListFrames()`
- No `--frame-id` required — lists all frames accessible to the authenticated user
- Output is JSON via printJSON, consistent with all other commands

## Problem

Users with multiple Skylight devices had no way to discover their frame IDs from the CLI. lib.ListFrames() already existed in the library but was never surfaced as a command.

## Usage

```bash
go-skylight get frame list --refresh-token TOKEN
```

## Test plan
- make build succeeds
- lib.TestListFrames tests already cover the library function
- make lint passes with 0 issues

Closes #41