### PR TITLE
refactor: replace raw date format literals with lib.DateFormat in cmd/

### DIFF
--- a/cmd/calendar.go
+++ b/cmd/calendar.go
@@ -169,8 +169,8 @@ var calendarWeekCmd = &cobra.Command{
 
 		events, err := client.ListCalendarEvents(
 			frameID,
-			monday.Format("2006-01-02"),
-			sunday.Format("2006-01-02"),
+			monday.Format(lib.DateFormat),
+			sunday.Format(lib.DateFormat),
 		)
 		if err != nil {
 			fmt.Printf("Error listing calendar events: %v\n", err)

--- a/cmd/calendar_week.go
+++ b/cmd/calendar_week.go
@@ -25,7 +25,7 @@ func buildCalendarWeeklyView(events []lib.CalendarEvent, monday time.Time) []Wee
 		d := monday.AddDate(0, 0, i)
 		days[i] = WeeklyCalendarDay{
 			Day:     d.Format("Mon"),
-			Date:    d.Format("2006-01-02"),
+			Date:    d.Format(lib.DateFormat),
 			Display: d.Format("Jan 02"),
 			Events:  []lib.CalendarEvent{},
 		}

--- a/cmd/chore.go
+++ b/cmd/chore.go
@@ -56,8 +56,8 @@ var choreListCmd = &cobra.Command{
 			}
 			sunday := monday.AddDate(0, 0, 6)
 			chores, err := client.ListChores(frameID, lib.ChoreListOptions{
-				After:       monday.Format("2006-01-02"),
-				Before:      sunday.Format("2006-01-02"),
+				After:       monday.Format(lib.DateFormat),
+				Before:      sunday.Format(lib.DateFormat),
 				IncludeLate: true,
 			})
 			if err != nil {

--- a/cmd/chore_streak.go
+++ b/cmd/chore_streak.go
@@ -129,8 +129,8 @@ for a given member are ignored and do not break streaks.`,
 		client := getClient()
 
 		now := time.Now()
-		end := now.Format("2006-01-02")
-		start := now.AddDate(0, 0, -(streakDays - 1)).Format("2006-01-02")
+		end := now.Format(lib.DateFormat)
+		start := now.AddDate(0, 0, -(streakDays - 1)).Format(lib.DateFormat)
 
 		var (
 			categories []lib.Category
@@ -171,7 +171,7 @@ for a given member are ignored and do not break streaks.`,
 
 		dates := make([]string, 0, streakDays)
 		for i := -(streakDays - 1); i <= 0; i++ {
-			dates = append(dates, now.AddDate(0, 0, i).Format("2006-01-02"))
+			dates = append(dates, now.AddDate(0, 0, i).Format(lib.DateFormat))
 		}
 
 		results := computeChoreStreaks(chores, dates, catNames)

--- a/cmd/chore_week.go
+++ b/cmd/chore_week.go
@@ -26,7 +26,7 @@ func weekStart(date string) (time.Time, error) {
 		t = time.Now()
 	} else {
 		var err error
-		t, err = time.Parse("2006-01-02", date)
+		t, err = time.Parse(lib.DateFormat, date)
 		if err != nil {
 			return time.Time{}, fmt.Errorf("invalid date %q: use YYYY-MM-DD format", date)
 		}
@@ -46,7 +46,7 @@ func buildWeeklyView(chores []lib.Chore, monday time.Time) []WeeklyChoreDay {
 		d := monday.AddDate(0, 0, i)
 		days[i] = WeeklyChoreDay{
 			Day:     d.Format("Mon"),
-			Date:    d.Format("2006-01-02"),
+			Date:    d.Format(lib.DateFormat),
 			Display: d.Format("Jan 02"),
 			Chores:  []lib.Chore{},
 		}

--- a/cmd/status.go
+++ b/cmd/status.go
@@ -17,7 +17,7 @@ var statusCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		requireFrameID()
 		client := getClient()
-		today := time.Now().Format("2006-01-02")
+		today := time.Now().Format(lib.DateFormat)
 
 		frame, err := client.GetFrame(frameID)
 		if err != nil {


### PR DESCRIPTION
## Summary
- Replace all 11 occurrences of `"2006-01-02"` in `cmd/` with `lib.DateFormat`
- Affected files: `chore.go`, `chore_week.go`, `chore_streak.go`, `calendar.go`, `calendar_week.go`, `status.go`
- `boolNo` was already extracted in a prior PR — nothing left to do there

## Test plan
- [ ] CI passes