### PR TITLE
feat: add chore streak command for completion stats

### DIFF
--- a/cmd/chore_streak.go
+++ b/cmd/chore_streak.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"sort"
+	"sync"
 	"time"
 
 	"github.com/sebrandon1/go-skylight/lib"
@@ -131,24 +132,41 @@ for a given member are ignored and do not break streaks.`,
 		end := now.Format("2006-01-02")
 		start := now.AddDate(0, 0, -(streakDays - 1)).Format("2006-01-02")
 
-		categories, err := client.ListCategories(frameID)
-		if err != nil {
-			fmt.Printf("Error listing categories: %v\n", err)
+		var (
+			categories []lib.Category
+			catErr     error
+			chores     []lib.Chore
+			choreErr   error
+			wg         sync.WaitGroup
+		)
+
+		wg.Add(2)
+		go func() {
+			defer wg.Done()
+			categories, catErr = client.ListCategories(frameID)
+		}()
+		go func() {
+			defer wg.Done()
+			chores, choreErr = client.ListChores(frameID, lib.ChoreListOptions{
+				After:       start,
+				Before:      end,
+				IncludeLate: true,
+			})
+		}()
+		wg.Wait()
+
+		if catErr != nil {
+			fmt.Printf("Error listing categories: %v\n", catErr)
 			os.Exit(1)
 		}
+		if choreErr != nil {
+			fmt.Printf("Error listing chores: %v\n", choreErr)
+			os.Exit(1)
+		}
+
 		catNames := make(map[string]string, len(categories))
 		for _, c := range categories {
 			catNames[c.ID] = c.Name
-		}
-
-		chores, err := client.ListChores(frameID, lib.ChoreListOptions{
-			After:       start,
-			Before:      end,
-			IncludeLate: true,
-		})
-		if err != nil {
-			fmt.Printf("Error listing chores: %v\n", err)
-			os.Exit(1)
 		}
 
 		dates := make([]string, 0, streakDays)
@@ -158,11 +176,7 @@ for a given member are ignored and do not break streaks.`,
 
 		results := computeChoreStreaks(chores, dates, catNames)
 
-		if outputFormat == outputTable {
-			printChoreStreakTable(results)
-		} else {
-			printJSON(results)
-		}
+		printOutput(results)
 	},
 }
 

