### PR TITLE
feat: add config show/set/get subcommands

### DIFF
--- a/cmd/configcmd.go
+++ b/cmd/configcmd.go
@@ -1,0 +1,127 @@
+package cmd
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/spf13/cobra"
+)
+
+var knownConfigKeys = []string{
+	"SKYLIGHT_EMAIL",
+	"SKYLIGHT_PASSWORD",
+	"SKYLIGHT_TOKEN",
+	"SKYLIGHT_USER_ID",
+	"SKYLIGHT_FRAME_ID",
+	"SKYLIGHT_REFRESH_TOKEN",
+	"SKYLIGHT_DEVICE_FINGERPRINT",
+}
+
+var sensitiveConfigKeys = map[string]bool{
+	"SKYLIGHT_PASSWORD":      true,
+	"SKYLIGHT_TOKEN":         true,
+	"SKYLIGHT_REFRESH_TOKEN": true,
+}
+
+const notSet = "(not set)"
+
+// configValues returns pointers to the package-level config globals.
+// Must stay in sync with the vars map in loadConfig().
+func configValues() map[string]*string {
+	return map[string]*string{
+		"SKYLIGHT_EMAIL":              &email,
+		"SKYLIGHT_PASSWORD":           &password,
+		"SKYLIGHT_TOKEN":              &token,
+		"SKYLIGHT_USER_ID":            &userID,
+		"SKYLIGHT_FRAME_ID":           &frameID,
+		"SKYLIGHT_REFRESH_TOKEN":      &refreshToken,
+		"SKYLIGHT_DEVICE_FINGERPRINT": &deviceFingerprint,
+	}
+}
+
+func maskValue(key, value string) string {
+	if value == "" {
+		return notSet
+	}
+	if sensitiveConfigKeys[key] {
+		if len(value) <= 4 {
+			return "****"
+		}
+		return value[:4] + "****"
+	}
+	return value
+}
+
+var configCmd = &cobra.Command{
+	Use:   "config",
+	Short: "View and modify the local configuration file",
+}
+
+var configShowCmd = &cobra.Command{
+	Use:   "show",
+	Short: "Display all current configuration values",
+	Run: func(cmd *cobra.Command, args []string) {
+		path := configPath
+		if path == "" {
+			path = defaultConfigPath()
+		}
+		fmt.Fprintf(cmd.OutOrStdout(), "Config file: %s\n\n", path)
+
+		vals := configValues()
+		for _, key := range knownConfigKeys {
+			fmt.Fprintf(cmd.OutOrStdout(), "%-32s %s\n", key, maskValue(key, *vals[key]))
+		}
+	},
+}
+
+var configGetCmd = &cobra.Command{
+	Use:   "get <key>",
+	Short: "Get the value of a configuration key",
+	Args:  cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		key := args[0]
+		vals := configValues()
+		ptr, ok := vals[key]
+		if !ok {
+			return fmt.Errorf("unknown config key %q; valid keys: %s", key, strings.Join(knownConfigKeys, ", "))
+		}
+		if *ptr == "" {
+			fmt.Fprintln(cmd.OutOrStdout(), notSet)
+		} else {
+			fmt.Fprintln(cmd.OutOrStdout(), *ptr)
+		}
+		return nil
+	},
+}
+
+var configSetCmd = &cobra.Command{
+	Use:   "set <key> <value>",
+	Short: "Set a configuration key to a value",
+	Args:  cobra.ExactArgs(2),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		key := args[0]
+		value := args[1]
+
+		vals := configValues()
+		if _, ok := vals[key]; !ok {
+			return fmt.Errorf("unknown config key %q; valid keys: %s", key, strings.Join(knownConfigKeys, ", "))
+		}
+
+		if err := saveConfig(map[string]string{key: value}); err != nil {
+			return fmt.Errorf("saving config: %w", err)
+		}
+
+		path := configPath
+		if path == "" {
+			path = defaultConfigPath()
+		}
+		fmt.Fprintf(cmd.OutOrStdout(), "Set %s in %s\n", key, path)
+		return nil
+	},
+}
+
+func init() {
+	configCmd.AddCommand(configShowCmd)
+	configCmd.AddCommand(configGetCmd)
+	configCmd.AddCommand(configSetCmd)
+}

--- a/cmd/configcmd.go
+++ b/cmd/configcmd.go
@@ -24,6 +24,7 @@ var sensitiveConfigKeys = map[string]bool{
 }
 
 const notSet = "(not set)"
