### PR TITLE
fix: enforce required flags on update/delete/action commands

### DIFF
--- a/cmd/calendar.go
+++ b/cmd/calendar.go
@@ -186,6 +186,7 @@ func init() {
 	calendarUpdateCmd.Flags().StringVar(&calendarStartAt, "start-at", "", "Event start time")
 	calendarUpdateCmd.Flags().StringVar(&calendarEndAt, "end-at", "", "Event end time")
 	calendarUpdateCmd.Flags().BoolVar(&calendarAllDay, "all-day", false, "All day event")
+	calendarUpdateCmd.MarkFlagRequired("event-id") //nolint:errcheck
 
 	calendarDeleteCmd.Flags().StringVar(&calendarEventID, "event-id", "", "Event ID to delete")
 	calendarDeleteCmd.MarkFlagRequired("event-id") //nolint:errcheck

--- a/cmd/chore.go
+++ b/cmd/chore.go
@@ -250,6 +250,7 @@ func init() {
 	choreUpdateCmd.Flags().StringVar(&choreDate, "date", "", "Due date")
 
 	choreDeleteCmd.Flags().StringVar(&choreID, "chore-id", "", "Chore ID to delete")
+	choreDeleteCmd.MarkFlagRequired("chore-id") //nolint:errcheck
 
 	choreCompleteCmd.Flags().StringVar(&choreID, "chore-id", "", "Chore ID to complete")
 	choreCompleteCmd.MarkFlagRequired("chore-id") //nolint:errcheck

--- a/cmd/meal.go
+++ b/cmd/meal.go
@@ -274,6 +274,9 @@ func init() {
 	mealCreateSittingCmd.Flags().StringVar(&sittingSummary, "summary", "", "Meal sitting summary/title")
 	mealCreateSittingCmd.Flags().StringVar(&sittingDate, "date", "", "Sitting date")
 	mealCreateSittingCmd.Flags().StringVar(&mealCategoryID, "meal-category-id", "", "Meal category ID")
+	mealCreateSittingCmd.MarkFlagRequired("recipe-id")        //nolint:errcheck
+	mealCreateSittingCmd.MarkFlagRequired("date")             //nolint:errcheck
+	mealCreateSittingCmd.MarkFlagRequired("meal-category-id") //nolint:errcheck
 
 	mealDeleteSittingCmd.Flags().StringVar(&sittingID, "sitting-id", "", "Meal sitting ID")
 	mealDeleteSittingCmd.Flags().StringVar(&sittingDate, "date", "", "Instance date to delete (YYYY-MM-DD)")
@@ -281,4 +284,5 @@ func init() {
 	mealDeleteSittingCmd.MarkFlagRequired("date")       //nolint:errcheck
 
 	mealAddToGroceryCmd.Flags().StringVar(&recipeID, "recipe-id", "", "Recipe ID")
+	mealAddToGroceryCmd.MarkFlagRequired("recipe-id") //nolint:errcheck
 }

--- a/cmd/reward.go
+++ b/cmd/reward.go
@@ -194,8 +194,14 @@ func init() {
 	rewardUpdateCmd.Flags().StringVar(&rewardTitle, "title", "", "Reward title")
 	rewardUpdateCmd.Flags().IntVar(&rewardPoints, "points", 0, "Points cost")
 	rewardUpdateCmd.Flags().StringVar(&rewardEmojiIcon, "emoji-icon", "", "Emoji icon for the reward")
+	rewardUpdateCmd.MarkFlagRequired("reward-id") //nolint:errcheck
 
 	rewardDeleteCmd.Flags().StringVar(&rewardID, "reward-id", "", "Reward ID")
+	rewardDeleteCmd.MarkFlagRequired("reward-id") //nolint:errcheck
+
 	rewardRedeemCmd.Flags().StringVar(&rewardID, "reward-id", "", "Reward ID")
+	rewardRedeemCmd.MarkFlagRequired("reward-id") //nolint:errcheck
+
 	rewardUnredeemCmd.Flags().StringVar(&rewardID, "reward-id", "", "Reward ID")
+	rewardUnredeemCmd.MarkFlagRequired("reward-id") //nolint:errcheck
 }


### PR DESCRIPTION
## Summary
- Add `MarkFlagRequired` to 8 commands missing flag enforcement: `chore delete`, `reward update/delete/redeem/unredeem`, `calendar update`, `meal create-sitting` (recipe-id, date, meal-category-id), `meal add-to-grocery`
- Prevents cryptic API errors when required IDs are omitted — cobra now shows a clear error message instead

## Test plan
- [ ] CI passes
- [ ] `skylight chore delete` without `--chore-id` shows required flag error
- [ ] `skylight reward redeem` without `--reward-id` shows required flag error