### PR TITLE
feat: add table output support for missing list commands

### DIFF
--- a/cmd/bounty.go
+++ b/cmd/bounty.go
@@ -65,7 +65,7 @@ var bountyListCmd = &cobra.Command{
 			os.Exit(1)
 		}
 
-		printJSON(bounties)
+		printOutput(bounties)
 	},
 }
 

--- a/cmd/calendar.go
+++ b/cmd/calendar.go
@@ -97,7 +97,7 @@ var sourceCalendarsCmd = &cobra.Command{
 			os.Exit(1)
 		}
 
-		printJSON(calendars)
+		printOutput(calendars)
 	},
 }
 

--- a/cmd/calendar_week.go
+++ b/cmd/calendar_week.go
@@ -72,7 +72,7 @@ func printCalendarWeekTable(days []WeeklyCalendarDay) {
 					timeCol = e.StartAt[11:16]
 				}
 			}
-			allDayCol := "no"
+			allDayCol := boolNo
 			if e.AllDay {
 				allDayCol = boolYes
 			}

--- a/cmd/frame.go
+++ b/cmd/frame.go
@@ -60,7 +60,7 @@ var frameDevicesCmd = &cobra.Command{
 			os.Exit(1)
 		}
 
-		printJSON(devices)
+		printOutput(devices)
 	},
 }
 
@@ -76,7 +76,7 @@ var frameAvatarsCmd = &cobra.Command{
 			os.Exit(1)
 		}
 
-		printJSON(avatars)
+		printOutput(avatars)
 	},
 }
 
@@ -92,7 +92,7 @@ var frameColorsCmd = &cobra.Command{
 			os.Exit(1)
 		}
 
-		printJSON(colors)
+		printOutput(colors)
 	},
 }
 

--- a/cmd/helpers.go
+++ b/cmd/helpers.go
@@ -9,7 +9,10 @@ import (
 	"github.com/sebrandon1/go-skylight/lib"
 )
 
