### PR TITLE
feat: filter and auto-date up-for-grabs chore listing

### DIFF
--- a/lib/chore.go
+++ b/lib/chore.go
@@ -3,6 +3,7 @@ package lib
 import (
 	"fmt"
 	"regexp"
+	"time"
 )
 
 const (
@@ -35,13 +36,7 @@ func (c *Client) setCompletion(frameID, choreID, status string) error {
 	return c.put(req, &result)
 }
 
-// ListChores retrieves chores for a frame with optional filters.
-func (c *Client) ListChores(frameID string, opts ChoreListOptions) ([]Chore, error) {
-	req, err := newRequest("GET", fmt.Sprintf("%s/frames/%s/chores", c.effectiveURL(), frameID))
-	if err != nil {
-		return nil, fmt.Errorf("failed to create list chores request: %w", err)
-	}
-
+func (opts ChoreListOptions) queryParams() map[string]string {
 	params := map[string]string{}
 	if opts.Date != "" {
 		params["date"] = opts.Date
@@ -64,8 +59,24 @@ func (c *Client) ListChores(frameID string, opts ChoreListOptions) ([]Chore, err
 	if opts.UpForGrabs {
 		params["include_up_for_grabs"] = paramTrue
 		params["filter"] = "linked_to_profile"
+		if opts.After == "" {
+			params["after"] = time.Now().Format("2006-01-02")
+		}
+		if opts.Before == "" {
+			params["before"] = time.Now().AddDate(0, 0, 7).Format("2006-01-02")
+		}
 	}
-	if len(params) > 0 {
+	return params
+}
+
+// ListChores retrieves chores for a frame with optional filters.
+func (c *Client) ListChores(frameID string, opts ChoreListOptions) ([]Chore, error) {
+	req, err := newRequest("GET", fmt.Sprintf("%s/frames/%s/chores", c.effectiveURL(), frameID))
+	if err != nil {
+		return nil, fmt.Errorf("failed to create list chores request: %w", err)
+	}
+
+	if params := opts.queryParams(); len(params) > 0 {
 		addQueryParams(req, params)
 	}
 
@@ -74,9 +85,13 @@ func (c *Client) ListChores(frameID string, opts ChoreListOptions) ([]Chore, err
 		return nil, fmt.Errorf("failed to list chores: %w", err)
 	}
 
-	chores := make([]Chore, len(apiResp.Data))
+	chores := make([]Chore, 0, len(apiResp.Data))
 	for i := range apiResp.Data {
-		chores[i] = apiResp.Data[i].toChore()
+		c := apiResp.Data[i].toChore()
+		if opts.UpForGrabs && !c.UpForGrabs {
+			continue
+		}
+		chores = append(chores, c)
 	}
 
 	return chores, nil


### PR DESCRIPTION
## Summary

- **Client-side filter**: --up-for-grabs now only returns chores with up_for_grabs=true instead of all chores (the API include_up_for_grabs param includes them alongside regular chores, it does not filter)
- **Auto date range**: When --up-for-grabs is used without --after/--before, defaults to today + 7 days so the API does not reject the request with a 422
- **Refactor**: Extract queryParams() method from ListChores to reduce cyclomatic complexity

## Usage

Before (required date range):
```
skylight chore list --up-for-grabs --after 2026-04-28 --before 2026-05-05
```

After (just works):
```
skylight chore list --up-for-grabs
```

## Test plan

- [x] make test — all tests pass
- [x] make lint — 0 issues
- [x] Manual: skylight chore list --up-for-grabs returns only up-for-grabs chores
- [x] Manual: skylight chore list --up-for-grabs --after X --before Y still respects explicit dates
- [x] Manual: skylight chore list (without flag) unchanged behavior