--- a/cmd/chore_streak.go
+++ b/cmd/chore_streak.go
@@ -1,0 +1,172 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+	"sort"
+	"time"
+
+	"github.com/sebrandon1/go-skylight/lib"
+	"github.com/spf13/cobra"
+)
+
+var streakDays int
+
+// ChoreStreakStats holds per-assignee chore completion statistics over a window.
+type ChoreStreakStats struct {
+	AssigneeID      string  `json:"assignee_id"`
+	AssigneeName    string  `json:"assignee_name"`
+	CurrentStreak   int     `json:"current_streak"`
+	LongestStreak   int     `json:"longest_streak"`
+	TotalChores     int     `json:"total_chores"`
+	CompletedChores int     `json:"completed_chores"`
+	CompletionRate  float64 `json:"completion_rate_pct"`
+}
+
+type choreDay struct {
+	date       string
+	assigneeID string
+}
+
+// computeChoreStreaks derives per-assignee streak stats from a flat chore list.
+// dates must be a sorted (ascending) slice of YYYY-MM-DD strings covering the window.
+// catNames maps category ID → display name; missing IDs fall back to the raw ID.
+// Days with no chores for a given assignee are skipped (they neither break nor extend streaks).
+func computeChoreStreaks(chores []lib.Chore, dates []string, catNames map[string]string) []ChoreStreakStats {
+	total := map[choreDay]int{}
+	done := map[choreDay]int{}
+	assigneeSet := map[string]bool{}
+
+	for _, c := range chores {
+		if c.AssigneeID == "" {
+			continue
+		}
+		key := choreDay{c.DueDate, c.AssigneeID}
+		total[key]++
+		if c.Status == "completed" {
+			done[key]++
+		}
+		assigneeSet[c.AssigneeID] = true
+	}
+
+	results := make([]ChoreStreakStats, 0, len(assigneeSet))
+	for aid := range assigneeSet {
+		var totalC, doneC, longestStreak, curStreak int
+
+		for _, date := range dates {
+			key := choreDay{date, aid}
+			t := total[key]
+			d := done[key]
+			totalC += t
+			doneC += d
+
+			if t == 0 {
+				continue
+			}
+			if d == t {
+				curStreak++
+				if curStreak > longestStreak {
+					longestStreak = curStreak
+				}
+			} else {
+				curStreak = 0
+			}
+		}
+
+		// Current streak: walk backwards from the most-recent date.
+		currentStreak := 0
+		for i := len(dates) - 1; i >= 0; i-- {
+			key := choreDay{dates[i], aid}
+			t := total[key]
+			if t == 0 {
+				continue
+			}
+			if done[key] == t {
+				currentStreak++
+			} else {
+				break
+			}
+		}
+
+		rate := 0.0
+		if totalC > 0 {
+			rate = float64(doneC) / float64(totalC) * 100
+		}
+
+		name := catNames[aid]
+		if name == "" {
+			name = aid
+		}
+		results = append(results, ChoreStreakStats{
+			AssigneeID:      aid,
+			AssigneeName:    name,
+			CurrentStreak:   currentStreak,
+			LongestStreak:   longestStreak,
+			TotalChores:     totalC,
+			CompletedChores: doneC,
+			CompletionRate:  rate,
+		})
+	}
+
+	sort.Slice(results, func(i, j int) bool {
+		return results[i].AssigneeName < results[j].AssigneeName
+	})
+
+	return results
+}
+
+var choreStreakCmd = &cobra.Command{
+	Use:   "streak",
+	Short: "Show chore completion streaks per family member",
+	Long: `Compute chore completion streaks and stats for each family member.
+
+Reports current streak, longest streak, and overall completion rate over
+the requested window (default: last 30 days). Days with no assigned chores
+for a given member are ignored and do not break streaks.`,
+	Run: func(cmd *cobra.Command, args []string) {
+		requireFrameID()
+		client := getClient()
+
+		now := time.Now()
+		end := now.Format("2006-01-02")
+		start := now.AddDate(0, 0, -(streakDays - 1)).Format("2006-01-02")
+
+		categories, err := client.ListCategories(frameID)
+		if err != nil {
+			fmt.Printf("Error listing categories: %v\n", err)
+			os.Exit(1)
+		}
+		catNames := make(map[string]string, len(categories))
+		for _, c := range categories {
+			catNames[c.ID] = c.Name
+		}
+
+		chores, err := client.ListChores(frameID, lib.ChoreListOptions{
+			After:       start,
+			Before:      end,
+			IncludeLate: true,
+		})
+		if err != nil {
+			fmt.Printf("Error listing chores: %v\n", err)
+			os.Exit(1)
+		}
+
+		dates := make([]string, 0, streakDays)
+		for i := -(streakDays - 1); i <= 0; i++ {
+			dates = append(dates, now.AddDate(0, 0, i).Format("2006-01-02"))
+		}
+
+		results := computeChoreStreaks(chores, dates, catNames)
+
+		if outputFormat == outputTable {
+			printChoreStreakTable(results)
+		} else {
+			printJSON(results)
+		}
+	},
+}
+
+func init() {
+	choreCmd.AddCommand(choreStreakCmd)
+	choreStreakCmd.Flags().IntVar(&streakDays, "days", 30, "Number of days to analyze (default 30)")
+}

