### PR TITLE
feat: add config unset and config edit subcommands

### DIFF
--- a/cmd/config.go
+++ b/cmd/config.go
@@ -117,3 +117,56 @@ func saveConfig(values map[string]string) error {
 
 	return nil
 }
+
+// deleteFromConfig removes key from the config file.
+// Returns true if found and removed, false if the key was not present.
+func deleteFromConfig(key string) (bool, error) {
+	path := configPath
+	if path == "" {
+		path = defaultConfigPath()
+	}
+	if path == "" {
+		return false, fmt.Errorf("could not determine config path")
+	}
+
+	f, err := os.Open(path)
+	if os.IsNotExist(err) {
+		return false, nil
+	}
+	if err != nil {
+		return false, err
+	}
+
+	var lines []string
+	found := false
+	scanner := bufio.NewScanner(f)
+	for scanner.Scan() {
+		line := scanner.Text()
+		trimmed := strings.TrimSpace(line)
+		if trimmed == "" || strings.HasPrefix(trimmed, "#") {
+			lines = append(lines, line)
+			continue
+		}
+		k, _, ok := strings.Cut(trimmed, "=")
+		if ok && strings.TrimSpace(k) == key {
+			found = true
+			continue
+		}
+		lines = append(lines, line)
+	}
+	f.Close()
+
+	if !found {
+		return false, nil
+	}
+
+	out, err := os.OpenFile(path, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0o600)
+	if err != nil {
+		return false, err
+	}
+	defer out.Close()
+	for _, line := range lines {
+		fmt.Fprintln(out, line)
+	}
+	return true, nil
+}

--- a/cmd/configcmd.go
+++ b/cmd/configcmd.go
@@ -2,6 +2,9 @@ package cmd
 
 import (
 	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
 	"strings"
 
 	"github.com/spf13/cobra"
@@ -121,8 +124,77 @@ var configSetCmd = &cobra.Command{
 	},
 }
 
+var configUnsetCmd = &cobra.Command{
+	Use:   "unset <key>",
+	Short: "Remove a key from the configuration file",
+	Args:  cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		key := args[0]
+		if _, ok := configValues()[key]; !ok {
+			return fmt.Errorf("unknown config key %q; valid keys: %s", key, strings.Join(knownConfigKeys, ", "))
+		}
+
+		removed, err := deleteFromConfig(key)
+		if err != nil {
+			return fmt.Errorf("updating config: %w", err)
+		}
+
+		path := configPath
+		if path == "" {
+			path = defaultConfigPath()
+		}
+		if !removed {
+			fmt.Fprintf(cmd.ErrOrStderr(), "warning: %s was not set in %s\n", key, path)
+		} else {
+			fmt.Fprintf(cmd.OutOrStdout(), "Unset %s in %s\n", key, path)
+		}
+		return nil
+	},
+}
+
+var configEditCmd = &cobra.Command{
+	Use:   "edit",
+	Short: "Open the configuration file in $EDITOR",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		path := configPath
+		if path == "" {
+			path = defaultConfigPath()
+		}
+		if path == "" {
+			return fmt.Errorf("could not determine config path")
+		}
+
+		if _, err := os.Stat(path); os.IsNotExist(err) {
+			if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+				return fmt.Errorf("creating config directory: %w", err)
+			}
+			f, err := os.OpenFile(path, os.O_CREATE, 0o600)
+			if err != nil {
+				return fmt.Errorf("creating config file: %w", err)
+			}
+			f.Close()
+		}
+
+		editor := os.Getenv("EDITOR")
+		if editor == "" {
+			editor = os.Getenv("VISUAL")
+		}
+		if editor == "" {
+			editor = "vi"
+		}
+
+		c := exec.Command(editor, path) //nolint:gosec
+		c.Stdin = os.Stdin
+		c.Stdout = os.Stdout
+		c.Stderr = os.Stderr
+		return c.Run()
+	},
+}
+
 func init() {
 	configCmd.AddCommand(configShowCmd)
 	configCmd.AddCommand(configGetCmd)
 	configCmd.AddCommand(configSetCmd)
+	configCmd.AddCommand(configUnsetCmd)
+	configCmd.AddCommand(configEditCmd)
 }

