### PR TITLE
feat: add --output table|json global formatting flag

### DIFF
--- a/cmd/calendar.go
+++ b/cmd/calendar.go
@@ -37,7 +37,7 @@ var calendarListCmd = &cobra.Command{
 			os.Exit(1)
 		}
 
-		printJSON(events)
+		printOutput(events)
 	},
 }
 

--- a/cmd/category.go
+++ b/cmd/category.go
@@ -21,6 +21,6 @@ var categoryCmd = &cobra.Command{
 			os.Exit(1)
 		}
 
-		printJSON(categories)
+		printOutput(categories)
 	},
 }

--- a/cmd/chore.go
+++ b/cmd/chore.go
@@ -49,7 +49,7 @@ var choreListCmd = &cobra.Command{
 			os.Exit(1)
 		}
 
-		printJSON(chores)
+		printOutput(chores)
 	},
 }
 

--- a/cmd/frame.go
+++ b/cmd/frame.go
@@ -24,7 +24,7 @@ var frameListCmd = &cobra.Command{
 			os.Exit(1)
 		}
 
-		printJSON(frames)
+		printOutput(frames)
 	},
 }
 

--- a/cmd/helpers.go
+++ b/cmd/helpers.go
@@ -4,6 +4,9 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+	"text/tabwriter"
+
+	"github.com/sebrandon1/go-skylight/lib"
 )
 
 func printJSON(data any) {
@@ -13,4 +16,85 @@ func printJSON(data any) {
 		os.Exit(1)
 	}
 	fmt.Println(string(output))
+}
+
+// printOutput prints data in the format specified by --output (json or table).
+// Defaults to JSON for types that don't have a dedicated table renderer.
+func printOutput(data any) {
+	if outputFormat == "table" {
+		switch v := data.(type) {
+		case []lib.Chore:
+			printChoresTable(v)
+			return
+		case []lib.Reward:
+			printRewardsTable(v)
+			return
+		case []lib.Frame:
+			printFramesTable(v)
+			return
+		case []lib.CalendarEvent:
+			printCalendarTable(v)
+			return
+		case []lib.Category:
+			printCategoriesTable(v)
+			return
+		}
+	}
+	printJSON(data)
+}
+
+func printChoresTable(chores []lib.Chore) {
+	w := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
+	fmt.Fprintln(w, "ID\tTITLE\tSTATUS\tDUE DATE\tPOINTS\tASSIGNEE")
+	for _, c := range chores {
+		fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%d\t%s\n",
+			c.ID, c.Title, c.Status, c.DueDate, c.Points, c.AssigneeID)
+	}
+	w.Flush()
+}
+
+func printRewardsTable(rewards []lib.Reward) {
+	w := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
+	fmt.Fprintln(w, "ID\tTITLE\tPOINTS\tEMOJI\tREDEEMED\tCATEGORY")
+	for _, r := range rewards {
+		redeemed := "no"
+		if r.Redeemed {
+			redeemed = "yes"
+		}
+		fmt.Fprintf(w, "%s\t%s\t%d\t%s\t%s\t%s\n",
+			r.ID, r.Title, r.Points, r.EmojiIcon, redeemed, r.CategoryID)
+	}
+	w.Flush()
+}
+
+func printFramesTable(frames []lib.Frame) {
+	w := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
+	fmt.Fprintln(w, "ID\tNAME\tTIMEZONE")
+	for _, f := range frames {
+		fmt.Fprintf(w, "%s\t%s\t%s\n", f.ID, f.Name, f.TimeZone)
+	}
+	w.Flush()
+}
+
+func printCalendarTable(events []lib.CalendarEvent) {
+	w := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
+	fmt.Fprintln(w, "ID\tTITLE\tSTART\tEND\tALL DAY")
+	for _, e := range events {
+		allDay := "no"
+		if e.AllDay {
+			allDay = "yes"
+		}
+		fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\n",
+			e.ID, e.Title, e.StartAt, e.EndAt, allDay)
+	}
+	w.Flush()
+}
+
+func printCategoriesTable(cats []lib.Category) {
+	w := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
+	fmt.Fprintln(w, "ID\tNAME\tCOLOR")
+	for _, c := range cats {
+		fmt.Fprintf(w, "%s\t%s\t%s\n", c.ID, c.Name, c.Color)
+	}
+	w.Flush()
 }

