### PR TITLE
fix: correct chore status string from 'completed' to 'complete'

### DIFF
--- a/cmd/chore_streak.go
+++ b/cmd/chore_streak.go
@@ -44,7 +44,7 @@ func computeChoreStreaks(chores []lib.Chore, dates []string, catNames map[string
 		}
 		key := choreDay{c.DueDate, c.AssigneeID}
 		total[key]++
-		if c.Status == "completed" {
+		if c.Status == "complete" {
 			done[key]++
 		}
 		assigneeSet[c.AssigneeID] = true

--- a/cmd/chore_streak.go
+++ b/cmd/chore_streak.go
@@ -44,7 +44,7 @@ func computeChoreStreaks(chores []lib.Chore, dates []string, catNames map[string
 		}
 		key := choreDay{c.DueDate, c.AssigneeID}
 		total[key]++
-		if c.Status == "complete" {
+		if c.Status == lib.ChoreStatusComplete {
 			done[key]++
 		}
 		assigneeSet[c.AssigneeID] = true

--- a/cmd/chore_streak_test.go
+++ b/cmd/chore_streak_test.go
@@ -16,9 +16,9 @@ func TestComputeChoreStreaks_Empty(t *testing.T) {
 func TestComputeChoreStreaks_AllCompleted(t *testing.T) {
 	dates := []string{"2026-04-27", "2026-04-28", "2026-04-29"}
 	chores := []lib.Chore{
-		{AssigneeID: "1", DueDate: "2026-04-27", Status: "completed"},
-		{AssigneeID: "1", DueDate: "2026-04-28", Status: "completed"},
-		{AssigneeID: "1", DueDate: "2026-04-29", Status: "completed"},
+		{AssigneeID: "1", DueDate: "2026-04-27", Status: "complete"},
+		{AssigneeID: "1", DueDate: "2026-04-28", Status: "complete"},
+		{AssigneeID: "1", DueDate: "2026-04-29", Status: "complete"},
 	}
 	catNames := map[string]string{"1": "Alice"}
 
@@ -44,9 +44,9 @@ func TestComputeChoreStreaks_AllCompleted(t *testing.T) {
 func TestComputeChoreStreaks_BrokenStreak(t *testing.T) {
 	dates := []string{"2026-04-27", "2026-04-28", "2026-04-29"}
 	chores := []lib.Chore{
-		{AssigneeID: "1", DueDate: "2026-04-27", Status: "completed"},
+		{AssigneeID: "1", DueDate: "2026-04-27", Status: "complete"},
 		{AssigneeID: "1", DueDate: "2026-04-28", Status: "pending"},
-		{AssigneeID: "1", DueDate: "2026-04-29", Status: "completed"},
+		{AssigneeID: "1", DueDate: "2026-04-29", Status: "complete"},
 	}
 
 	results := computeChoreStreaks(chores, dates, nil)
@@ -66,8 +66,8 @@ func TestComputeChoreStreaks_SkipDaysWithNoChores(t *testing.T) {
 	// April 28 has no chores for assignee "1" — streak should not break.
 	dates := []string{"2026-04-27", "2026-04-28", "2026-04-29"}
 	chores := []lib.Chore{
-		{AssigneeID: "1", DueDate: "2026-04-27", Status: "completed"},
-		{AssigneeID: "1", DueDate: "2026-04-29", Status: "completed"},
+		{AssigneeID: "1", DueDate: "2026-04-27", Status: "complete"},
+		{AssigneeID: "1", DueDate: "2026-04-29", Status: "complete"},
 	}
 
 	results := computeChoreStreaks(chores, dates, nil)
@@ -87,10 +87,10 @@ func TestComputeChoreStreaks_SkipDaysWithNoChores(t *testing.T) {
 func TestComputeChoreStreaks_MultipleAssignees(t *testing.T) {
 	dates := []string{"2026-04-27", "2026-04-28", "2026-04-29"}
 	chores := []lib.Chore{
-		{AssigneeID: "1", DueDate: "2026-04-27", Status: "completed"},
-		{AssigneeID: "1", DueDate: "2026-04-28", Status: "completed"},
-		{AssigneeID: "1", DueDate: "2026-04-29", Status: "completed"},
-		{AssigneeID: "2", DueDate: "2026-04-27", Status: "completed"},
+		{AssigneeID: "1", DueDate: "2026-04-27", Status: "complete"},
+		{AssigneeID: "1", DueDate: "2026-04-28", Status: "complete"},
+		{AssigneeID: "1", DueDate: "2026-04-29", Status: "complete"},
+		{AssigneeID: "2", DueDate: "2026-04-27", Status: "complete"},
 		{AssigneeID: "2", DueDate: "2026-04-28", Status: "pending"},
 		{AssigneeID: "2", DueDate: "2026-04-29", Status: "pending"},
 	}
@@ -119,8 +119,8 @@ func TestComputeChoreStreaks_MultipleAssignees(t *testing.T) {
 func TestComputeChoreStreaks_CompletionRate(t *testing.T) {
 	dates := []string{"2026-04-27", "2026-04-28"}
 	chores := []lib.Chore{
-		{AssigneeID: "1", DueDate: "2026-04-27", Status: "completed"},
-		{AssigneeID: "1", DueDate: "2026-04-27", Status: "completed"},
+		{AssigneeID: "1", DueDate: "2026-04-27", Status: "complete"},
+		{AssigneeID: "1", DueDate: "2026-04-27", Status: "complete"},
 		{AssigneeID: "1", DueDate: "2026-04-28", Status: "pending"},
 		{AssigneeID: "1", DueDate: "2026-04-28", Status: "pending"},
 	}
@@ -144,7 +144,7 @@ func TestComputeChoreStreaks_CompletionRate(t *testing.T) {
 func TestComputeChoreStreaks_SkipsUnassigned(t *testing.T) {
 	dates := []string{"2026-04-29"}
 	chores := []lib.Chore{
-		{AssigneeID: "", DueDate: "2026-04-29", Status: "completed"},
+		{AssigneeID: "", DueDate: "2026-04-29", Status: "complete"},
 	}
 
 	results := computeChoreStreaks(chores, dates, nil)
@@ -156,7 +156,7 @@ func TestComputeChoreStreaks_SkipsUnassigned(t *testing.T) {
 func TestComputeChoreStreaks_FallbackToID(t *testing.T) {
 	dates := []string{"2026-04-29"}
 	chores := []lib.Chore{
-		{AssigneeID: "99", DueDate: "2026-04-29", Status: "completed"},
+		{AssigneeID: "99", DueDate: "2026-04-29", Status: "complete"},
 	}
 
 	results := computeChoreStreaks(chores, dates, map[string]string{})

--- a/cmd/chore_streak_test.go
+++ b/cmd/chore_streak_test.go
@@ -16,9 +16,9 @@ func TestComputeChoreStreaks_Empty(t *testing.T) {
 func TestComputeChoreStreaks_AllCompleted(t *testing.T) {
 	dates := []string{"2026-04-27", "2026-04-28", "2026-04-29"}
 	chores := []lib.Chore{
-		{AssigneeID: "1", DueDate: "2026-04-27", Status: "complete"},
-		{AssigneeID: "1", DueDate: "2026-04-28", Status: "complete"},
-		{AssigneeID: "1", DueDate: "2026-04-29", Status: "complete"},
+		{AssigneeID: "1", DueDate: "2026-04-27", Status: lib.ChoreStatusComplete},
+		{AssigneeID: "1", DueDate: "2026-04-28", Status: lib.ChoreStatusComplete},
+		{AssigneeID: "1", DueDate: "2026-04-29", Status: lib.ChoreStatusComplete},
 	}
 	catNames := map[string]string{"1": "Alice"}
 
@@ -44,9 +44,9 @@ func TestComputeChoreStreaks_AllCompleted(t *testing.T) {
 func TestComputeChoreStreaks_BrokenStreak(t *testing.T) {
 	dates := []string{"2026-04-27", "2026-04-28", "2026-04-29"}
 	chores := []lib.Chore{
-		{AssigneeID: "1", DueDate: "2026-04-27", Status: "complete"},
-		{AssigneeID: "1", DueDate: "2026-04-28", Status: "pending"},
-		{AssigneeID: "1", DueDate: "2026-04-29", Status: "complete"},
+		{AssigneeID: "1", DueDate: "2026-04-27", Status: lib.ChoreStatusComplete},
+		{AssigneeID: "1", DueDate: "2026-04-28", Status: lib.ChoreStatusPending},
+		{AssigneeID: "1", DueDate: "2026-04-29", Status: lib.ChoreStatusComplete},
 	}
 
 	results := computeChoreStreaks(chores, dates, nil)
@@ -66,8 +66,8 @@ func TestComputeChoreStreaks_SkipDaysWithNoChores(t *testing.T) {
 	// April 28 has no chores for assignee "1" — streak should not break.
 	dates := []string{"2026-04-27", "2026-04-28", "2026-04-29"}
 	chores := []lib.Chore{
-		{AssigneeID: "1", DueDate: "2026-04-27", Status: "complete"},
-		{AssigneeID: "1", DueDate: "2026-04-29", Status: "complete"},
+		{AssigneeID: "1", DueDate: "2026-04-27", Status: lib.ChoreStatusComplete},
+		{AssigneeID: "1", DueDate: "2026-04-29", Status: lib.ChoreStatusComplete},
 	}
 
 	results := computeChoreStreaks(chores, dates, nil)
@@ -87,12 +87,12 @@ func TestComputeChoreStreaks_SkipDaysWithNoChores(t *testing.T) {
 func TestComputeChoreStreaks_MultipleAssignees(t *testing.T) {
 	dates := []string{"2026-04-27", "2026-04-28", "2026-04-29"}
 	chores := []lib.Chore{
-		{AssigneeID: "1", DueDate: "2026-04-27", Status: "complete"},
-		{AssigneeID: "1", DueDate: "2026-04-28", Status: "complete"},
-		{AssigneeID: "1", DueDate: "2026-04-29", Status: "complete"},
-		{AssigneeID: "2", DueDate: "2026-04-27", Status: "complete"},
-		{AssigneeID: "2", DueDate: "2026-04-28", Status: "pending"},
-		{AssigneeID: "2", DueDate: "2026-04-29", Status: "pending"},
+		{AssigneeID: "1", DueDate: "2026-04-27", Status: lib.ChoreStatusComplete},
+		{AssigneeID: "1", DueDate: "2026-04-28", Status: lib.ChoreStatusComplete},
+		{AssigneeID: "1", DueDate: "2026-04-29", Status: lib.ChoreStatusComplete},
+		{AssigneeID: "2", DueDate: "2026-04-27", Status: lib.ChoreStatusComplete},
+		{AssigneeID: "2", DueDate: "2026-04-28", Status: lib.ChoreStatusPending},
+		{AssigneeID: "2", DueDate: "2026-04-29", Status: lib.ChoreStatusPending},
 	}
 	catNames := map[string]string{"1": "Alice", "2": "Bob"}
 
@@ -119,10 +119,10 @@ func TestComputeChoreStreaks_MultipleAssignees(t *testing.T) {
 func TestComputeChoreStreaks_CompletionRate(t *testing.T) {
 	dates := []string{"2026-04-27", "2026-04-28"}
 	chores := []lib.Chore{
-		{AssigneeID: "1", DueDate: "2026-04-27", Status: "complete"},
-		{AssigneeID: "1", DueDate: "2026-04-27", Status: "complete"},
-		{AssigneeID: "1", DueDate: "2026-04-28", Status: "pending"},
-		{AssigneeID: "1", DueDate: "2026-04-28", Status: "pending"},
+		{AssigneeID: "1", DueDate: "2026-04-27", Status: lib.ChoreStatusComplete},
+		{AssigneeID: "1", DueDate: "2026-04-27", Status: lib.ChoreStatusComplete},
+		{AssigneeID: "1", DueDate: "2026-04-28", Status: lib.ChoreStatusPending},
+		{AssigneeID: "1", DueDate: "2026-04-28", Status: lib.ChoreStatusPending},
 	}
 
 	results := computeChoreStreaks(chores, dates, nil)
@@ -144,7 +144,7 @@ func TestComputeChoreStreaks_CompletionRate(t *testing.T) {
 func TestComputeChoreStreaks_SkipsUnassigned(t *testing.T) {
 	dates := []string{"2026-04-29"}
 	chores := []lib.Chore{
-		{AssigneeID: "", DueDate: "2026-04-29", Status: "complete"},
+		{AssigneeID: "", DueDate: "2026-04-29", Status: lib.ChoreStatusComplete},
 	}
 
 	results := computeChoreStreaks(chores, dates, nil)
@@ -156,7 +156,7 @@ func TestComputeChoreStreaks_SkipsUnassigned(t *testing.T) {
 func TestComputeChoreStreaks_FallbackToID(t *testing.T) {
 	dates := []string{"2026-04-29"}
 	chores := []lib.Chore{
-		{AssigneeID: "99", DueDate: "2026-04-29", Status: "complete"},
+		{AssigneeID: "99", DueDate: "2026-04-29", Status: lib.ChoreStatusComplete},
 	}
 
 	results := computeChoreStreaks(chores, dates, map[string]string{})

--- a/cmd/chore_week.go
+++ b/cmd/chore_week.go
@@ -85,7 +85,7 @@ func printChoreWeekTable(days []WeeklyChoreDay) {
 				dayCol, dateCol = "", ""
 			}
 			status := "✗"
-			if c.Status == "completed" {
+			if c.Status == "complete" {
 				status = "✓"
 			}
 			fmt.Fprintf(w, "%s\t%s\t%s\t%s\n", dayCol, dateCol, c.Title, status)

--- a/cmd/chore_week.go
+++ b/cmd/chore_week.go
@@ -85,7 +85,7 @@ func printChoreWeekTable(days []WeeklyChoreDay) {
 				dayCol, dateCol = "", ""
 			}
 			status := "✗"
-			if c.Status == "complete" {
+			if c.Status == lib.ChoreStatusComplete {
 				status = "✓"
 			}
 			fmt.Fprintf(w, "%s\t%s\t%s\t%s\n", dayCol, dateCol, c.Title, status)

--- a/cmd/chore_week_test.go
+++ b/cmd/chore_week_test.go
@@ -84,9 +84,9 @@ func TestBuildWeeklyView_SlotCount(t *testing.T) {
 func TestBuildWeeklyView_ChoresGroupedByDate(t *testing.T) {
 	monday, _ := weekStart("2026-04-27")
 	chores := []lib.Chore{
-		{ID: "1", Title: "Walk the dog", Status: "completed", DueDate: "2026-04-27"},
+		{ID: "1", Title: "Walk the dog", Status: "complete", DueDate: "2026-04-27"},
 		{ID: "2", Title: "Take out trash", Status: "pending", DueDate: "2026-04-28"},
-		{ID: "3", Title: "Feed the cat", Status: "completed", DueDate: "2026-04-28"},
+		{ID: "3", Title: "Feed the cat", Status: "complete", DueDate: "2026-04-28"},
 	}
 	days := buildWeeklyView(chores, monday)
 
@@ -118,7 +118,7 @@ func TestBuildWeeklyView_EmptyDays(t *testing.T) {
 func TestBuildWeeklyView_OutOfRangeChoresIgnored(t *testing.T) {
 	monday, _ := weekStart("2026-04-27")
 	chores := []lib.Chore{
-		{ID: "99", Title: "Old chore", Status: "completed", DueDate: "2026-04-20"},
+		{ID: "99", Title: "Old chore", Status: "complete", DueDate: "2026-04-20"},
 	}
 	days := buildWeeklyView(chores, monday)
 	for _, d := range days {

--- a/cmd/chore_week_test.go
+++ b/cmd/chore_week_test.go
@@ -84,9 +84,9 @@ func TestBuildWeeklyView_SlotCount(t *testing.T) {
 func TestBuildWeeklyView_ChoresGroupedByDate(t *testing.T) {
 	monday, _ := weekStart("2026-04-27")
 	chores := []lib.Chore{
-		{ID: "1", Title: "Walk the dog", Status: "complete", DueDate: "2026-04-27"},
-		{ID: "2", Title: "Take out trash", Status: "pending", DueDate: "2026-04-28"},
-		{ID: "3", Title: "Feed the cat", Status: "complete", DueDate: "2026-04-28"},
+		{ID: "1", Title: "Walk the dog", Status: lib.ChoreStatusComplete, DueDate: "2026-04-27"},
+		{ID: "2", Title: "Take out trash", Status: lib.ChoreStatusPending, DueDate: "2026-04-28"},
+		{ID: "3", Title: "Feed the cat", Status: lib.ChoreStatusComplete, DueDate: "2026-04-28"},
 	}
 	days := buildWeeklyView(chores, monday)
 
@@ -118,7 +118,7 @@ func TestBuildWeeklyView_EmptyDays(t *testing.T) {
 func TestBuildWeeklyView_OutOfRangeChoresIgnored(t *testing.T) {
 	monday, _ := weekStart("2026-04-27")
 	chores := []lib.Chore{
-		{ID: "99", Title: "Old chore", Status: "complete", DueDate: "2026-04-20"},
+		{ID: "99", Title: "Old chore", Status: lib.ChoreStatusComplete, DueDate: "2026-04-20"},
 	}
 	days := buildWeeklyView(chores, monday)
 	for _, d := range days {

--- a/lib/chore.go
+++ b/lib/chore.go
@@ -7,7 +7,11 @@ import (
 )
 
 const (
-	choreStatusPending = "pending"
+	ChoreStatusComplete = "complete"
+	ChoreStatusPending  = "pending"
+	ChoreStatusSkipped  = "skipped"
+
+	choreStatusPending = ChoreStatusPending
 	paramTrue          = "true"
 )
 
@@ -152,7 +156,7 @@ func (c *Client) UpdateChore(frameID, choreID string, chore ChoreData) (*Chore, 
 
 // SkipChore skips a single instance of a recurring chore.
 func (c *Client) SkipChore(frameID, choreID string) error {
-	return c.setCompletion(frameID, choreID, "skipped")
+	return c.setCompletion(frameID, choreID, ChoreStatusSkipped)
 }
 
 // CompleteChore marks a chore instance as completed via the completions endpoint.


### PR DESCRIPTION
## Summary

- The Skylight API returns `"complete"` for finished chores, not `"completed"`
- This caused the streak command to report 0% completion for everyone and the week view to show ✗ for all completed chores
- Fixed the status check in `chore_streak.go` and `chore_week.go`, and updated the corresponding tests

## Test plan

- [x] `make lint` — 0 issues
- [x] `make test` — all tests pass
- [x] Manual: `skylight chore streak --output table` now shows real completion rates and streaks
- [x] Manual: `skylight chore list --week --output table` now shows ✓ for completed chores