### PR TITLE
feat: add status command for quick frame overview

### DIFF
--- a/cmd/status.go
+++ b/cmd/status.go
@@ -1,0 +1,85 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/sebrandon1/go-skylight/lib"
+	"github.com/spf13/cobra"
+)
+
+var statusCmd = &cobra.Command{
+	Use:   "status",
+	Short: "Quick overview of the connected frame",
+	Run: func(cmd *cobra.Command, args []string) {
+		requireFrameID()
+		client := getClient()
+		today := time.Now().Format("2006-01-02")
+
+		frame, err := client.GetFrame(frameID)
+		if err != nil {
+			fmt.Printf("Error getting frame: %v\n", err)
+			os.Exit(1)
+		}
+
+		chores, err := client.ListChores(frameID, lib.ChoreListOptions{
+			Date:   today,
+			Status: "pending",
+		})
+		if err != nil {
+			fmt.Printf("Error listing chores: %v\n", err)
+			os.Exit(1)
+		}
+
+		events, err := client.ListCalendarEvents(frameID, today, today)
+		if err != nil {
+			fmt.Printf("Error listing calendar events: %v\n", err)
+			os.Exit(1)
+		}
+
+		categories, err := client.ListCategories(frameID)
+		if err != nil {
+			fmt.Printf("Error listing categories: %v\n", err)
+			os.Exit(1)
+		}
+
+		points, err := client.GetRewardPoints(frameID)
+		if err != nil {
+			fmt.Printf("Error getting reward points: %v\n", err)
+			os.Exit(1)
+		}
+
+		catNames := make(map[int]string, len(categories))
+		for _, c := range categories {
+			id, convErr := strconv.Atoi(c.ID)
+			if convErr == nil {
+				catNames[id] = c.Name
+			}
+		}
+
+		var pointParts []string
+		for _, p := range points {
+			name := catNames[p.CategoryID]
+			if name == "" {
+				name = strconv.Itoa(p.CategoryID)
+			}
+			pointParts = append(pointParts, fmt.Sprintf("%s: %d", name, p.CurrentPointBalance))
+		}
+		pointsStr := strings.Join(pointParts, "  ")
+		if pointsStr == "" {
+			pointsStr = "none"
+		}
+
+		fmt.Printf("Frame:   %s\n", frame.Name)
+		fmt.Printf("Chores:  %d pending today\n", len(chores))
+		fmt.Printf("Events:  %d today\n", len(events))
+		fmt.Printf("Points:  %s\n", pointsStr)
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(statusCmd)
+}


### PR DESCRIPTION
## Summary

- Adds `go-skylight status` command that prints a concise summary of the connected frame
- Shows connected frame name, pending chores today, upcoming events today, and point balances per family member
- Output is human-readable plain text, suitable for scripting and shell prompts

## Example output

```
Frame:   My Family Frame
Chores:  3 pending today
Events:  2 today
Points:  Alice: 150  Bob: 75  Charlie: 200
```

## Test plan

- [ ] `make build` passes
- [ ] `make test` passes (all existing tests)
- [ ] `make lint` reports 0 issues
- [ ] Manual: run `go-skylight status --frame-id <id>` and verify output fields match the frame

Closes #43