+const masked = "****"
 
 // configValues returns pointers to the package-level config globals.
 // Must stay in sync with the vars map in loadConfig().
@@ -45,9 +46,9 @@ func maskValue(key, value string) string {
 	}
 	if sensitiveConfigKeys[key] {
 		if len(value) <= 4 {
-			return "****"
+			return masked
 		}
-		return value[:4] + "****"
+		return value[:4] + masked
 	}
 	return value
 }

--- a/cmd/configcmd_test.go
+++ b/cmd/configcmd_test.go
@@ -1,0 +1,244 @@
+package cmd
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestMaskValueEmpty(t *testing.T) {
+	got := maskValue("SKYLIGHT_TOKEN", "")
+	if got != notSet {
+		t.Errorf("maskValue empty = %q, want %q", got, notSet)
+	}
+}
+
+func TestMaskValueNonSensitive(t *testing.T) {
+	got := maskValue("SKYLIGHT_FRAME_ID", "frame123")
+	if got != "frame123" {
+		t.Errorf("maskValue non-sensitive = %q, want %q", got, "frame123")
+	}
+}
+
+func TestMaskValueSensitiveLong(t *testing.T) {
+	got := maskValue("SKYLIGHT_TOKEN", "abcdefgh")
+	if got != "abcd****" {
+		t.Errorf("maskValue sensitive long = %q, want %q", got, "abcd****")
+	}
+}
+
+func TestMaskValueSensitiveShort(t *testing.T) {
+	got := maskValue("SKYLIGHT_TOKEN", "ab")
+	if got != "****" {
+		t.Errorf("maskValue sensitive short = %q, want %q", got, "****")
+	}
+}
+
+func TestMaskValueSensitiveExactlyFour(t *testing.T) {
+	got := maskValue("SKYLIGHT_PASSWORD", "abcd")
+	if got != "****" {
+		t.Errorf("maskValue sensitive exactly 4 = %q, want %q", got, "****")
+	}
+}
+
+func TestConfigShowAllNotSet(t *testing.T) {
+	resetGlobals(t)
+
+	var buf bytes.Buffer
+	configShowCmd.SetOut(&buf)
+	configShowCmd.Run(configShowCmd, nil)
+
+	out := buf.String()
+	if !strings.Contains(out, "Config file:") {
+		t.Error("config show output missing 'Config file:' line")
+	}
+	for _, key := range knownConfigKeys {
+		if !strings.Contains(out, key) {
+			t.Errorf("config show output missing key %s", key)
+		}
+	}
+	if count := strings.Count(out, notSet); count != len(knownConfigKeys) {
+		t.Errorf("expected %d %q entries, got %d", len(knownConfigKeys), notSet, count)
+	}
+}
+
+func TestConfigShowMasksSensitiveKeys(t *testing.T) {
+	resetGlobals(t)
+	token = "mysecrettoken"
+	t.Cleanup(func() { token = "" })
+
+	var buf bytes.Buffer
+	configShowCmd.SetOut(&buf)
+	configShowCmd.Run(configShowCmd, nil)
+
+	out := buf.String()
+	if strings.Contains(out, "mysecrettoken") {
+		t.Error("config show should not print plaintext token")
+	}
+	if !strings.Contains(out, "myse****") {
+		t.Error("config show should print masked token prefix")
+	}
+}
+
+func TestConfigShowNonSensitiveUnmasked(t *testing.T) {
+	resetGlobals(t)
+	frameID = "frame-abc-123"
+	t.Cleanup(func() { frameID = "" })
+
+	var buf bytes.Buffer
+	configShowCmd.SetOut(&buf)
+	configShowCmd.Run(configShowCmd, nil)
+
+	out := buf.String()
+	if !strings.Contains(out, "frame-abc-123") {
+		t.Error("config show should print non-sensitive value unmasked")
+	}
+}
+
+func TestConfigGetUnknownKey(t *testing.T) {
+	resetGlobals(t)
+	err := configGetCmd.RunE(configGetCmd, []string{"SKYLIGHT_INVALID"})
+	if err == nil {
+		t.Error("expected error for unknown key, got nil")
+	}
+}
+
+func TestConfigGetEmptyValue(t *testing.T) {
+	resetGlobals(t)
+
+	var buf bytes.Buffer
+	configGetCmd.SetOut(&buf)
+	err := configGetCmd.RunE(configGetCmd, []string{"SKYLIGHT_TOKEN"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if strings.TrimSpace(buf.String()) != notSet {
+		t.Errorf("expected %q, got %q", notSet, buf.String())
+	}
+}
+
+func TestConfigGetKnownValue(t *testing.T) {
+	resetGlobals(t)
+	token = "plaintext-value"
+	t.Cleanup(func() { token = "" })
+
+	var buf bytes.Buffer
+	configGetCmd.SetOut(&buf)
+	err := configGetCmd.RunE(configGetCmd, []string{"SKYLIGHT_TOKEN"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	// get must return plaintext (no masking) for scripting use
+	if strings.TrimSpace(buf.String()) != "plaintext-value" {
+		t.Errorf("expected %q, got %q", "plaintext-value", buf.String())
+	}
+}
+
+func TestConfigSetUnknownKey(t *testing.T) {
+	resetGlobals(t)
+	dir := t.TempDir()
+	configPath = filepath.Join(dir, "config")
+	t.Cleanup(func() { configPath = "" })
+
+	err := configSetCmd.RunE(configSetCmd, []string{"SKYLIGHT_INVALID", "val"})
+	if err == nil {
+		t.Error("expected error for unknown key, got nil")
+	}
+	if _, statErr := os.Stat(configPath); !os.IsNotExist(statErr) {
+		t.Error("config file should not be created on unknown key error")
+	}
+}
+
+func TestConfigSetWritesToFile(t *testing.T) {
+	resetGlobals(t)
+	dir := t.TempDir()
+	configPath = filepath.Join(dir, "config")
+	t.Cleanup(func() { configPath = "" })
+
+	var buf bytes.Buffer
+	configSetCmd.SetOut(&buf)
+	err := configSetCmd.RunE(configSetCmd, []string{"SKYLIGHT_FRAME_ID", "test-frame-789"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	data, readErr := os.ReadFile(configPath)
+	if readErr != nil {
+		t.Fatalf("could not read config file: %v", readErr)
+	}
+	if !strings.Contains(string(data), "SKYLIGHT_FRAME_ID=test-frame-789") {
+		t.Errorf("config file missing expected entry, got: %s", data)
+	}
+}
+
+func TestConfigSetPreservesExistingKeys(t *testing.T) {
+	resetGlobals(t)
+	dir := t.TempDir()
+	configPath = filepath.Join(dir, "config")
+	t.Cleanup(func() { configPath = "" })
+
+	// Pre-populate file
+	if err := os.WriteFile(configPath, []byte("SKYLIGHT_USER_ID=existing-user\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	err := configSetCmd.RunE(configSetCmd, []string{"SKYLIGHT_FRAME_ID", "new-frame"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	data, _ := os.ReadFile(configPath)
+	content := string(data)
+	if !strings.Contains(content, "SKYLIGHT_USER_ID=existing-user") {
+		t.Error("config set should preserve existing keys")
+	}
+	if !strings.Contains(content, "SKYLIGHT_FRAME_ID=new-frame") {
+		t.Error("config set should write new key")
+	}
+}
+
+func TestConfigSetUpdatesExistingKey(t *testing.T) {
+	resetGlobals(t)
+	dir := t.TempDir()
+	configPath = filepath.Join(dir, "config")
+	t.Cleanup(func() { configPath = "" })
+
+	if err := os.WriteFile(configPath, []byte("SKYLIGHT_FRAME_ID=old-frame\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	err := configSetCmd.RunE(configSetCmd, []string{"SKYLIGHT_FRAME_ID", "new-frame"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	data, _ := os.ReadFile(configPath)
+	content := string(data)
+	if strings.Contains(content, "old-frame") {
+		t.Error("config set should overwrite existing key value")
+	}
+	if !strings.Contains(content, "SKYLIGHT_FRAME_ID=new-frame") {
+		t.Error("config set should write updated value")
+	}
+}
+
+// resetGlobals clears all config globals and resets them via t.Cleanup.
+func resetGlobals(t *testing.T) {
+	t.Helper()
+	prev := struct{ e, p, tok, uid, fid, rt, df, cp string }{
+		email, password, token, userID, frameID, refreshToken, deviceFingerprint, configPath,
+	}
+	email, password, token, userID, frameID, refreshToken, deviceFingerprint, configPath = "", "", "", "", "", "", "", ""
+	t.Cleanup(func() {
+		email = prev.e
+		password = prev.p
+		token = prev.tok
+		userID = prev.uid
+		frameID = prev.fid
+		refreshToken = prev.rt
+		deviceFingerprint = prev.df
+		configPath = prev.cp
+	})
+}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -43,8 +43,10 @@ func init() {
 		// Load config file first (CLI flags take precedence since they're already set)
 		loadConfig()
 
-		// Skip auto-login for login command itself and help
-		if cmd.Name() == loginCmd.Name() || cmd.Name() == "help" {
+		// Skip auto-login for login command itself, help, and config subcommands
+		// (config commands must work even when credentials are missing or expired).
+		if cmd.Name() == loginCmd.Name() || cmd.Name() == "help" ||
+			(cmd.Parent() != nil && cmd.Parent().Name() == "config") {
 			return nil
 		}
 
@@ -107,6 +109,7 @@ func init() {
 	rootCmd.AddCommand(categoryCmd)
 	rootCmd.AddCommand(frameCmd)
 	rootCmd.AddCommand(photoCmd)
+	rootCmd.AddCommand(configCmd)
 }
 
 func requireFrameID() {

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -661,6 +661,10 @@ func TestAllCommandsHaveShortDescriptions(t *testing.T) {
 		"frame devices":       frameDevicesCmd,
 		"frame avatars":       frameAvatarsCmd,
 		"frame colors":        frameColorsCmd,
+		"config":              configCmd,
+		"config show":         configShowCmd,
+		"config get":          configGetCmd,
+		"config set":          configSetCmd,
 	}
 
 	for name, c := range cmds {
@@ -709,12 +713,15 @@ func TestLeafCommandsHaveRunFunctions(t *testing.T) {
 		"frame devices":       frameDevicesCmd,
 		"frame avatars":       frameAvatarsCmd,
 		"frame colors":        frameColorsCmd,
+		"config show":         configShowCmd,
+		"config get":          configGetCmd,
+		"config set":          configSetCmd,
 	}
 
 	for name, c := range leafCmds {
 		t.Run(name, func(t *testing.T) {
-			if c.Run == nil {
-				t.Errorf("Leaf command '%s' should have a Run function", name)
+			if c.Run == nil && c.RunE == nil {
+				t.Errorf("Leaf command '%s' should have a Run or RunE function", name)
 			}
 		})
 	}
@@ -732,6 +739,7 @@ func TestParentCommandsHaveNoRunFunction(t *testing.T) {
 		"reward":   rewardCmd,
 		"meal":     mealCmd,
 		"frame":    frameCmd,
+		"config":   configCmd,
 	}
 
 	for name, c := range parentCmds {
@@ -813,5 +821,26 @@ func TestResourceCommandPaths(t *testing.T) {
 func TestGetCommandIsHidden(t *testing.T) {
 	if !getCmd.Hidden {
 		t.Error("getCmd should be hidden after flattening resource commands to top level")
+	}
+}
+
+func TestConfigCommandExists(t *testing.T) {
+	if configCmd == nil {
+		t.Fatal("configCmd should not be nil")
+	}
+	if configCmd.Use != "config" {
+		t.Errorf("Expected Use 'config', got '%s'", configCmd.Use)
+	}
+
+	expected := map[string]bool{"show": false, "get": false, "set": false}
+	for _, sub := range configCmd.Commands() {
+		if _, ok := expected[sub.Name()]; ok {
+			expected[sub.Name()] = true
+		}
+	}
+	for name, found := range expected {
+		if !found {
+			t.Errorf("Expected subcommand '%s' under config", name)
+		}
 	}
 }


### PR DESCRIPTION
Closes #40

## Summary

- Adds `config show` — displays all config keys in aligned columns with sensitive values (password, token, refresh token) masked
- Adds `config get <key>` — prints a single key value in plaintext, suitable for scripting
- Adds `config set <key> <value>` — writes a single key to the config file while preserving all existing keys
- Updates `PersistentPreRunE` to skip auth for config subcommands, so they work even when credentials are missing or expired

## Test plan

- [x] `make test` passes (16 new tests covering masking, show/get/set behavior, edge cases)
- [x] `make lint` reports 0 issues
- [x] `go-skylight config show` displays config file path and all 7 keys
- [x] Sensitive keys (TOKEN, PASSWORD, REFRESH_TOKEN) are masked in `show` output
- [x] `go-skylight config get SKYLIGHT_FRAME_ID` prints plaintext value
- [x] `go-skylight config get SKYLIGHT_INVALID` exits non-zero with helpful error
- [x] `go-skylight config set SKYLIGHT_FRAME_ID test-123` writes to config and preserves other keys
- [x] `config show` works with no config file (all keys show not set)
- [x] `config show` works when refresh token is expired (no auth error)