--- a/cmd/configcmd_test.go
+++ b/cmd/configcmd_test.go
@@ -224,6 +224,79 @@ func TestConfigSetUpdatesExistingKey(t *testing.T) {
 	}
 }
 
+func TestConfigUnsetUnknownKey(t *testing.T) {
+	resetGlobals(t)
+	err := configUnsetCmd.RunE(configUnsetCmd, []string{"SKYLIGHT_INVALID"})
+	if err == nil {
+		t.Error("expected error for unknown key, got nil")
+	}
+}
+
+func TestConfigUnsetKeyNotInFile(t *testing.T) {
+	resetGlobals(t)
+	dir := t.TempDir()
+	configPath = filepath.Join(dir, "config")
+	t.Cleanup(func() { configPath = "" })
+
+	if err := os.WriteFile(configPath, []byte("SKYLIGHT_FRAME_ID=frame1\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	var errBuf bytes.Buffer
+	configUnsetCmd.SetErr(&errBuf)
+	if err := configUnsetCmd.RunE(configUnsetCmd, []string{"SKYLIGHT_TOKEN"}); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.Contains(errBuf.String(), "warning") {
+		t.Errorf("expected warning for missing key, got: %q", errBuf.String())
+	}
+}
+
+func TestConfigUnsetRemovesKey(t *testing.T) {
+	resetGlobals(t)
+	dir := t.TempDir()
+	configPath = filepath.Join(dir, "config")
+	t.Cleanup(func() { configPath = "" })
+
+	if err := os.WriteFile(configPath, []byte("SKYLIGHT_FRAME_ID=frame1\nSKYLIGHT_TOKEN=tok123\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	var outBuf bytes.Buffer
+	configUnsetCmd.SetOut(&outBuf)
+	if err := configUnsetCmd.RunE(configUnsetCmd, []string{"SKYLIGHT_TOKEN"}); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	data, _ := os.ReadFile(configPath)
+	content := string(data)
+	if strings.Contains(content, "SKYLIGHT_TOKEN") {
+		t.Error("config unset should have removed SKYLIGHT_TOKEN")
+	}
+	if !strings.Contains(content, "SKYLIGHT_FRAME_ID=frame1") {
+		t.Error("config unset should preserve other keys")
+	}
+	if !strings.Contains(outBuf.String(), "Unset") {
+		t.Errorf("expected 'Unset' in output, got: %q", outBuf.String())
+	}
+}
+
+func TestConfigEditCreatesFileIfMissing(t *testing.T) {
+	resetGlobals(t)
+	dir := t.TempDir()
+	configPath = filepath.Join(dir, "config")
+	t.Cleanup(func() { configPath = "" })
+
+	t.Setenv("EDITOR", "true")
+
+	if err := configEditCmd.RunE(configEditCmd, nil); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if _, err := os.Stat(configPath); os.IsNotExist(err) {
+		t.Error("config edit should create config file if missing")
+	}
+}
+
 // resetGlobals clears all config globals and resets them via t.Cleanup.
 func resetGlobals(t *testing.T) {
 	t.Helper()


### PR DESCRIPTION
## Summary
- `config unset <KEY>` — removes a key from `~/.skylight/config`; prints a warning if the key wasn't present
- `config edit` — opens the config file in `$EDITOR` (falls back to `$VISUAL`, then `vi`); creates the file if it doesn't exist

## Test plan
- [ ] CI passes
- [ ] `config unset SKYLIGHT_INVALID` errors with helpful message listing valid keys
- [ ] `config unset SKYLIGHT_EMAIL` on a file without that key prints a warning
- [ ] `config unset SKYLIGHT_FRAME_ID` removes the key while preserving others
- [ ] `config edit` with `EDITOR=true` exits cleanly and creates file if missing