### PR TITLE
feat: validate date flag inputs at CLI layer before API calls

### DIFF
--- a/cmd/bounty.go
+++ b/cmd/bounty.go
@@ -31,6 +31,11 @@ var bountyCreateCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		requireFrameID()
 
+		if err := validateDate(bountyDueDate); err != nil {
+			fmt.Println(err)
+			os.Exit(1)
+		}
+
 		client := getClient()
 
 		bounty, err := client.CreateBounty(frameID, lib.BountyData{
@@ -91,6 +96,13 @@ var bountyUpdateCmd = &cobra.Command{
 	Short: "Update a bounty's chore and paired reward",
 	Run: func(cmd *cobra.Command, args []string) {
 		requireFrameID()
+
+		if cmd.Flags().Changed("due-date") {
+			if err := validateDate(bountyDueDate); err != nil {
+				fmt.Println(err)
+				os.Exit(1)
+			}
+		}
 
 		client := getClient()
 

--- a/cmd/calendar.go
+++ b/cmd/calendar.go
@@ -30,6 +30,18 @@ var calendarListCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		requireFrameID()
 
+		for _, f := range []struct {
+			name string
+			val  string
+		}{{"start-date", calendarStartDate}, {"end-date", calendarEndDate}} {
+			if cmd.Flags().Changed(f.name) {
+				if err := validateDate(f.val); err != nil {
+					fmt.Println(err)
+					os.Exit(1)
+				}
+			}
+		}
+
 		client := getClient()
 
 		events, err := client.ListCalendarEvents(frameID, calendarStartDate, calendarEndDate)
@@ -138,6 +150,13 @@ var calendarWeekCmd = &cobra.Command{
 	Short: "Show a 7-day Mon-Sun view of calendar events",
 	Run: func(cmd *cobra.Command, args []string) {
 		requireFrameID()
+
+		if cmd.Flags().Changed("date") {
+			if err := validateDate(calendarWeekDate); err != nil {
+				fmt.Println(err)
+				os.Exit(1)
+			}
+		}
 
 		monday, err := weekStart(calendarWeekDate)
 		if err != nil {

--- a/cmd/chore.go
+++ b/cmd/chore.go
@@ -36,6 +36,18 @@ var choreListCmd = &cobra.Command{
 
 		client := getClient()
 
+		for _, f := range []struct {
+			name string
+			val  string
+		}{{"date", choreDate}, {"after", choreAfter}, {"before", choreBefore}} {
+			if cmd.Flags().Changed(f.name) {
+				if err := validateDate(f.val); err != nil {
+					fmt.Println(err)
+					os.Exit(1)
+				}
+			}
+		}
+
 		if cmd.Flags().Changed("week") {
 			monday, err := weekStart(choreWeek)
 			if err != nil {
@@ -80,6 +92,11 @@ var choreCreateCmd = &cobra.Command{
 	Short: "Create a chore",
 	Run: func(cmd *cobra.Command, args []string) {
 		requireFrameID()
+
+		if err := validateDate(choreDate); err != nil {
+			fmt.Println(err)
+			os.Exit(1)
+		}
 
 		client := getClient()
 
@@ -149,6 +166,13 @@ var choreUpdateCmd = &cobra.Command{
 	Short: "Update a chore",
 	Run: func(cmd *cobra.Command, args []string) {
 		requireFrameID()
+
+		if cmd.Flags().Changed("date") {
+			if err := validateDate(choreDate); err != nil {
+				fmt.Println(err)
+				os.Exit(1)
+			}
+		}
 
 		client := getClient()
 

--- a/cmd/helpers.go
+++ b/cmd/helpers.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"text/tabwriter"
+	"time"
 
 	"github.com/sebrandon1/go-skylight/lib"
 )
@@ -13,6 +14,17 @@ const (
 	boolYes = "yes"
 	boolNo  = "no"
 )
+
+// validateDate returns an error if date is non-empty and not in YYYY-MM-DD format.
+func validateDate(date string) error {
+	if date == "" {
+		return nil
+	}
+	if _, err := time.Parse(lib.DateFormat, date); err != nil {
+		return fmt.Errorf("invalid date %q: use YYYY-MM-DD format", date)
+	}
+	return nil
+}
 
 func printJSON(data any) {
 	output, err := json.MarshalIndent(data, "", "  ")

--- a/cmd/meal.go
+++ b/cmd/meal.go
@@ -130,6 +130,18 @@ var mealSittingsCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		requireFrameID()
 
+		for _, f := range []struct {
+			name string
+			val  string
+		}{{"date-min", sittingDateMin}, {"date-max", sittingDateMax}} {
+			if cmd.Flags().Changed(f.name) {
+				if err := validateDate(f.val); err != nil {
+					fmt.Println(err)
+					os.Exit(1)
+				}
+			}
+		}
+
 		client := getClient()
 
 		sittings, err := client.ListMealSittings(frameID, lib.MealSittingListOptions{
@@ -150,6 +162,11 @@ var mealCreateSittingCmd = &cobra.Command{
 	Short: "Create a meal sitting",
 	Run: func(cmd *cobra.Command, args []string) {
 		requireFrameID()
+
+		if err := validateDate(sittingDate); err != nil {
+			fmt.Println(err)
+			os.Exit(1)
+		}
 
 		client := getClient()
 
@@ -173,6 +190,11 @@ var mealDeleteSittingCmd = &cobra.Command{
 	Short: "Delete a meal sitting instance",
 	Run: func(cmd *cobra.Command, args []string) {
 		requireFrameID()
+
+		if err := validateDate(sittingDate); err != nil {
+			fmt.Println(err)
+			os.Exit(1)
+		}
 
 		client := getClient()
 


### PR DESCRIPTION
## Summary
- Add `validateDate` helper in `cmd/helpers.go` using `lib.DateFormat`
- Validate `--date`, `--after`, `--before`, `--due-date`, `--date-min`, `--date-max`, `--start-date`, `--end-date` in bounty, chore, meal, and calendar commands
- Invalid dates now fail immediately with `invalid date "X": use YYYY-MM-DD format` instead of a cryptic API error

## Test plan
- [ ] CI passes
- [ ] `chore list --date not-a-date` prints clear error and exits 1
- [ ] `meal sittings --date-min 2026/05/01` prints clear error (wrong separator)
- [ ] Valid dates still reach the API normally