--- a/cmd/helpers.go
+++ b/cmd/helpers.go
@@ -21,7 +21,7 @@ func printJSON(data any) {
 // printOutput prints data in the format specified by --output (json or table).
 // Defaults to JSON for types that don't have a dedicated table renderer.
 func printOutput(data any) {
-	if outputFormat == "table" {
+	if outputFormat == outputTable {
 		switch v := data.(type) {
 		case []lib.Chore:
 			printChoresTable(v)

--- a/cmd/helpers_test.go
+++ b/cmd/helpers_test.go
@@ -216,7 +216,7 @@ func captureStdout(fn func()) string {
 }
 
 func TestPrintOutputJSONFallback(t *testing.T) {
-	outputFormat = "json"
+	outputFormat = outputJSON
 	output := captureStdout(func() {
 		printOutput(map[string]string{"key": "value"})
 	})
@@ -226,7 +226,7 @@ func TestPrintOutputJSONFallback(t *testing.T) {
 }
 
 func TestPrintOutputChoresTable(t *testing.T) {
-	outputFormat = "table"
+	outputFormat = outputTable
 	chores := []lib.Chore{
 		{ID: "1", Title: "Clean room", Status: "pending", DueDate: "2026-04-28", Points: 10, AssigneeID: "cat1"},
 	}
@@ -240,7 +240,7 @@ func TestPrintOutputChoresTable(t *testing.T) {
 }
 
 func TestPrintOutputRewardsTable(t *testing.T) {
-	outputFormat = "table"
+	outputFormat = outputTable
 	rewards := []lib.Reward{
 		{ID: "r1", Title: "Ice cream", Points: 50, EmojiIcon: "🍦", Redeemed: false},
 	}
@@ -254,7 +254,7 @@ func TestPrintOutputRewardsTable(t *testing.T) {
 }
 
 func TestPrintOutputFramesTable(t *testing.T) {
-	outputFormat = "table"
+	outputFormat = outputTable
 	frames := []lib.Frame{
 		{ID: "f1", Name: "Kitchen Frame", TimeZone: "America/New_York"},
 	}
@@ -268,7 +268,7 @@ func TestPrintOutputFramesTable(t *testing.T) {
 }
 
 func TestPrintOutputCalendarTable(t *testing.T) {
-	outputFormat = "table"
+	outputFormat = outputTable
 	events := []lib.CalendarEvent{
 		{ID: "e1", Title: "Soccer practice", StartAt: "2026-04-28T16:00:00Z", AllDay: false},
 	}
@@ -282,7 +282,7 @@ func TestPrintOutputCalendarTable(t *testing.T) {
 }
 
 func TestPrintOutputCategoriesTable(t *testing.T) {
-	outputFormat = "table"
+	outputFormat = outputTable
 	cats := []lib.Category{
 		{ID: "c1", Name: "Alice", Color: "blue"},
 	}
@@ -296,7 +296,7 @@ func TestPrintOutputCategoriesTable(t *testing.T) {
 }
 
 func TestPrintOutputRewardRedeemedFlag(t *testing.T) {
-	outputFormat = "table"
+	outputFormat = outputTable
 	rewards := []lib.Reward{
 		{ID: "r1", Title: "Movie night", Points: 100, Redeemed: true},
 		{ID: "r2", Title: "Candy", Points: 20, Redeemed: false},
@@ -311,7 +311,7 @@ func TestPrintOutputRewardRedeemedFlag(t *testing.T) {
 }
 
 func TestPrintOutputUnknownTypeDefaultsToJSON(t *testing.T) {
-	outputFormat = "table"
+	outputFormat = outputTable
 	output := captureStdout(func() {
 		printOutput(map[string]int{"count": 5})
 	})

--- a/cmd/helpers_test.go
+++ b/cmd/helpers_test.go
@@ -5,6 +5,8 @@ import (
 	"os"
 	"strings"
 	"testing"
+
+	"github.com/sebrandon1/go-skylight/lib"
 )
 
 func TestPrintJSON(t *testing.T) {
@@ -198,6 +200,123 @@ func TestPrintJSONWithBooleans(t *testing.T) {
 	}
 	if !strings.Contains(output, "\"deleted\": false") {
 		t.Errorf("Expected deleted=false in output, got: %s", output)
+	}
+}
+
+func captureStdout(fn func()) string {
+	old := os.Stdout
+	r, w, _ := os.Pipe()
+	os.Stdout = w
+	fn()
+	w.Close()
+	os.Stdout = old
+	var buf bytes.Buffer
+	buf.ReadFrom(r)
+	return buf.String()
+}
+
+func TestPrintOutputJSONFallback(t *testing.T) {
+	outputFormat = "json"
+	output := captureStdout(func() {
+		printOutput(map[string]string{"key": "value"})
+	})
+	if !strings.Contains(output, `"key": "value"`) {
+		t.Errorf("Expected JSON output, got: %s", output)
+	}
+}
+
+func TestPrintOutputChoresTable(t *testing.T) {
+	outputFormat = "table"
+	chores := []lib.Chore{
+		{ID: "1", Title: "Clean room", Status: "pending", DueDate: "2026-04-28", Points: 10, AssigneeID: "cat1"},
+	}
+	output := captureStdout(func() { printOutput(chores) })
+	if !strings.Contains(output, "Clean room") {
+		t.Errorf("Expected chore title in table output, got: %s", output)
+	}
+	if !strings.Contains(output, "TITLE") {
+		t.Errorf("Expected header in table output, got: %s", output)
+	}
+}
+
+func TestPrintOutputRewardsTable(t *testing.T) {
+	outputFormat = "table"
+	rewards := []lib.Reward{
+		{ID: "r1", Title: "Ice cream", Points: 50, EmojiIcon: "🍦", Redeemed: false},
+	}
+	output := captureStdout(func() { printOutput(rewards) })
+	if !strings.Contains(output, "Ice cream") {
+		t.Errorf("Expected reward title in table output, got: %s", output)
+	}
+	if !strings.Contains(output, "POINTS") {
+		t.Errorf("Expected POINTS header, got: %s", output)
+	}
+}
+
+func TestPrintOutputFramesTable(t *testing.T) {
+	outputFormat = "table"
+	frames := []lib.Frame{
+		{ID: "f1", Name: "Kitchen Frame", TimeZone: "America/New_York"},
+	}
+	output := captureStdout(func() { printOutput(frames) })
+	if !strings.Contains(output, "Kitchen Frame") {
+		t.Errorf("Expected frame name in table output, got: %s", output)
+	}
+	if !strings.Contains(output, "TIMEZONE") {
+		t.Errorf("Expected TIMEZONE header, got: %s", output)
+	}
+}
+
+func TestPrintOutputCalendarTable(t *testing.T) {
+	outputFormat = "table"
+	events := []lib.CalendarEvent{
+		{ID: "e1", Title: "Soccer practice", StartAt: "2026-04-28T16:00:00Z", AllDay: false},
+	}
+	output := captureStdout(func() { printOutput(events) })
+	if !strings.Contains(output, "Soccer practice") {
+		t.Errorf("Expected event title in table output, got: %s", output)
+	}
+	if !strings.Contains(output, "ALL DAY") {
+		t.Errorf("Expected ALL DAY header, got: %s", output)
+	}
+}
+
+func TestPrintOutputCategoriesTable(t *testing.T) {
+	outputFormat = "table"
+	cats := []lib.Category{
+		{ID: "c1", Name: "Alice", Color: "blue"},
+	}
+	output := captureStdout(func() { printOutput(cats) })
+	if !strings.Contains(output, "Alice") {
+		t.Errorf("Expected category name in table output, got: %s", output)
+	}
+	if !strings.Contains(output, "COLOR") {
+		t.Errorf("Expected COLOR header, got: %s", output)
+	}
+}
+
+func TestPrintOutputRewardRedeemedFlag(t *testing.T) {
+	outputFormat = "table"
+	rewards := []lib.Reward{
+		{ID: "r1", Title: "Movie night", Points: 100, Redeemed: true},
+		{ID: "r2", Title: "Candy", Points: 20, Redeemed: false},
+	}
+	output := captureStdout(func() { printOutput(rewards) })
+	if !strings.Contains(output, "yes") {
+		t.Errorf("Expected 'yes' for redeemed reward, got: %s", output)
+	}
+	if !strings.Contains(output, "no") {
+		t.Errorf("Expected 'no' for unredeemed reward, got: %s", output)
+	}
+}
+
+func TestPrintOutputUnknownTypeDefaultsToJSON(t *testing.T) {
+	outputFormat = "table"
+	output := captureStdout(func() {
+		printOutput(map[string]int{"count": 5})
+	})
+	if !strings.Contains(output, `"count": 5`) {
+		t.Errorf("Expected JSON fallback for unknown type, got: %s", output)
 	}
 }
 

--- a/cmd/reward.go
+++ b/cmd/reward.go
@@ -36,7 +36,7 @@ var rewardListCmd = &cobra.Command{
 			os.Exit(1)
 		}
 
-		printJSON(rewards)
+		printOutput(rewards)
 	},
 }
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -8,6 +8,11 @@ import (
 	"github.com/spf13/cobra"
 )
 
+const (
+	outputJSON  = "json"
+	outputTable = "table"
+)
+
 var (
 	email             string
 	password          string
@@ -95,7 +100,7 @@ func init() {
 	rootCmd.PersistentFlags().StringVar(&frameID, "frame-id", "", "Frame ID")
 	rootCmd.PersistentFlags().StringVar(&refreshToken, "refresh-token", "", "OAuth2 refresh token")
 	rootCmd.PersistentFlags().StringVar(&deviceFingerprint, "device-fingerprint", "", "Device fingerprint UUID (stable per device)")
-	rootCmd.PersistentFlags().StringVarP(&outputFormat, "output", "o", "json", "Output format: json or table")
+	rootCmd.PersistentFlags().StringVarP(&outputFormat, "output", "o", outputJSON, "Output format: json or table")
 
 	getCmd.Hidden = true
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -16,6 +16,7 @@ var (
 	frameID           string
 	refreshToken      string
 	deviceFingerprint string
+	outputFormat      string
 	autoClient        *lib.Client
 )
 
@@ -94,6 +95,7 @@ func init() {
 	rootCmd.PersistentFlags().StringVar(&frameID, "frame-id", "", "Frame ID")
 	rootCmd.PersistentFlags().StringVar(&refreshToken, "refresh-token", "", "OAuth2 refresh token")
 	rootCmd.PersistentFlags().StringVar(&deviceFingerprint, "device-fingerprint", "", "Device fingerprint UUID (stable per device)")
+	rootCmd.PersistentFlags().StringVarP(&outputFormat, "output", "o", "json", "Output format: json or table")
 
 	getCmd.Hidden = true
 

--- a/cmd/status.go
+++ b/cmd/status.go
@@ -73,6 +73,28 @@ var statusCmd = &cobra.Command{
 			pointsStr = "none"
 		}
 
+		if outputFormat == "json" {
+			type pointEntry struct {
+				Name    string `json:"name"`
+				Balance int    `json:"balance"`
+			}
+			var pointEntries []pointEntry
+			for _, p := range points {
+				name := catNames[p.CategoryID]
+				if name == "" {
+					name = strconv.Itoa(p.CategoryID)
+				}
+				pointEntries = append(pointEntries, pointEntry{Name: name, Balance: p.CurrentPointBalance})
+			}
+			printJSON(map[string]any{
+				"frame":          frame.Name,
+				"pending_chores": len(chores),
+				"events_today":   len(events),
+				"points":         pointEntries,
+			})
+			return
+		}
+
 		fmt.Printf("Frame:   %s\n", frame.Name)
 		fmt.Printf("Chores:  %d pending today\n", len(chores))
 		fmt.Printf("Events:  %d today\n", len(events))

--- a/cmd/status.go
+++ b/cmd/status.go
@@ -73,7 +73,7 @@ var statusCmd = &cobra.Command{
 			pointsStr = "none"
 		}
 
-		if outputFormat == "json" {
+		if outputFormat == outputJSON {
 			type pointEntry struct {
 				Name    string `json:"name"`
 				Balance int    `json:"balance"`


### PR DESCRIPTION
## Summary

- Adds a persistent `--output`/`-o` flag (default: `json`) to all commands via the root `PersistentFlags`
- When `--output table` is passed, the following list commands render as aligned tabular output using `text/tabwriter`:
  - `chore list` — columns: ID, TITLE, STATUS, DUE DATE, POINTS, ASSIGNEE
  - `reward list` — columns: ID, TITLE, POINTS, EMOJI, REDEEMED, CATEGORY
  - `frame list` — columns: ID, NAME, TIMEZONE
  - `calendar list` — columns: ID, TITLE, START, END, ALL DAY
  - `category` — columns: ID, NAME, COLOR
- The `status` command gains `--output json` support, emitting a structured JSON object with `frame`, `pending_chores`, `events_today`, and `points` fields
- All other commands (single-object responses, mutations) fall back to JSON automatically
- 8 new tests in `helpers_test.go` cover all table renderers and the JSON fallback path

## Test plan

- [x] `make test` — all tests pass
- [x] `make lint` — 0 issues
- [x] `make build` — compiles cleanly

Closes #44