### PR TITLE
feat: add chore complete shortcut command

### DIFF
--- a/cmd/chore.go
+++ b/cmd/chore.go
@@ -93,6 +93,24 @@ var choreDeleteCmd = &cobra.Command{
 	},
 }
 
+var choreCompleteCmd = &cobra.Command{
+	Use:   "complete",
+	Short: "Mark a chore as completed",
+	Run: func(cmd *cobra.Command, args []string) {
+		requireFrameID()
+
+		client := getClient()
+
+		chore, err := client.UpdateChore(frameID, choreID, lib.ChoreData{Status: "completed"})
+		if err != nil {
+			fmt.Printf("Error completing chore: %v\n", err)
+			os.Exit(1)
+		}
+
+		printJSON(chore)
+	},
+}
+
 var choreUpdateCmd = &cobra.Command{
 	Use:   "update",
 	Short: "Update a chore",
@@ -133,6 +151,7 @@ func init() {
 	choreCmd.AddCommand(choreCreateCmd)
 	choreCmd.AddCommand(choreUpdateCmd)
 	choreCmd.AddCommand(choreDeleteCmd)
+	choreCmd.AddCommand(choreCompleteCmd)
 
 	choreListCmd.Flags().StringVar(&choreDate, "date", "", "Date filter")
 	choreListCmd.Flags().StringVar(&choreStatus, "status", "", "Status filter")
@@ -157,4 +176,7 @@ func init() {
 	choreUpdateCmd.Flags().StringVar(&choreDate, "date", "", "Due date")
 
 	choreDeleteCmd.Flags().StringVar(&choreID, "chore-id", "", "Chore ID to delete")
+
+	choreCompleteCmd.Flags().StringVar(&choreID, "chore-id", "", "Chore ID to complete")
+	choreCompleteCmd.MarkFlagRequired("chore-id") //nolint:errcheck
 }

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -212,9 +212,10 @@ func TestChoreSubcommands(t *testing.T) {
 	subcommands := choreCmd.Commands()
 
 	expected := map[string]bool{
-		"list":   false,
-		"create": false,
-		"delete": false,
+		"list":     false,
+		"create":   false,
+		"delete":   false,
+		"complete": false,
 	}
 
 	for _, cmd := range subcommands {
@@ -283,6 +284,13 @@ func TestChoreDeleteFlags(t *testing.T) {
 	f := choreDeleteCmd.Flags().Lookup("chore-id")
 	if f == nil {
 		t.Error("Expected flag 'chore-id' on chore delete command")
+	}
+}
+
+func TestChoreCompleteFlags(t *testing.T) {
+	f := choreCompleteCmd.Flags().Lookup("chore-id")
+	if f == nil {
+		t.Error("Expected flag 'chore-id' on chore complete command")
 	}
 }
 
@@ -632,6 +640,7 @@ func TestAllCommandsHaveShortDescriptions(t *testing.T) {
 		"chore list":          choreListCmd,
 		"chore create":        choreCreateCmd,
 		"chore delete":        choreDeleteCmd,
+		"chore complete":      choreCompleteCmd,
 		"list":                listCmd,
 		"list all":            listListCmd,
 		"list info":           listGetCmd,
@@ -688,6 +697,7 @@ func TestLeafCommandsHaveRunFunctions(t *testing.T) {
 		"chore list":          choreListCmd,
 		"chore create":        choreCreateCmd,
 		"chore delete":        choreDeleteCmd,
+		"chore complete":      choreCompleteCmd,
 		"list all":            listListCmd,
 		"list info":           listGetCmd,
 		"list create":         listCreateCmd,


### PR DESCRIPTION
## Summary

- Adds `chore complete --chore-id ID` as a shortcut for marking a chore as done
- Wraps UpdateChore with status=completed pre-filled, avoiding the longer `chore update --chore-id ID --status completed` form
- Updates tests to cover the new subcommand and its --chore-id flag

Closes #42

## Test plan

- Updated TestChoreSubcommands to expect complete subcommand
- Added TestChoreCompleteFlags to verify --chore-id flag is registered
- Updated TestAllCommandsHaveShortDescriptions and TestLeafCommandsHaveRunFunctions
- All tests pass (make test)
- Lint clean (make lint)

Generated with Claude Code