### PR TITLE
feat: add up-for-grabs chore support and skip task command

### DIFF
--- a/cmd/chore.go
+++ b/cmd/chore.go
@@ -19,6 +19,7 @@ var (
 	choreBefore      string
 	choreIncludeLate bool
 	choreRecurring   bool
+	choreUpForGrabs  bool
 )
 
 var choreCmd = &cobra.Command{
@@ -41,6 +42,7 @@ var choreListCmd = &cobra.Command{
 			After:       choreAfter,
 			Before:      choreBefore,
 			IncludeLate: choreIncludeLate,
+			UpForGrabs:  choreUpForGrabs,
 		})
 		if err != nil {
 			fmt.Printf("Error listing chores: %v\n", err)
@@ -59,13 +61,23 @@ var choreCreateCmd = &cobra.Command{
 
 		client := getClient()
 
-		chore, err := client.CreateChore(frameID, lib.ChoreData{
-			Title:      choreTitle,
-			DueDate:    choreDate,
-			AssigneeID: choreAssigneeID,
-			Points:     chorePoints,
-			Recurring:  choreRecurring,
-		})
+		var chore *lib.Chore
+		var err error
+		if choreUpForGrabs {
+			chore, err = client.CreateUpForGrabsChore(frameID, lib.ChoreData{
+				Title:   choreTitle,
+				DueDate: choreDate,
+				Points:  chorePoints,
+			})
+		} else {
+			chore, err = client.CreateChore(frameID, lib.ChoreData{
+				Title:      choreTitle,
+				DueDate:    choreDate,
+				AssigneeID: choreAssigneeID,
+				Points:     chorePoints,
+				Recurring:  choreRecurring,
+			})
+		}
 		if err != nil {
 			fmt.Printf("Error creating chore: %v\n", err)
 			os.Exit(1)
@@ -101,13 +113,12 @@ var choreCompleteCmd = &cobra.Command{
 
 		client := getClient()
 
-		chore, err := client.UpdateChore(frameID, choreID, lib.ChoreData{Status: "completed"})
-		if err != nil {
+		if err := client.CompleteChore(frameID, choreID); err != nil {
 			fmt.Printf("Error completing chore: %v\n", err)
 			os.Exit(1)
 		}
 
-		printJSON(chore)
+		fmt.Println("Chore completed successfully")
 	},
 }
 
@@ -146,12 +157,49 @@ var choreUpdateCmd = &cobra.Command{
 	},
 }
 
+var choreSkipCmd = &cobra.Command{
+	Use:   "skip",
+	Short: "Skip a recurring chore instance",
+	Run: func(cmd *cobra.Command, args []string) {
+		requireFrameID()
+
+		client := getClient()
+
+		if err := client.SkipChore(frameID, choreID); err != nil {
+			fmt.Printf("Error skipping chore: %v\n", err)
+			os.Exit(1)
+		}
+
+		fmt.Println("Chore skipped successfully")
+	},
+}
+
+var choreClaimCmd = &cobra.Command{
+	Use:   "claim",
+	Short: "Claim an up-for-grabs chore",
+	Run: func(cmd *cobra.Command, args []string) {
+		requireFrameID()
+
+		client := getClient()
+
+		chore, err := client.ClaimChore(frameID, choreID, choreAssigneeID)
+		if err != nil {
+			fmt.Printf("Error claiming chore: %v\n", err)
+			os.Exit(1)
+		}
+
+		printJSON(chore)
+	},
+}
+
 func init() {
 	choreCmd.AddCommand(choreListCmd)
 	choreCmd.AddCommand(choreCreateCmd)
 	choreCmd.AddCommand(choreUpdateCmd)
 	choreCmd.AddCommand(choreDeleteCmd)
 	choreCmd.AddCommand(choreCompleteCmd)
+	choreCmd.AddCommand(choreSkipCmd)
+	choreCmd.AddCommand(choreClaimCmd)
 
 	choreListCmd.Flags().StringVar(&choreDate, "date", "", "Date filter")
 	choreListCmd.Flags().StringVar(&choreStatus, "status", "", "Status filter")
@@ -160,12 +208,14 @@ func init() {
 	choreListCmd.Flags().StringVar(&choreAfter, "after", "", "After date filter")
 	choreListCmd.Flags().StringVar(&choreBefore, "before", "", "Before date filter")
 	choreListCmd.Flags().BoolVar(&choreIncludeLate, "include-late", false, "Include late chores")
+	choreListCmd.Flags().BoolVar(&choreUpForGrabs, "up-for-grabs", false, "Only show up-for-grabs chores")
 
 	choreCreateCmd.Flags().StringVar(&choreTitle, "title", "", "Chore title")
 	choreCreateCmd.Flags().StringVar(&choreDate, "date", "", "Due date")
 	choreCreateCmd.Flags().StringVar(&choreAssigneeID, "assignee-id", "", "Assignee ID")
 	choreCreateCmd.Flags().IntVar(&chorePoints, "points", 0, "Points value")
 	choreCreateCmd.Flags().BoolVar(&choreRecurring, "recurring", false, "Make chore recurring")
+	choreCreateCmd.Flags().BoolVar(&choreUpForGrabs, "up-for-grabs", false, "Make chore claimable by anyone")
 	choreCreateCmd.MarkFlagRequired("title") //nolint:errcheck
 
 	choreUpdateCmd.Flags().StringVar(&choreID, "chore-id", "", "Chore ID to update")
@@ -179,4 +229,12 @@ func init() {
 
 	choreCompleteCmd.Flags().StringVar(&choreID, "chore-id", "", "Chore ID to complete")
 	choreCompleteCmd.MarkFlagRequired("chore-id") //nolint:errcheck
+
+	choreSkipCmd.Flags().StringVar(&choreID, "chore-id", "", "Chore ID to skip")
+	choreSkipCmd.MarkFlagRequired("chore-id") //nolint:errcheck
+
+	choreClaimCmd.Flags().StringVar(&choreID, "chore-id", "", "Chore ID to claim")
+	choreClaimCmd.Flags().StringVar(&choreAssigneeID, "assignee-id", "", "Family member ID claiming the chore")
+	choreClaimCmd.MarkFlagRequired("chore-id")    //nolint:errcheck
+	choreClaimCmd.MarkFlagRequired("assignee-id") //nolint:errcheck
 }

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -216,6 +216,8 @@ func TestChoreSubcommands(t *testing.T) {
 		"create":   false,
 		"delete":   false,
 		"complete": false,
+		"skip":     false,
+		"claim":    false,
 	}
 
 	for _, cmd := range subcommands {
@@ -244,6 +246,7 @@ func TestChoreListFlags(t *testing.T) {
 		{"after flag", "after"},
 		{"before flag", "before"},
 		{"include-late flag", "include-late"},
+		{"up-for-grabs flag", "up-for-grabs"},
 	}
 
 	for _, tt := range tests {
@@ -268,6 +271,7 @@ func TestChoreCreateFlags(t *testing.T) {
 		{"assignee-id flag", "assignee-id"},
 		{"points flag", "points"},
 		{"recurring flag", "recurring"},
+		{"up-for-grabs flag", "up-for-grabs"},
 	}
 
 	for _, tt := range tests {
@@ -291,6 +295,22 @@ func TestChoreCompleteFlags(t *testing.T) {
 	f := choreCompleteCmd.Flags().Lookup("chore-id")
 	if f == nil {
 		t.Error("Expected flag 'chore-id' on chore complete command")
+	}
+}
+
+func TestChoreSkipFlags(t *testing.T) {
+	f := choreSkipCmd.Flags().Lookup("chore-id")
+	if f == nil {
+		t.Error("Expected flag 'chore-id' on chore skip command")
+	}
+}
+
+func TestChoreClaimFlags(t *testing.T) {
+	flags := choreClaimCmd.Flags()
+	for _, name := range []string{"chore-id", "assignee-id"} {
+		if flags.Lookup(name) == nil {
+			t.Errorf("Expected flag %q on chore claim command", name)
+		}
 	}
 }
 

--- a/lib/bounty_test.go
+++ b/lib/bounty_test.go
@@ -35,6 +35,7 @@ func TestCreateBounty(t *testing.T) {
 							Start        string `json:"start"`
 							RewardPoints int    `json:"reward_points"`
 							Recurring    bool   `json:"recurring"`
+							UpForGrabs   bool   `json:"up_for_grabs"`
 						}{Summary: "Task", RewardPoints: 5}},
 					}); err != nil {
 						http.Error(w, err.Error(), http.StatusInternalServerError)
@@ -87,6 +88,7 @@ func TestCreateBounty(t *testing.T) {
 							Start        string `json:"start"`
 							RewardPoints int    `json:"reward_points"`
 							Recurring    bool   `json:"recurring"`
+							UpForGrabs   bool   `json:"up_for_grabs"`
 						}{Summary: "Task", RewardPoints: 5}},
 					}); err != nil {
 						http.Error(w, err.Error(), http.StatusInternalServerError)
@@ -138,6 +140,7 @@ func TestCreateBounty(t *testing.T) {
 								Start        string `json:"start"`
 								RewardPoints int    `json:"reward_points"`
 								Recurring    bool   `json:"recurring"`
+								UpForGrabs   bool   `json:"up_for_grabs"`
 							}{Summary: "Do dishes", RewardPoints: 10},
 						},
 					}); err != nil {
@@ -214,6 +217,7 @@ func TestCreateBountyCleanupOnRewardFailure(t *testing.T) {
 						Start        string `json:"start"`
 						RewardPoints int    `json:"reward_points"`
 						Recurring    bool   `json:"recurring"`
+						UpForGrabs   bool   `json:"up_for_grabs"`
 					}{Summary: "Test"},
 				},
 			}); err != nil {
@@ -388,6 +392,7 @@ func TestListBounties(t *testing.T) {
 								Start        string `json:"start"`
 								RewardPoints int    `json:"reward_points"`
 								Recurring    bool   `json:"recurring"`
+								UpForGrabs   bool   `json:"up_for_grabs"`
 							}{Summary: "Task A", Status: "pending", RewardPoints: 10}},
 							{ID: "ch2", Attributes: struct {
 								Summary      string `json:"summary"`
@@ -395,6 +400,7 @@ func TestListBounties(t *testing.T) {
 								Start        string `json:"start"`
 								RewardPoints int    `json:"reward_points"`
 								Recurring    bool   `json:"recurring"`
+								UpForGrabs   bool   `json:"up_for_grabs"`
 							}{Summary: "Task B", Status: "pending", RewardPoints: 0}},
 						},
 					}); err != nil {

--- a/lib/chore.go
+++ b/lib/chore.go
@@ -1,8 +1,39 @@
 package lib
 
-import "fmt"
+import (
+	"fmt"
+	"regexp"
+)
 
-const choreStatusPending = "pending"
+const (
+	choreStatusPending = "pending"
+	paramTrue          = "true"
+)
+
+// choreIDRe matches composite chore IDs like "18731133-2026-04-28" or "70190003-2026-04-28-0600".
+var choreIDRe = regexp.MustCompile(`^(\d+)-(\d{4}-\d{2}-\d{2})`)
+
+// parseChoreID splits a composite chore ID into its base numeric ID and instance date.
+// For non-recurring chores with plain numeric IDs, instanceDate is empty.
+func parseChoreID(choreID string) (baseID, instanceDate string) {
+	if m := choreIDRe.FindStringSubmatch(choreID); m != nil {
+		return m[1], m[2]
+	}
+	return choreID, ""
+}
+
+// setCompletion calls the chore completions endpoint with the given status.
+func (c *Client) setCompletion(frameID, choreID, status string) error {
+	baseID, instanceDate := parseChoreID(choreID)
+	body := ChoreCompletionData{Status: status, InstanceDate: instanceDate}
+	req, err := newRequestWithBody("PUT",
+		fmt.Sprintf("%s/frames/%s/chores/%s/completions", c.effectiveURL(), frameID, baseID), body)
+	if err != nil {
+		return fmt.Errorf("failed to create completion request: %w", err)
+	}
+	var result choreAPISingleResponse
+	return c.put(req, &result)
+}
 
 // ListChores retrieves chores for a frame with optional filters.
 func (c *Client) ListChores(frameID string, opts ChoreListOptions) ([]Chore, error) {
@@ -28,7 +59,11 @@ func (c *Client) ListChores(frameID string, opts ChoreListOptions) ([]Chore, err
 		params["before"] = opts.Before
 	}
 	if opts.IncludeLate {
-		params["include_late"] = "true"
+		params["include_late"] = paramTrue
+	}
+	if opts.UpForGrabs {
+		params["include_up_for_grabs"] = paramTrue
+		params["filter"] = "linked_to_profile"
 	}
 	if len(params) > 0 {
 		addQueryParams(req, params)
@@ -63,6 +98,27 @@ func (c *Client) CreateChore(frameID string, chore ChoreData) (*Chore, error) {
 	return &result, nil
 }
 
+// CreateUpForGrabsChore creates a shared chore that anyone can claim, using the
+// create_multiple endpoint which accepts up_for_grabs without a category_id.
+func (c *Client) CreateUpForGrabsChore(frameID string, chore ChoreData) (*Chore, error) {
+	chore.UpForGrabs = true
+	req, err := newRequestWithBody("POST", fmt.Sprintf("%s/frames/%s/chores/create_multiple", c.effectiveURL(), frameID), chore)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create up-for-grabs chore request: %w", err)
+	}
+
+	var apiResp choreAPIResponse
+	if err := c.post(req, &apiResp); err != nil {
+		return nil, fmt.Errorf("failed to create up-for-grabs chore: %w", err)
+	}
+	if len(apiResp.Data) == 0 {
+		return nil, fmt.Errorf("no chore returned from create_multiple")
+	}
+
+	result := apiResp.Data[0].toChore()
+	return &result, nil
+}
+
 // UpdateChore updates an existing chore.
 func (c *Client) UpdateChore(frameID, choreID string, chore ChoreData) (*Chore, error) {
 	req, err := newRequestWithBody("PUT", fmt.Sprintf("%s/frames/%s/chores/%s", c.effectiveURL(), frameID, choreID), chore)
@@ -77,6 +133,21 @@ func (c *Client) UpdateChore(frameID, choreID string, chore ChoreData) (*Chore, 
 
 	result := apiResp.Data.toChore()
 	return &result, nil
+}
+
+// SkipChore skips a single instance of a recurring chore.
+func (c *Client) SkipChore(frameID, choreID string) error {
+	return c.setCompletion(frameID, choreID, "skipped")
+}
+
+// CompleteChore marks a chore instance as completed via the completions endpoint.
+func (c *Client) CompleteChore(frameID, choreID string) error {
+	return c.setCompletion(frameID, choreID, "completed")
+}
+
+// ClaimChore assigns an up-for-grabs chore to the given assignee.
+func (c *Client) ClaimChore(frameID, choreID, assigneeID string) (*Chore, error) {
+	return c.UpdateChore(frameID, choreID, ChoreData{AssigneeID: assigneeID})
 }
 
 // DeleteChore deletes a chore.

--- a/lib/chore_test.go
+++ b/lib/chore_test.go
@@ -250,6 +250,336 @@ func TestUpdateChore(t *testing.T) {
 	}
 }
 
+func TestSkipChore(t *testing.T) {
+	tests := []struct {
+		name    string
+		choreID string
+		status  int
+		wantErr bool
+	}{
+		{
+			name:    "skips recurring chore via completions endpoint",
+			choreID: "18731133-2026-04-28",
+			status:  http.StatusOK,
+		},
+		{
+			name:    "skips non-recurring chore (plain ID)",
+			choreID: "12345",
+			status:  http.StatusOK,
+		},
+		{
+			name:    "server error returns error",
+			choreID: "18731133-2026-04-28",
+			status:  http.StatusInternalServerError,
+			wantErr: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			baseID, instanceDate := parseChoreID(tc.choreID)
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if r.Method != http.MethodPut {
+					t.Errorf("expected PUT, got %s", r.Method)
+				}
+				wantPath := "/api/frames/frame1/chores/" + baseID + "/completions"
+				if r.URL.Path != wantPath {
+					t.Errorf("path: want %q got %q", wantPath, r.URL.Path)
+				}
+				var raw map[string]any
+				if err := json.NewDecoder(r.Body).Decode(&raw); err != nil {
+					t.Errorf("decode body: %v", err)
+				}
+				if raw["status"] != "skipped" {
+					t.Errorf("status: want %q got %v", "skipped", raw["status"])
+				}
+				if instanceDate != "" && raw["instance_date"] != instanceDate {
+					t.Errorf("instance_date: want %q got %v", instanceDate, raw["instance_date"])
+				}
+				w.Header().Set("Content-Type", "application/json")
+				w.WriteHeader(tc.status)
+				if tc.status == http.StatusOK {
+					if _, err := w.Write([]byte(`{"data":{"id":"` + baseID + `","attributes":{"status":"skipped"}}}`)); err != nil {
+						t.Errorf("write: %v", err)
+					}
+				}
+			}))
+			defer srv.Close()
+
+			old := SkylightURL
+			SkylightURL = srv.URL + "/api"
+			defer func() { SkylightURL = old }()
+
+			client, _ := NewClientWithToken("u", "t")
+			err := client.SkipChore("frame1", tc.choreID)
+			if (err != nil) != tc.wantErr {
+				t.Fatalf("wantErr=%v got %v", tc.wantErr, err)
+			}
+		})
+	}
+}
+
+func TestClaimChore(t *testing.T) {
+	tests := []struct {
+		name       string
+		assigneeID string
+		status     int
+		wantErr    bool
+	}{
+		{
+			name:       "claims chore by setting assignee",
+			assigneeID: "member1",
+			status:     http.StatusOK,
+		},
+		{
+			name:       "server error returns error",
+			assigneeID: "member1",
+			status:     http.StatusInternalServerError,
+			wantErr:    true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if r.Method != http.MethodPut {
+					t.Errorf("expected PUT, got %s", r.Method)
+				}
+				if r.URL.Path != "/api/frames/frame1/chores/chore1" {
+					t.Errorf("unexpected path: %s", r.URL.Path)
+				}
+				var raw map[string]any
+				if err := json.NewDecoder(r.Body).Decode(&raw); err != nil {
+					t.Errorf("decode body: %v", err)
+				}
+				if raw["category_id"] != tc.assigneeID {
+					t.Errorf("category_id: want %q got %v", tc.assigneeID, raw["category_id"])
+				}
+				w.Header().Set("Content-Type", "application/json")
+				w.WriteHeader(tc.status)
+				if tc.status == http.StatusOK {
+					resp := `{"data":{"id":"chore1","attributes":{"summary":"Clean room"},"relationships":{"category":{"data":{"id":"member1"}}}}}`
+					if _, err := w.Write([]byte(resp)); err != nil {
+						t.Errorf("write: %v", err)
+					}
+				}
+			}))
+			defer srv.Close()
+
+			old := SkylightURL
+			SkylightURL = srv.URL + "/api"
+			defer func() { SkylightURL = old }()
+
+			client, _ := NewClientWithToken("u", "t")
+			chore, err := client.ClaimChore("frame1", "chore1", tc.assigneeID)
+			if (err != nil) != tc.wantErr {
+				t.Fatalf("wantErr=%v got %v", tc.wantErr, err)
+			}
+			if !tc.wantErr && chore.AssigneeID != tc.assigneeID {
+				t.Errorf("AssigneeID: want %q got %q", tc.assigneeID, chore.AssigneeID)
+			}
+		})
+	}
+}
+
+func TestListChoresUpForGrabs(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Query().Get("include_up_for_grabs") != "true" {
+			t.Errorf("expected include_up_for_grabs=true query param")
+		}
+		if r.URL.Query().Get("filter") != "linked_to_profile" {
+			t.Errorf("expected filter=linked_to_profile query param")
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		resp := `{"data":[{"id":"1","attributes":{"summary":"Wash car","up_for_grabs":true}}]}`
+		if _, err := w.Write([]byte(resp)); err != nil {
+			t.Errorf("write: %v", err)
+		}
+	}))
+	defer srv.Close()
+
+	old := SkylightURL
+	SkylightURL = srv.URL + "/api"
+	defer func() { SkylightURL = old }()
+
+	client, _ := NewClientWithToken("u", "t")
+	chores, err := client.ListChores("frame1", ChoreListOptions{UpForGrabs: true})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(chores) != 1 {
+		t.Fatalf("want 1 chore, got %d", len(chores))
+	}
+	if !chores[0].UpForGrabs {
+		t.Errorf("expected UpForGrabs=true on returned chore")
+	}
+}
+
+func TestCreateUpForGrabsChore(t *testing.T) {
+	tests := []struct {
+		name      string
+		input     ChoreData
+		status    int
+		response  string
+		wantTitle string
+		wantErr   bool
+	}{
+		{
+			name:      "creates up-for-grabs chore via create_multiple",
+			input:     ChoreData{Title: "Pet the cats", DueDate: "2026-04-28"},
+			status:    http.StatusOK,
+			response:  `{"data":[{"id":"99","attributes":{"summary":"Pet the cats","up_for_grabs":true}}]}`,
+			wantTitle: "Pet the cats",
+		},
+		{
+			name:    "server error returns error",
+			input:   ChoreData{Title: "Test"},
+			status:  http.StatusInternalServerError,
+			wantErr: true,
+		},
+		{
+			name:     "empty data returns error",
+			input:    ChoreData{Title: "Test"},
+			status:   http.StatusOK,
+			response: `{"data":[]}`,
+			wantErr:  true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if r.Method != http.MethodPost {
+					t.Errorf("expected POST, got %s", r.Method)
+				}
+				if r.URL.Path != "/api/frames/frame1/chores/create_multiple" {
+					t.Errorf("unexpected path: %s", r.URL.Path)
+				}
+				var raw map[string]any
+				if err := json.NewDecoder(r.Body).Decode(&raw); err != nil {
+					t.Errorf("decode body: %v", err)
+				}
+				if raw["up_for_grabs"] != true {
+					t.Errorf("up_for_grabs: want true got %v", raw["up_for_grabs"])
+				}
+				w.Header().Set("Content-Type", "application/json")
+				w.WriteHeader(tc.status)
+				if tc.response != "" {
+					if _, err := w.Write([]byte(tc.response)); err != nil {
+						t.Errorf("write: %v", err)
+					}
+				}
+			}))
+			defer srv.Close()
+
+			old := SkylightURL
+			SkylightURL = srv.URL + "/api"
+			defer func() { SkylightURL = old }()
+
+			client, _ := NewClientWithToken("u", "t")
+			chore, err := client.CreateUpForGrabsChore("frame1", tc.input)
+			if (err != nil) != tc.wantErr {
+				t.Fatalf("wantErr=%v got %v", tc.wantErr, err)
+			}
+			if !tc.wantErr && chore.Title != tc.wantTitle {
+				t.Errorf("Title: want %q got %q", tc.wantTitle, chore.Title)
+			}
+		})
+	}
+}
+
+func TestParseChoreID(t *testing.T) {
+	tests := []struct {
+		input        string
+		wantBase     string
+		wantInstance string
+	}{
+		{"18731133-2026-04-28", "18731133", "2026-04-28"},
+		{"70190003-2026-04-28-0600", "70190003", "2026-04-28"},
+		{"12345", "12345", ""},
+		{"abc", "abc", ""},
+	}
+	for _, tc := range tests {
+		base, inst := parseChoreID(tc.input)
+		if base != tc.wantBase {
+			t.Errorf("parseChoreID(%q) base=%q, want %q", tc.input, base, tc.wantBase)
+		}
+		if inst != tc.wantInstance {
+			t.Errorf("parseChoreID(%q) instance=%q, want %q", tc.input, inst, tc.wantInstance)
+		}
+	}
+}
+
+func TestCompleteChore(t *testing.T) {
+	tests := []struct {
+		name    string
+		choreID string
+		status  int
+		wantErr bool
+	}{
+		{
+			name:    "completes recurring chore",
+			choreID: "18731133-2026-04-28",
+			status:  http.StatusOK,
+		},
+		{
+			name:    "completes non-recurring chore",
+			choreID: "12345",
+			status:  http.StatusOK,
+		},
+		{
+			name:    "server error returns error",
+			choreID: "18731133-2026-04-28",
+			status:  http.StatusInternalServerError,
+			wantErr: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			baseID, instanceDate := parseChoreID(tc.choreID)
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if r.Method != http.MethodPut {
+					t.Errorf("expected PUT, got %s", r.Method)
+				}
+				wantPath := "/api/frames/frame1/chores/" + baseID + "/completions"
+				if r.URL.Path != wantPath {
+					t.Errorf("path: want %q got %q", wantPath, r.URL.Path)
+				}
+				var raw map[string]any
+				if err := json.NewDecoder(r.Body).Decode(&raw); err != nil {
+					t.Errorf("decode body: %v", err)
+				}
+				if raw["status"] != "completed" {
+					t.Errorf("status: want %q got %v", "completed", raw["status"])
+				}
+				if instanceDate != "" && raw["instance_date"] != instanceDate {
+					t.Errorf("instance_date: want %q got %v", instanceDate, raw["instance_date"])
+				}
+				w.Header().Set("Content-Type", "application/json")
+				w.WriteHeader(tc.status)
+				if tc.status == http.StatusOK {
+					if _, err := w.Write([]byte(`{"data":{"id":"` + baseID + `","attributes":{"status":"completed"}}}`)); err != nil {
+						t.Errorf("write: %v", err)
+					}
+				}
+			}))
+			defer srv.Close()
+
+			old := SkylightURL
+			SkylightURL = srv.URL + "/api"
+			defer func() { SkylightURL = old }()
+
+			client, _ := NewClientWithToken("u", "t")
+			err := client.CompleteChore("frame1", tc.choreID)
+			if (err != nil) != tc.wantErr {
+				t.Fatalf("wantErr=%v got %v", tc.wantErr, err)
+			}
+		})
+	}
+}
+
 func TestDeleteChore(t *testing.T) {
 	tests := []struct {
 		name    string

--- a/lib/rotation_test.go
+++ b/lib/rotation_test.go
@@ -32,6 +32,7 @@ func TestCreateChoreRotation(t *testing.T) {
 					Start        string `json:"start"`
 					RewardPoints int    `json:"reward_points"`
 					Recurring    bool   `json:"recurring"`
+					UpForGrabs   bool   `json:"up_for_grabs"`
 				}{
 					Summary: body["summary"].(string),
 					Start:   body["start"].(string),
@@ -114,6 +115,7 @@ func TestCreateChoreRotationPartialFailure(t *testing.T) {
 					Start        string `json:"start"`
 					RewardPoints int    `json:"reward_points"`
 					Recurring    bool   `json:"recurring"`
+					UpForGrabs   bool   `json:"up_for_grabs"`
 				}{Summary: "Task"},
 			},
 		}); err != nil {

--- a/lib/structs.go
+++ b/lib/structs.go
@@ -146,6 +146,7 @@ type Chore struct {
 	Points     int    `json:"points,omitempty"`
 	Recurring  bool   `json:"recurring"`
 	AssigneeID string `json:"assignee_id,omitempty"`
+	UpForGrabs bool   `json:"up_for_grabs,omitempty"`
 }
 
 // choreAPIResponse wraps the JSON-API envelope for chore list responses.
@@ -162,6 +163,7 @@ type choreAPIEntry struct {
 		Start        string `json:"start"`
 		RewardPoints int    `json:"reward_points"`
 		Recurring    bool   `json:"recurring"`
+		UpForGrabs   bool   `json:"up_for_grabs"`
 	} `json:"attributes"`
 	Relationships struct {
 		Category struct {
@@ -178,12 +180,13 @@ type choreAPISingleResponse struct {
 // toChore converts a JSON-API chore entry to a flat Chore struct.
 func (e *choreAPIEntry) toChore() Chore {
 	c := Chore{
-		ID:        e.ID,
-		Title:     e.Attributes.Summary,
-		Status:    e.Attributes.Status,
-		DueDate:   e.Attributes.Start,
-		Points:    e.Attributes.RewardPoints,
-		Recurring: e.Attributes.Recurring,
+		ID:         e.ID,
+		Title:      e.Attributes.Summary,
+		Status:     e.Attributes.Status,
+		DueDate:    e.Attributes.Start,
+		Points:     e.Attributes.RewardPoints,
+		Recurring:  e.Attributes.Recurring,
+		UpForGrabs: e.Attributes.UpForGrabs,
 	}
 	if e.Relationships.Category.Data != nil {
 		c.AssigneeID = e.Relationships.Category.Data.ID
@@ -200,6 +203,7 @@ type ChoreData struct {
 	Status     string `json:"status,omitempty"`
 	AssigneeID string `json:"category_id,omitempty"`
 	Recurring  bool   `json:"recurring,omitempty"`
+	UpForGrabs bool   `json:"up_for_grabs,omitempty"`
 }
 
 // List represents a list (e.g., grocery list, todo list).
@@ -296,7 +300,7 @@ func (e *listItemAPIEntry) toListItem() ListItem {
 		ID:        e.ID,
 		Title:     e.Attributes.Label,
 		Status:    e.Attributes.Status,
-		Completed: e.Attributes.Status == "completed",
+		Completed: e.Attributes.Status == listItemStatusCompleted,
 		Position:  e.Attributes.Position,
 	}
 }
@@ -380,6 +384,12 @@ type RewardData struct {
 	CategoryIDs         []int  `json:"category_ids,omitempty"`
 }
 
+// ChoreCompletionData is the request body for the chore completions endpoint.
+type ChoreCompletionData struct {
+	Status       string `json:"status"`
+	InstanceDate string `json:"instance_date,omitempty"`
+}
+
 // ChoreListOptions holds optional filters for listing chores.
 type ChoreListOptions struct {
 	Date        string
@@ -388,6 +398,7 @@ type ChoreListOptions struct {
 	After       string
 	Before      string
 	IncludeLate bool
+	UpForGrabs  bool
 }
 
 // RewardPointEntry represents a per-category point balance.


### PR DESCRIPTION
## Summary

- **Up For Grabs**: Create unassigned claimable chores via the `create_multiple` endpoint (`POST /frames/{id}/chores/create_multiple`), list them with `--up-for-grabs`, and claim them with `chore claim --chore-id ID --assignee-id ID`
- **Skip Tasks**: Skip a single recurring chore instance via `chore skip --chore-id ID`, using the `/completions` endpoint with `status: skipped` and an `instance_date` parsed from composite chore IDs (e.g. `18731133-2026-04-28`)
- **Complete Chore**: Migrated `CompleteChore` from `UpdateChore` to the same `/completions` endpoint to match actual Skylight API behavior
- **Cleanup**: Removed unused `Routine` field from `ChoreData`; used existing `listItemStatusCompleted` constant to fix goconst lint

## Test plan

- [ ] `make test` — all tests pass (new: `TestParseChoreID`, `TestCompleteChore`, `TestSkipChore`, `TestClaimChore`, `TestListChoresUpForGrabs`, `TestCreateUpForGrabsChore`, plus cmd flag/subcommand tests)
- [ ] `make lint` — 0 issues
- [ ] Manual: `skylight chore create --frame-id ID --title "Test" --up-for-grabs`
- [ ] Manual: `skylight chore list --frame-id ID --up-for-grabs`
- [ ] Manual: `skylight chore claim --frame-id ID --chore-id ID --assignee-id MEMBER_ID`
- [ ] Manual: `skylight chore skip --frame-id ID --chore-id 18731133-2026-04-28`