-const boolYes = "yes"
+const (
+	boolYes = "yes"
+	boolNo  = "no"
+)
 
 func printJSON(data any) {
 	output, err := json.MarshalIndent(data, "", "  ")
@@ -23,35 +26,62 @@ func printJSON(data any) {
 // printOutput prints data in the format specified by --output (json or table).
 // Defaults to JSON for types that don't have a dedicated table renderer.
 func printOutput(data any) {
-	if outputFormat == outputTable {
-		switch v := data.(type) {
-		case []lib.Chore:
-			printChoresTable(v)
-			return
-		case []lib.Reward:
-			printRewardsTable(v)
-			return
-		case []lib.Frame:
-			printFramesTable(v)
-			return
-		case []lib.CalendarEvent:
-			printCalendarTable(v)
-			return
-		case []lib.Category:
-			printCategoriesTable(v)
-			return
-		case []ChoreStreakStats:
-			printChoreStreakTable(v)
-			return
-		case []WeeklyChoreDay:
-			printChoreWeekTable(v)
-			return
-		case []WeeklyCalendarDay:
-			printCalendarWeekTable(v)
-			return
-		}
+	if outputFormat == outputTable && printTableOutput(data) {
+		return
 	}
 	printJSON(data)
+}
+
+func printTableOutput(data any) bool {
+	switch v := data.(type) {
+	case []lib.Chore:
+		printChoresTable(v)
+	case []lib.Reward:
+		printRewardsTable(v)
+	case []lib.Frame:
+		printFramesTable(v)
+	case []lib.CalendarEvent:
+		printCalendarTable(v)
+	case []lib.Category:
+		printCategoriesTable(v)
+	case []ChoreStreakStats:
+		printChoreStreakTable(v)
+	case []WeeklyChoreDay:
+		printChoreWeekTable(v)
+	case []WeeklyCalendarDay:
+		printCalendarWeekTable(v)
+	default:
+		return printTableOutputExtended(data)
+	}
+	return true
+}
+
+func printTableOutputExtended(data any) bool {
+	switch v := data.(type) {
+	case []lib.Bounty:
+		printBountiesTable(v)
+	case []lib.SourceCalendar:
+		printSourceCalendarsTable(v)
+	case []lib.Device:
+		printDevicesTable(v)
+	case []lib.Avatar:
+		printAvatarsTable(v)
+	case []lib.Color:
+		printColorsTable(v)
+	case []lib.List:
+		printListsTable(v)
+	case []lib.MealCategory:
+		printMealCategoriesTable(v)
+	case []lib.Recipe:
+		printRecipesTable(v)
+	case []lib.MealSitting:
+		printMealSittingsTable(v)
+	case []lib.Photo:
+		printPhotosTable(v)
+	default:
+		return false
+	}
+	return true
 }
 
 func printChoresTable(chores []lib.Chore) {
@@ -68,7 +98,7 @@ func printRewardsTable(rewards []lib.Reward) {
 	w := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
 	fmt.Fprintln(w, "ID\tTITLE\tPOINTS\tEMOJI\tREDEEMED\tCATEGORY")
 	for _, r := range rewards {
-		redeemed := "no"
+		redeemed := boolNo
 		if r.Redeemed {
 			redeemed = boolYes
 		}
@@ -91,7 +121,7 @@ func printCalendarTable(events []lib.CalendarEvent) {
 	w := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
 	fmt.Fprintln(w, "ID\tTITLE\tSTART\tEND\tALL DAY")
 	for _, e := range events {
-		allDay := "no"
+		allDay := boolNo
 		if e.AllDay {
 			allDay = boolYes
 		}
@@ -116,6 +146,101 @@ func printChoreStreakTable(stats []ChoreStreakStats) {
 	for _, s := range stats {
 		fmt.Fprintf(w, "%s\t%d days\t%d days\t%d\t%d\t%.1f%%\n",
 			s.AssigneeName, s.CurrentStreak, s.LongestStreak, s.CompletedChores, s.TotalChores, s.CompletionRate)
+	}
+	w.Flush()
+}
+
+func printBountiesTable(bounties []lib.Bounty) {
+	w := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
+	fmt.Fprintln(w, "CHORE ID\tCHORE TITLE\tPOINTS\tDUE DATE\tREWARD ID\tREWARD TITLE")
+	for _, b := range bounties {
+		fmt.Fprintf(w, "%s\t%s\t%d\t%s\t%s\t%s\n",
+			b.Chore.ID, b.Chore.Title, b.Chore.Points, b.Chore.DueDate, b.Reward.ID, b.Reward.Title)
+	}
+	w.Flush()
+}
+
+func printSourceCalendarsTable(cals []lib.SourceCalendar) {
+	w := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
+	fmt.Fprintln(w, "ID\tNAME\tPROVIDER\tCOLOR")
+	for _, c := range cals {
+		fmt.Fprintf(w, "%s\t%s\t%s\t%s\n", c.ID, c.Name, c.Provider, c.Color)
+	}
+	w.Flush()
+}
+
+func printDevicesTable(devices []lib.Device) {
+	w := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
+	fmt.Fprintln(w, "ID\tNAME\tONLINE")
+	for _, d := range devices {
+		online := boolNo
+		if d.Online {
+			online = boolYes
+		}
+		fmt.Fprintf(w, "%s\t%s\t%s\n", d.ID, d.Name, online)
+	}
+	w.Flush()
+}
+
+func printAvatarsTable(avatars []lib.Avatar) {
+	w := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
+	fmt.Fprintln(w, "ID\tNAME\tIMAGE URL")
+	for _, a := range avatars {
+		fmt.Fprintf(w, "%s\t%s\t%s\n", a.ID, a.Name, a.ImageURL)
+	}
+	w.Flush()
+}
+
+func printColorsTable(colors []lib.Color) {
+	w := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
+	fmt.Fprintln(w, "NAME\tHEX")
+	for _, c := range colors {
+		fmt.Fprintf(w, "%s\t%s\n", c.Name, c.Hex)
+	}
+	w.Flush()
+}
+
+func printListsTable(lists []lib.List) {
+	w := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
+	fmt.Fprintln(w, "ID\tTITLE\tCOLOR\tKIND\tITEMS")
+	for _, l := range lists {
+		fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%d\n", l.ID, l.Title, l.Color, l.Kind, len(l.Items))
+	}
+	w.Flush()
+}
+
+func printMealCategoriesTable(cats []lib.MealCategory) {
+	w := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
+	fmt.Fprintln(w, "ID\tNAME\tCOLOR")
+	for _, c := range cats {
+		fmt.Fprintf(w, "%s\t%s\t%s\n", c.ID, c.Name, c.Color)
+	}
+	w.Flush()
+}
+
+func printRecipesTable(recipes []lib.Recipe) {
+	w := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
+	fmt.Fprintln(w, "ID\tTITLE\tCATEGORY\tURL")
+	for _, r := range recipes {
+		fmt.Fprintf(w, "%s\t%s\t%s\t%s\n", r.ID, r.Title, r.MealCategoryID, r.URL)
+	}
+	w.Flush()
+}
+
+func printMealSittingsTable(sittings []lib.MealSitting) {
+	w := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
+	fmt.Fprintln(w, "ID\tSUMMARY\tDATE\tRECIPE ID\tCATEGORY ID")
+	for _, s := range sittings {
+		fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\n", s.ID, s.Summary, s.Date, s.RecipeID, s.MealCategoryID)
+	}
+	w.Flush()
+}
+
+func printPhotosTable(photos []lib.Photo) {
+	w := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
+	fmt.Fprintln(w, "ID\tTYPE\tSTATUS\tCREATED")
+	for _, p := range photos {
+		fmt.Fprintf(w, "%s\t%s\t%s\t%s\n", p.ID, p.AssetType, p.Status, p.CreatedAt)
 	}
 	w.Flush()
 }

--- a/cmd/list.go
+++ b/cmd/list.go
@@ -36,7 +36,7 @@ var listListCmd = &cobra.Command{
 			os.Exit(1)
 		}
 
-		printJSON(lists)
+		printOutput(lists)
 	},
 }
 

--- a/cmd/meal.go
+++ b/cmd/meal.go
@@ -42,7 +42,7 @@ var mealCategoriesCmd = &cobra.Command{
 			os.Exit(1)
 		}
 
-		printJSON(categories)
+		printOutput(categories)
 	},
 }
 
@@ -60,7 +60,7 @@ var mealRecipesCmd = &cobra.Command{
 			os.Exit(1)
 		}
 
-		printJSON(recipes)
+		printOutput(recipes)
 	},
 }
 
@@ -141,7 +141,7 @@ var mealSittingsCmd = &cobra.Command{
 			os.Exit(1)
 		}
 
-		printJSON(sittings)
+		printOutput(sittings)
 	},
 }
 

--- a/cmd/photo.go
+++ b/cmd/photo.go
@@ -39,7 +39,7 @@ var photoListCmd = &cobra.Command{
 			os.Exit(1)
 		}
 
-		printJSON(photos)
+		printOutput(photos)
 
 		if nextToken != "" {
 			fmt.Fprintf(os.Stderr, "Next page token: %s\n", nextToken)


### PR DESCRIPTION
Closes #83

## Summary

- Adds printXTable functions for all list commands that previously ignored --output table: bounties, source calendars, devices, avatars, colors, lists, meal categories, recipes, meal sittings, and photos
- Switches each affected list command from printJSON to printOutput
- Splits printOutput type switch into printTableOutput + printTableOutputExtended to keep cyclomatic complexity under the gocyclo limit of 15
- Extracts boolNo constant alongside the existing boolYes, replacing all raw no strings in table printers (partial #85)

## Test plan

- [ ] make build passes
- [ ] make lint passes
- [ ] make test passes
- [ ] CI green