### PR TITLE
feat: add bounty delete and update commands

### DIFF
--- a/cmd/bounty.go
+++ b/cmd/bounty.go
@@ -16,6 +16,8 @@ var (
 	bountyRewardTitle string
 	bountyEmojiIcon   string
 	bountyRecurring   bool
+	bountyChoreID     string
+	bountyRewardID    string
 )
 
 var bountyCmd = &cobra.Command{
@@ -67,9 +69,63 @@ var bountyListCmd = &cobra.Command{
 	},
 }
 
+var bountyDeleteCmd = &cobra.Command{
+	Use:   "delete",
+	Short: "Delete a bounty (removes both the chore and the paired reward)",
+	Run: func(cmd *cobra.Command, args []string) {
+		requireFrameID()
+
+		client := getClient()
+
+		if err := client.DeleteBounty(frameID, bountyChoreID, bountyRewardID); err != nil {
+			fmt.Printf("Error deleting bounty: %v\n", err)
+			os.Exit(1)
+		}
+
+		fmt.Println("Bounty deleted.")
+	},
+}
+
+var bountyUpdateCmd = &cobra.Command{
+	Use:   "update",
+	Short: "Update a bounty's chore and paired reward",
+	Run: func(cmd *cobra.Command, args []string) {
+		requireFrameID()
+
+		client := getClient()
+
+		data := lib.BountyData{}
+		if cmd.Flags().Changed("title") {
+			data.Title = bountyTitle
+		}
+		if cmd.Flags().Changed("reward-title") {
+			data.RewardTitle = bountyRewardTitle
+		}
+		if cmd.Flags().Changed("points") {
+			data.Points = bountyPoints
+		}
+		if cmd.Flags().Changed("due-date") {
+			data.DueDate = bountyDueDate
+		}
+		if cmd.Flags().Changed("emoji-icon") {
+			data.EmojiIcon = bountyEmojiIcon
+		}
+
+		bounty, err := client.UpdateBounty(frameID, bountyChoreID, bountyRewardID, data)
+		if err != nil {
+			fmt.Printf("Error updating bounty: %v\n", err)
+			os.Exit(1)
+		}
+
+		printJSON(bounty)
+	},
+}
+
 func init() {
 	bountyCmd.AddCommand(bountyCreateCmd)
 	bountyCmd.AddCommand(bountyListCmd)
+	bountyCmd.AddCommand(bountyDeleteCmd)
+	bountyCmd.AddCommand(bountyUpdateCmd)
 
 	bountyCreateCmd.Flags().StringVar(&bountyTitle, "title", "", "Chore title")
 	bountyCreateCmd.Flags().IntVar(&bountyPoints, "points", 0, "Point value for chore and reward")
@@ -81,4 +137,19 @@ func init() {
 	bountyCreateCmd.MarkFlagRequired("title")        //nolint:errcheck
 	bountyCreateCmd.MarkFlagRequired("points")       //nolint:errcheck
 	bountyCreateCmd.MarkFlagRequired("reward-title") //nolint:errcheck
+
+	bountyDeleteCmd.Flags().StringVar(&bountyChoreID, "chore-id", "", "Chore ID of the bounty")
+	bountyDeleteCmd.Flags().StringVar(&bountyRewardID, "reward-id", "", "Reward ID of the bounty")
+	bountyDeleteCmd.MarkFlagRequired("chore-id")  //nolint:errcheck
+	bountyDeleteCmd.MarkFlagRequired("reward-id") //nolint:errcheck
+
+	bountyUpdateCmd.Flags().StringVar(&bountyChoreID, "chore-id", "", "Chore ID of the bounty")
+	bountyUpdateCmd.Flags().StringVar(&bountyRewardID, "reward-id", "", "Reward ID of the bounty")
+	bountyUpdateCmd.Flags().StringVar(&bountyTitle, "title", "", "New chore title")
+	bountyUpdateCmd.Flags().StringVar(&bountyRewardTitle, "reward-title", "", "New reward title")
+	bountyUpdateCmd.Flags().IntVar(&bountyPoints, "points", 0, "New point value for chore and reward")
+	bountyUpdateCmd.Flags().StringVar(&bountyDueDate, "due-date", "", "New due date (YYYY-MM-DD)")
+	bountyUpdateCmd.Flags().StringVar(&bountyEmojiIcon, "emoji-icon", "", "New reward emoji icon")
+	bountyUpdateCmd.MarkFlagRequired("chore-id")  //nolint:errcheck
+	bountyUpdateCmd.MarkFlagRequired("reward-id") //nolint:errcheck
 }

--- a/lib/bounty.go
+++ b/lib/bounty.go
@@ -48,6 +48,44 @@ func (c *Client) CreateBounty(frameID string, data BountyData) (*Bounty, error) 
 	}, nil
 }
 
+// DeleteBounty deletes the chore and reward that make up a bounty.
+// Both deletions are attempted; the first error encountered is returned.
+func (c *Client) DeleteBounty(frameID, choreID, rewardID string) error {
+	choreErr := c.DeleteChore(frameID, choreID)
+	rewardErr := c.DeleteReward(frameID, rewardID)
+	if choreErr != nil {
+		return fmt.Errorf("failed to delete bounty chore: %w", choreErr)
+	}
+	if rewardErr != nil {
+		return fmt.Errorf("failed to delete bounty reward: %w", rewardErr)
+	}
+	return nil
+}
+
+// UpdateBounty updates the chore and reward that make up a bounty.
+// Only fields set in data are applied; zero-value fields are ignored by the underlying update calls.
+func (c *Client) UpdateBounty(frameID, choreID, rewardID string, data BountyData) (*Bounty, error) {
+	chore, err := c.UpdateChore(frameID, choreID, ChoreData{
+		Title:   data.Title,
+		Points:  data.Points,
+		DueDate: data.DueDate,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to update bounty chore: %w", err)
+	}
+
+	reward, err := c.UpdateReward(frameID, rewardID, RewardData{
+		Title:     data.RewardTitle,
+		Points:    data.Points,
+		EmojiIcon: data.EmojiIcon,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to update bounty reward: %w", err)
+	}
+
+	return &Bounty{Chore: *chore, Reward: *reward}, nil
+}
+
 // ListBounties lists pending chores with points and unredeemed rewards,
 // matching them by point value as a heuristic.
 func (c *Client) ListBounties(frameID string) ([]Bounty, error) {


### PR DESCRIPTION
Closes #87

## Summary

- Adds `lib.DeleteBounty` — deletes both the chore and paired reward; attempts both deletions and surfaces the first error
- Adds `lib.UpdateBounty` — updates chore and reward fields using partial updates via `cmd.Flags().Changed()` so only explicitly-set flags are sent
- Adds `skylight bounty delete --chore-id ID --reward-id ID`
- Adds `skylight bounty update --chore-id ID --reward-id ID [--title] [--reward-title] [--points] [--due-date] [--emoji-icon]`
- Both new subcommands enforce `MarkFlagRequired` on `--chore-id` and `--reward-id`

## Test plan

- [ ] `make build` passes
- [ ] `make lint` passes
- [ ] `make test` passes
- [ ] CI green