### PR TITLE
feat: add photo download command

### DIFF
--- a/cmd/photo.go
+++ b/cmd/photo.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"fmt"
+	"net/url"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -12,10 +13,12 @@ import (
 )
 
 var (
-	photoPageToken string
-	photoFile      string
-	photoCaption   string
-	photoMessageID []string
+	photoPageToken   string
+	photoFile        string
+	photoCaption     string
+	photoMessageID   []string
+	photoOutputDir   string
+	photoDownloadAll bool
 )
 
 var photoCmd = &cobra.Command{
@@ -104,10 +107,88 @@ var photoDeleteCmd = &cobra.Command{
 	},
 }
 
+var photoDownloadCmd = &cobra.Command{
+	Use:   "download",
+	Short: "Download photos from a frame to local files",
+	Run: func(cmd *cobra.Command, args []string) {
+		requireFrameID()
+
+		if !photoDownloadAll && len(photoMessageID) == 0 {
+			fmt.Println("Error: specify --message-id or --all")
+			os.Exit(1)
+		}
+
+		client := getClient()
+
+		wantIDs := make(map[string]bool, len(photoMessageID))
+		for _, id := range photoMessageID {
+			wantIDs[id] = true
+		}
+
+		var toDownload []lib.Photo
+		pageToken := ""
+		for {
+			photos, nextToken, err := client.ListPhotos(frameID, lib.PhotoListOptions{PageToken: pageToken})
+			if err != nil {
+				fmt.Printf("Error listing photos: %v\n", err)
+				os.Exit(1)
+			}
+			for _, p := range photos {
+				if photoDownloadAll || wantIDs[p.ID] {
+					toDownload = append(toDownload, p)
+				}
+			}
+			if nextToken == "" {
+				break
+			}
+			pageToken = nextToken
+		}
+
+		if len(toDownload) == 0 {
+			fmt.Println("No matching photos found")
+			return
+		}
+
+		if err := os.MkdirAll(photoOutputDir, 0o755); err != nil {
+			fmt.Printf("Error creating output directory: %v\n", err)
+			os.Exit(1)
+		}
+
+		for _, p := range toDownload {
+			data, err := client.DownloadPhoto(p.AssetURL)
+			if err != nil {
+				fmt.Printf("Error downloading %s: %v\n", p.ID, err)
+				continue
+			}
+			ext := photoAssetExt(p.AssetURL, p.AssetType)
+			filename := filepath.Join(photoOutputDir, p.ID+ext)
+			if err := os.WriteFile(filename, data, 0o600); err != nil {
+				fmt.Printf("Error writing %s: %v\n", filename, err)
+				continue
+			}
+			fmt.Printf("Saved %s\n", filename)
+		}
+	},
+}
+
+// photoAssetExt infers the file extension from the asset URL path, falling back to asset type.
+func photoAssetExt(assetURL, assetType string) string {
+	if u, err := url.Parse(assetURL); err == nil {
+		if ext := filepath.Ext(u.Path); ext != "" {
+			return ext
+		}
+	}
+	if strings.HasPrefix(assetType, "video") {
+		return ".mp4"
+	}
+	return ".jpg"
+}
+
 func init() {
 	photoCmd.AddCommand(photoListCmd)
 	photoCmd.AddCommand(photoUploadCmd)
 	photoCmd.AddCommand(photoDeleteCmd)
+	photoCmd.AddCommand(photoDownloadCmd)
 
 	photoListCmd.Flags().StringVar(&photoPageToken, "page-token", "", "Pagination token (omit to start from beginning)")
 
@@ -117,4 +198,8 @@ func init() {
 
 	photoDeleteCmd.Flags().StringArrayVar(&photoMessageID, "message-id", nil, "Message ID to delete (repeatable)")
 	photoDeleteCmd.MarkFlagRequired("message-id") //nolint:errcheck
+
+	photoDownloadCmd.Flags().StringArrayVar(&photoMessageID, "message-id", nil, "Message ID to download (repeatable)")
+	photoDownloadCmd.Flags().BoolVar(&photoDownloadAll, "all", false, "Download all photos")
+	photoDownloadCmd.Flags().StringVar(&photoOutputDir, "output-dir", ".", "Directory to save downloaded files")
 }

--- a/lib/photo.go
+++ b/lib/photo.go
@@ -89,6 +89,28 @@ func (c *Client) UploadPhoto(frameID string, ext string, imageData []byte, capti
 	return &result, nil
 }
 
+// DownloadPhoto fetches the raw bytes of a photo from its CDN asset URL.
+// The URL is a pre-signed CloudFront URL returned by ListPhotos — no auth header is needed.
+func (c *Client) DownloadPhoto(assetURL string) ([]byte, error) {
+	req, err := http.NewRequest("GET", assetURL, nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create download request: %w", err)
+	}
+	resp, err := c.HTTPClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("failed to download photo: %w", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("download failed with status %d", resp.StatusCode)
+	}
+	data, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read photo data: %w", err)
+	}
+	return data, nil
+}
+
 // DeletePhotos deletes one or more photos by their message IDs.
 func (c *Client) DeletePhotos(frameID string, messageIDs []int) error {
 	req, err := newRequestWithBody(


### PR DESCRIPTION
## Summary
- Add `DownloadPhoto(assetURL string) ([]byte, error)` to `lib/photo.go` — plain GET against the pre-signed CloudFront URL (no auth header needed)
- Add `photo download` command to `cmd/photo.go`:
  - `--message-id ID` (repeatable) — download specific photos by ID
  - `--all` — download every photo on the frame
  - `--output-dir DIR` — destination directory (default: `.`)
  - Files saved as `<message-id>.<ext>` with extension inferred from asset URL path
  - Pages through all photos to find matching IDs

## Test plan
- [ ] CI passes
- [ ] `photo download` with no flags prints a helpful error
- [ ] `photo download --message-id ID --output-dir /tmp` saves `ID.jpg` to `/tmp`
- [ ] `photo download --all --output-dir /tmp` downloads all photos