--- a/cmd/chore_streak_test.go
+++ b/cmd/chore_streak_test.go
@@ -1,0 +1,169 @@
+package cmd
+
+import (
+	"testing"
+
+	"github.com/sebrandon1/go-skylight/lib"
+)
+
+func TestComputeChoreStreaks_Empty(t *testing.T) {
+	results := computeChoreStreaks(nil, []string{"2026-04-01"}, nil)
+	if len(results) != 0 {
+		t.Errorf("expected 0 results, got %d", len(results))
+	}
+}
+
+func TestComputeChoreStreaks_AllCompleted(t *testing.T) {
+	dates := []string{"2026-04-27", "2026-04-28", "2026-04-29"}
+	chores := []lib.Chore{
+		{AssigneeID: "1", DueDate: "2026-04-27", Status: "completed"},
+		{AssigneeID: "1", DueDate: "2026-04-28", Status: "completed"},
+		{AssigneeID: "1", DueDate: "2026-04-29", Status: "completed"},
+	}
+	catNames := map[string]string{"1": "Alice"}
+
+	results := computeChoreStreaks(chores, dates, catNames)
+	if len(results) != 1 {
+		t.Fatalf("expected 1 result, got %d", len(results))
+	}
+	s := results[0]
+	if s.CurrentStreak != 3 {
+		t.Errorf("CurrentStreak: want 3, got %d", s.CurrentStreak)
+	}
+	if s.LongestStreak != 3 {
+		t.Errorf("LongestStreak: want 3, got %d", s.LongestStreak)
+	}
+	if s.CompletionRate != 100.0 {
+		t.Errorf("CompletionRate: want 100.0, got %.2f", s.CompletionRate)
+	}
+	if s.AssigneeName != "Alice" {
+		t.Errorf("AssigneeName: want Alice, got %s", s.AssigneeName)
+	}
+}
+
+func TestComputeChoreStreaks_BrokenStreak(t *testing.T) {
+	dates := []string{"2026-04-27", "2026-04-28", "2026-04-29"}
+	chores := []lib.Chore{
+		{AssigneeID: "1", DueDate: "2026-04-27", Status: "completed"},
+		{AssigneeID: "1", DueDate: "2026-04-28", Status: "pending"},
+		{AssigneeID: "1", DueDate: "2026-04-29", Status: "completed"},
+	}
+
+	results := computeChoreStreaks(chores, dates, nil)
+	if len(results) != 1 {
+		t.Fatalf("expected 1 result, got %d", len(results))
+	}
+	s := results[0]
+	if s.CurrentStreak != 1 {
+		t.Errorf("CurrentStreak: want 1, got %d", s.CurrentStreak)
+	}
+	if s.LongestStreak != 1 {
+		t.Errorf("LongestStreak: want 1, got %d", s.LongestStreak)
+	}
+}
+
+func TestComputeChoreStreaks_SkipDaysWithNoChores(t *testing.T) {
+	// April 28 has no chores for assignee "1" — streak should not break.
+	dates := []string{"2026-04-27", "2026-04-28", "2026-04-29"}
+	chores := []lib.Chore{
+		{AssigneeID: "1", DueDate: "2026-04-27", Status: "completed"},
+		{AssigneeID: "1", DueDate: "2026-04-29", Status: "completed"},
+	}
+
+	results := computeChoreStreaks(chores, dates, nil)
+	if len(results) != 1 {
+		t.Fatalf("expected 1 result, got %d", len(results))
+	}
+	s := results[0]
+	// Both days with chores are complete, so current streak = 2, longest = 2
+	if s.CurrentStreak != 2 {
+		t.Errorf("CurrentStreak: want 2, got %d", s.CurrentStreak)
+	}
+	if s.LongestStreak != 2 {
+		t.Errorf("LongestStreak: want 2, got %d", s.LongestStreak)
+	}
+}
+
+func TestComputeChoreStreaks_MultipleAssignees(t *testing.T) {
+	dates := []string{"2026-04-27", "2026-04-28", "2026-04-29"}
+	chores := []lib.Chore{
+		{AssigneeID: "1", DueDate: "2026-04-27", Status: "completed"},
+		{AssigneeID: "1", DueDate: "2026-04-28", Status: "completed"},
+		{AssigneeID: "1", DueDate: "2026-04-29", Status: "completed"},
+		{AssigneeID: "2", DueDate: "2026-04-27", Status: "completed"},
+		{AssigneeID: "2", DueDate: "2026-04-28", Status: "pending"},
+		{AssigneeID: "2", DueDate: "2026-04-29", Status: "pending"},
+	}
+	catNames := map[string]string{"1": "Alice", "2": "Bob"}
+
+	results := computeChoreStreaks(chores, dates, catNames)
+	if len(results) != 2 {
+		t.Fatalf("expected 2 results, got %d", len(results))
+	}
+	// Results are sorted by name: Alice first, Bob second.
+	alice, bob := results[0], results[1]
+	if alice.AssigneeName != "Alice" {
+		t.Errorf("expected Alice first, got %s", alice.AssigneeName)
+	}
+	if alice.CurrentStreak != 3 || alice.LongestStreak != 3 {
+		t.Errorf("Alice streak: want 3/3, got %d/%d", alice.CurrentStreak, alice.LongestStreak)
+	}
+	if bob.CurrentStreak != 0 {
+		t.Errorf("Bob CurrentStreak: want 0, got %d", bob.CurrentStreak)
+	}
+	if bob.LongestStreak != 1 {
+		t.Errorf("Bob LongestStreak: want 1, got %d", bob.LongestStreak)
+	}
+}
+
+func TestComputeChoreStreaks_CompletionRate(t *testing.T) {
+	dates := []string{"2026-04-27", "2026-04-28"}
+	chores := []lib.Chore{
+		{AssigneeID: "1", DueDate: "2026-04-27", Status: "completed"},
+		{AssigneeID: "1", DueDate: "2026-04-27", Status: "completed"},
+		{AssigneeID: "1", DueDate: "2026-04-28", Status: "pending"},
+		{AssigneeID: "1", DueDate: "2026-04-28", Status: "pending"},
+	}
+
+	results := computeChoreStreaks(chores, dates, nil)
+	if len(results) != 1 {
+		t.Fatalf("expected 1 result, got %d", len(results))
+	}
+	s := results[0]
+	if s.TotalChores != 4 {
+		t.Errorf("TotalChores: want 4, got %d", s.TotalChores)
+	}
+	if s.CompletedChores != 2 {
+		t.Errorf("CompletedChores: want 2, got %d", s.CompletedChores)
+	}
+	if s.CompletionRate != 50.0 {
+		t.Errorf("CompletionRate: want 50.0, got %.2f", s.CompletionRate)
+	}
+}
+
+func TestComputeChoreStreaks_SkipsUnassigned(t *testing.T) {
+	dates := []string{"2026-04-29"}
+	chores := []lib.Chore{
+		{AssigneeID: "", DueDate: "2026-04-29", Status: "completed"},
+	}
+
+	results := computeChoreStreaks(chores, dates, nil)
+	if len(results) != 0 {
+		t.Errorf("expected 0 results for unassigned chores, got %d", len(results))
+	}
+}
+
+func TestComputeChoreStreaks_FallbackToID(t *testing.T) {
+	dates := []string{"2026-04-29"}
+	chores := []lib.Chore{
+		{AssigneeID: "99", DueDate: "2026-04-29", Status: "completed"},
+	}
+
+	results := computeChoreStreaks(chores, dates, map[string]string{})
+	if len(results) != 1 {
+		t.Fatalf("expected 1 result, got %d", len(results))
+	}
+	if results[0].AssigneeName != "99" {
+		t.Errorf("AssigneeName should fall back to ID, got %s", results[0].AssigneeName)
+	}
+}

