### PR TITLE
feat: add --week flag to chore list for weekly calendar view

### DIFF
--- a/cmd/chore.go
+++ b/cmd/chore.go
@@ -20,6 +20,7 @@ var (
 	choreIncludeLate bool
 	choreRecurring   bool
 	choreUpForGrabs  bool
+	choreWeek        string
 )
 
 var choreCmd = &cobra.Command{
@@ -34,6 +35,31 @@ var choreListCmd = &cobra.Command{
 		requireFrameID()
 
 		client := getClient()
+
+		if cmd.Flags().Changed("week") {
+			monday, err := weekStart(choreWeek)
+			if err != nil {
+				fmt.Printf("Error: %v\n", err)
+				os.Exit(1)
+			}
+			sunday := monday.AddDate(0, 0, 6)
+			chores, err := client.ListChores(frameID, lib.ChoreListOptions{
+				After:       monday.Format("2006-01-02"),
+				Before:      sunday.Format("2006-01-02"),
+				IncludeLate: true,
+			})
+			if err != nil {
+				fmt.Printf("Error listing chores: %v\n", err)
+				os.Exit(1)
+			}
+			days := buildWeeklyView(chores, monday)
+			if outputFormat == outputTable {
+				printChoreWeekTable(days)
+			} else {
+				printJSON(days)
+			}
+			return
+		}
 
 		chores, err := client.ListChores(frameID, lib.ChoreListOptions{
 			Date:        choreDate,
@@ -209,6 +235,8 @@ func init() {
 	choreListCmd.Flags().StringVar(&choreBefore, "before", "", "Before date filter")
 	choreListCmd.Flags().BoolVar(&choreIncludeLate, "include-late", false, "Include late chores")
 	choreListCmd.Flags().BoolVar(&choreUpForGrabs, "up-for-grabs", false, "Only show up-for-grabs chores")
+	choreListCmd.Flags().StringVar(&choreWeek, "week", "", "Show weekly calendar view; optionally specify YYYY-MM-DD to select the week")
+	choreListCmd.Flags().Lookup("week").NoOptDefVal = "current"
 
 	choreCreateCmd.Flags().StringVar(&choreTitle, "title", "", "Chore title")
 	choreCreateCmd.Flags().StringVar(&choreDate, "date", "", "Due date")

--- a/cmd/chore.go
+++ b/cmd/chore.go
@@ -53,11 +53,7 @@ var choreListCmd = &cobra.Command{
 				os.Exit(1)
 			}
 			days := buildWeeklyView(chores, monday)
-			if outputFormat == outputTable {
-				printChoreWeekTable(days)
-			} else {
-				printJSON(days)
-			}
+			printOutput(days)
 			return
 		}
 

--- a/cmd/chore_week.go
+++ b/cmd/chore_week.go
@@ -12,9 +12,10 @@ import (
 
 // WeeklyChoreDay represents one day's chores in the weekly view.
 type WeeklyChoreDay struct {
-	Day    string      `json:"day"`
-	Date   string      `json:"date"`
-	Chores []lib.Chore `json:"chores"`
+	Day     string      `json:"day"`
+	Date    string      `json:"date"`
+	Display string      `json:"-"`
+	Chores  []lib.Chore `json:"chores"`
 }
 
 // weekStart returns the Monday of the week containing the given date string.
@@ -44,13 +45,14 @@ func buildWeeklyView(chores []lib.Chore, monday time.Time) []WeeklyChoreDay {
 	for i := 0; i < 7; i++ {
 		d := monday.AddDate(0, 0, i)
 		days[i] = WeeklyChoreDay{
-			Day:    d.Format("Mon"),
-			Date:   d.Format("2006-01-02"),
-			Chores: []lib.Chore{},
+			Day:     d.Format("Mon"),
+			Date:    d.Format("2006-01-02"),
+			Display: d.Format("Jan 02"),
+			Chores:  []lib.Chore{},
 		}
 	}
 
-	byDate := make(map[string][]lib.Chore, len(chores))
+	byDate := make(map[string][]lib.Chore, 7)
 	for _, c := range chores {
 		date := c.DueDate
 		if len(date) >= 10 {
@@ -73,14 +75,12 @@ func printChoreWeekTable(days []WeeklyChoreDay) {
 	w := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
 	fmt.Fprintln(w, "DAY\tDATE\tTITLE\tSTATUS")
 	for _, d := range days {
-		t, _ := time.Parse("2006-01-02", d.Date)
-		dateStr := t.Format("Jan 02")
 		if len(d.Chores) == 0 {
-			fmt.Fprintf(w, "%s\t%s\t%s\t%s\n", d.Day, dateStr, "(no chores)", "—")
+			fmt.Fprintf(w, "%s\t%s\t%s\t%s\n", d.Day, d.Display, "(no chores)", "—")
 			continue
 		}
 		for i, c := range d.Chores {
-			dayCol, dateCol := d.Day, dateStr
+			dayCol, dateCol := d.Day, d.Display
 			if i > 0 {
 				dayCol, dateCol = "", ""
 			}

--- a/cmd/chore_week.go
+++ b/cmd/chore_week.go
@@ -1,0 +1,95 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+	"sort"
+	"text/tabwriter"
+	"time"
+
+	"github.com/sebrandon1/go-skylight/lib"
+)
+
+// WeeklyChoreDay represents one day's chores in the weekly view.
+type WeeklyChoreDay struct {
+	Day    string      `json:"day"`
+	Date   string      `json:"date"`
+	Chores []lib.Chore `json:"chores"`
+}
+
+// weekStart returns the Monday of the week containing the given date string.
+// "current" or "" resolves to the current week.
+func weekStart(date string) (time.Time, error) {
+	var t time.Time
+	if date == "" || date == "current" {
+		t = time.Now()
+	} else {
+		var err error
+		t, err = time.Parse("2006-01-02", date)
+		if err != nil {
+			return time.Time{}, fmt.Errorf("invalid date %q: use YYYY-MM-DD format", date)
+		}
+	}
+	wd := int(t.Weekday())
+	if wd == 0 {
+		wd = 7 // Sunday = 7 in ISO week
+	}
+	monday := t.AddDate(0, 0, -(wd - 1))
+	return time.Date(monday.Year(), monday.Month(), monday.Day(), 0, 0, 0, 0, time.UTC), nil
+}
+
+// buildWeeklyView groups chores into Mon–Sun slots for the week starting on monday.
+func buildWeeklyView(chores []lib.Chore, monday time.Time) []WeeklyChoreDay {
+	days := make([]WeeklyChoreDay, 7)
+	for i := 0; i < 7; i++ {
+		d := monday.AddDate(0, 0, i)
+		days[i] = WeeklyChoreDay{
+			Day:    d.Format("Mon"),
+			Date:   d.Format("2006-01-02"),
+			Chores: []lib.Chore{},
+		}
+	}
+
+	byDate := make(map[string][]lib.Chore, len(chores))
+	for _, c := range chores {
+		date := c.DueDate
+		if len(date) >= 10 {
+			date = date[:10]
+		}
+		byDate[date] = append(byDate[date], c)
+	}
+
+	for i, day := range days {
+		if cs, ok := byDate[day.Date]; ok {
+			sort.Slice(cs, func(a, b int) bool { return cs[a].Title < cs[b].Title })
+			days[i].Chores = cs
+		}
+	}
+
+	return days
+}
+
+func printChoreWeekTable(days []WeeklyChoreDay) {
+	w := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
+	fmt.Fprintln(w, "DAY\tDATE\tTITLE\tSTATUS")
+	for _, d := range days {
+		t, _ := time.Parse("2006-01-02", d.Date)
+		dateStr := t.Format("Jan 02")
+		if len(d.Chores) == 0 {
+			fmt.Fprintf(w, "%s\t%s\t%s\t%s\n", d.Day, dateStr, "(no chores)", "—")
+			continue
+		}
+		for i, c := range d.Chores {
+			dayCol, dateCol := d.Day, dateStr
+			if i > 0 {
+				dayCol, dateCol = "", ""
+			}
+			status := "✗"
+			if c.Status == "completed" {
+				status = "✓"
+			}
+			fmt.Fprintf(w, "%s\t%s\t%s\t%s\n", dayCol, dateCol, c.Title, status)
+		}
+	}
+	w.Flush()
+}

--- a/cmd/chore_week_test.go
+++ b/cmd/chore_week_test.go
@@ -1,0 +1,129 @@
+package cmd
+
+import (
+	"testing"
+	"time"
+
+	"github.com/sebrandon1/go-skylight/lib"
+)
+
+func TestWeekStart_Current(t *testing.T) {
+	monday, err := weekStart("current")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if monday.Weekday() != time.Monday {
+		t.Errorf("expected Monday, got %s", monday.Weekday())
+	}
+}
+
+func TestWeekStart_Empty(t *testing.T) {
+	monday, err := weekStart("")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if monday.Weekday() != time.Monday {
+		t.Errorf("expected Monday, got %s", monday.Weekday())
+	}
+}
+
+func TestWeekStart_KnownMonday(t *testing.T) {
+	// 2026-04-27 is a Monday.
+	monday, err := weekStart("2026-04-27")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if monday.Format("2006-01-02") != "2026-04-27" {
+		t.Errorf("want 2026-04-27, got %s", monday.Format("2006-01-02"))
+	}
+}
+
+func TestWeekStart_MidWeek(t *testing.T) {
+	// 2026-04-29 is a Wednesday; its Monday is 2026-04-27.
+	monday, err := weekStart("2026-04-29")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if monday.Format("2006-01-02") != "2026-04-27" {
+		t.Errorf("want 2026-04-27, got %s", monday.Format("2006-01-02"))
+	}
+}
+
+func TestWeekStart_Sunday(t *testing.T) {
+	// 2026-05-03 is a Sunday; its Monday is 2026-04-27.
+	monday, err := weekStart("2026-05-03")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if monday.Format("2006-01-02") != "2026-04-27" {
+		t.Errorf("want 2026-04-27, got %s", monday.Format("2006-01-02"))
+	}
+}
+
+func TestWeekStart_InvalidDate(t *testing.T) {
+	_, err := weekStart("not-a-date")
+	if err == nil {
+		t.Error("expected error for invalid date, got nil")
+	}
+}
+
+func TestBuildWeeklyView_SlotCount(t *testing.T) {
+	monday, _ := weekStart("2026-04-27")
+	days := buildWeeklyView(nil, monday)
+	if len(days) != 7 {
+		t.Errorf("want 7 days, got %d", len(days))
+	}
+	if days[0].Day != "Mon" {
+		t.Errorf("first slot should be Mon, got %s", days[0].Day)
+	}
+	if days[6].Day != "Sun" {
+		t.Errorf("last slot should be Sun, got %s", days[6].Day)
+	}
+}
+
+func TestBuildWeeklyView_ChoresGroupedByDate(t *testing.T) {
+	monday, _ := weekStart("2026-04-27")
+	chores := []lib.Chore{
+		{ID: "1", Title: "Walk the dog", Status: "completed", DueDate: "2026-04-27"},
+		{ID: "2", Title: "Take out trash", Status: "pending", DueDate: "2026-04-28"},
+		{ID: "3", Title: "Feed the cat", Status: "completed", DueDate: "2026-04-28"},
+	}
+	days := buildWeeklyView(chores, monday)
+
+	if len(days[0].Chores) != 1 {
+		t.Errorf("Mon: want 1 chore, got %d", len(days[0].Chores))
+	}
+	if days[0].Chores[0].Title != "Walk the dog" {
+		t.Errorf("Mon chore: want 'Walk the dog', got %s", days[0].Chores[0].Title)
+	}
+	if len(days[1].Chores) != 2 {
+		t.Errorf("Tue: want 2 chores, got %d", len(days[1].Chores))
+	}
+	// Chores sorted alphabetically: "Feed the cat" < "Take out trash"
+	if days[1].Chores[0].Title != "Feed the cat" {
+		t.Errorf("Tue first chore: want 'Feed the cat', got %s", days[1].Chores[0].Title)
+	}
+}
+
+func TestBuildWeeklyView_EmptyDays(t *testing.T) {
+	monday, _ := weekStart("2026-04-27")
+	days := buildWeeklyView(nil, monday)
+	for _, d := range days {
+		if len(d.Chores) != 0 {
+			t.Errorf("day %s should have 0 chores, got %d", d.Day, len(d.Chores))
+		}
+	}
+}
+
+func TestBuildWeeklyView_OutOfRangeChoresIgnored(t *testing.T) {
+	monday, _ := weekStart("2026-04-27")
+	chores := []lib.Chore{
+		{ID: "99", Title: "Old chore", Status: "completed", DueDate: "2026-04-20"},
+	}
+	days := buildWeeklyView(chores, monday)
+	for _, d := range days {
+		if len(d.Chores) != 0 {
+			t.Errorf("day %s should have 0 chores, got %d", d.Day, len(d.Chores))
+		}
+	}
+}

--- a/cmd/helpers.go
+++ b/cmd/helpers.go
@@ -41,6 +41,9 @@ func printOutput(data any) {
 		case []ChoreStreakStats:
 			printChoreStreakTable(v)
 			return
+		case []WeeklyChoreDay:
+			printChoreWeekTable(v)
+			return
 		}
 	}
 	printJSON(data)


### PR DESCRIPTION
Closes #70

## Summary

- Adds `--week` flag to `skylight chore list` that displays a Mon–Sun weekly drill-down grouped by day
- `--week` (no value) shows the current week; `--week 2026-04-28` selects the week containing that date
- Table output (`--output table`) shows `DAY | DATE | TITLE | STATUS` with ✓/✗ per chore and `(no chores) —` for empty days
- JSON output returns a structured `[]WeeklyChoreDay` array
- Uses existing `after`/`before` + `include_late` API parameters — no new API calls needed
- 10 unit tests covering `weekStart` and `buildWeeklyView` logic

## Usage

```
skylight chore list --week                    # current week
skylight chore list --week 2026-04-28         # week containing that date
skylight chore list --week --output table     # table view
skylight chore list --week --output json      # JSON view
```

## Test plan

- [x] `make build` passes
- [x] `make test` passes (all 10 new tests + existing suite green)
- [x] `make lint` introduces no new issues (pre-existing `rotation_test.go` staticcheck warnings are unrelated)