--- a/cmd/helpers.go
+++ b/cmd/helpers.go
@@ -38,6 +38,9 @@ func printOutput(data any) {
 		case []lib.Category:
 			printCategoriesTable(v)
 			return
+		case []ChoreStreakStats:
+			printChoreStreakTable(v)
+			return
 		}
 	}
 	printJSON(data)
@@ -95,6 +98,16 @@ func printCategoriesTable(cats []lib.Category) {
 	fmt.Fprintln(w, "ID\tNAME\tCOLOR")
 	for _, c := range cats {
 		fmt.Fprintf(w, "%s\t%s\t%s\n", c.ID, c.Name, c.Color)
+	}
+	w.Flush()
+}
+
+func printChoreStreakTable(stats []ChoreStreakStats) {
+	w := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
+	fmt.Fprintln(w, "NAME\tCURRENT STREAK\tLONGEST STREAK\tCOMPLETED\tTOTAL\tRATE")
+	for _, s := range stats {
+		fmt.Fprintf(w, "%s\t%d days\t%d days\t%d\t%d\t%.1f%%\n",
+			s.AssigneeName, s.CurrentStreak, s.LongestStreak, s.CompletedChores, s.TotalChores, s.CompletionRate)
 	}
 	w.Flush()
 }


### PR DESCRIPTION
Closes #50

## Summary

- Adds `skylight chore streak [--days N]` (default 30 days) as a new subcommand of `chore`
- Fetches all chores for the window via existing `ListChores` with `After`/`Before` filters and `IncludeLate: true`
- Resolves category IDs to display names via `ListCategories`
- Computes per-family-member stats client-side: current streak, longest streak, completed/total chore counts, and completion rate percentage
- Days with no assigned chores for a member are skipped (do not break or extend streaks)
- Output honours `--output json|table`; table format added to `printOutput` dispatcher in `helpers.go`

## Test plan

- [ ] `make test` — all 8 new unit tests for `computeChoreStreaks` pass
- [ ] `make build` — binary builds cleanly
- [ ] `make lint` — no new lint issues introduced
- [ ] Manual: `skylight chore streak --frame-id <ID> --days 7` returns JSON array per family member
- [ ] Manual: `skylight chore streak --frame-id <ID> --output table` renders tabular output

🤖 Generated with [Claude Code](https://claude.com/claude-code)