### PR TITLE
test: add cmd/ and lib/ coverage for photo, session, and helpers (issue #91)

### DIFF
--- a/cmd/helpers_test.go
+++ b/cmd/helpers_test.go
@@ -359,3 +359,162 @@ func TestPrintJSONOutputIsIndented(t *testing.T) {
 		t.Errorf("Expected indented output with two spaces, got: %s", output)
 	}
 }
+
+func TestValidateDate_Empty(t *testing.T) {
+	if err := validateDate(""); err != nil {
+		t.Errorf("expected nil for empty string, got %v", err)
+	}
+}
+
+func TestValidateDate_Valid(t *testing.T) {
+	if err := validateDate("2026-04-27"); err != nil {
+		t.Errorf("expected nil for valid date, got %v", err)
+	}
+}
+
+func TestValidateDate_Invalid(t *testing.T) {
+	cases := []string{"not-a-date", "04/27/2026", "2026-13-01", "2026-4-7"}
+	for _, c := range cases {
+		if err := validateDate(c); err == nil {
+			t.Errorf("expected error for %q, got nil", c)
+		}
+	}
+}
+
+func TestPrintOutputBountiesTable(t *testing.T) {
+	outputFormat = outputTable
+	bounties := []lib.Bounty{
+		{Chore: lib.Chore{ID: "c1", Title: "Walk dog", Points: 10, DueDate: "2026-04-28"}, Reward: lib.Reward{ID: "r1", Title: "Ice cream"}},
+	}
+	output := captureStdout(func() { printOutput(bounties) })
+	if !strings.Contains(output, "Walk dog") {
+		t.Errorf("Expected chore title in bounties table, got: %s", output)
+	}
+	if !strings.Contains(output, "Ice cream") {
+		t.Errorf("Expected reward title in bounties table, got: %s", output)
+	}
+}
+
+func TestPrintOutputSourceCalendarsTable(t *testing.T) {
+	outputFormat = outputTable
+	cals := []lib.SourceCalendar{
+		{ID: "sc1", Name: "Google Calendar", Provider: "google", Color: "blue"},
+	}
+	output := captureStdout(func() { printOutput(cals) })
+	if !strings.Contains(output, "Google Calendar") {
+		t.Errorf("Expected source calendar name in table, got: %s", output)
+	}
+	if !strings.Contains(output, "PROVIDER") {
+		t.Errorf("Expected PROVIDER header in table, got: %s", output)
+	}
+}
+
+func TestPrintOutputDevicesTable(t *testing.T) {
+	outputFormat = outputTable
+	devices := []lib.Device{
+		{ID: "d1", Name: "Kitchen Frame", Online: true},
+		{ID: "d2", Name: "Bedroom Frame", Online: false},
+	}
+	output := captureStdout(func() { printOutput(devices) })
+	if !strings.Contains(output, "Kitchen Frame") {
+		t.Errorf("Expected device name in table, got: %s", output)
+	}
+	if !strings.Contains(output, boolYes) {
+		t.Errorf("Expected %q for online device, got: %s", boolYes, output)
+	}
+	if !strings.Contains(output, boolNo) {
+		t.Errorf("Expected %q for offline device, got: %s", boolNo, output)
+	}
+}
+
+func TestPrintOutputAvatarsTable(t *testing.T) {
+	outputFormat = outputTable
+	avatars := []lib.Avatar{
+		{ID: "a1", Name: "Alice Avatar", ImageURL: "https://example.com/avatar.png"},
+	}
+	output := captureStdout(func() { printOutput(avatars) })
+	if !strings.Contains(output, "Alice Avatar") {
+		t.Errorf("Expected avatar name in table, got: %s", output)
+	}
+	if !strings.Contains(output, "IMAGE URL") {
+		t.Errorf("Expected IMAGE URL header in table, got: %s", output)
+	}
+}
+
+func TestPrintOutputColorsTable(t *testing.T) {
+	outputFormat = outputTable
+	colors := []lib.Color{
+		{Name: "Sky Blue", Hex: "#87CEEB"},
+	}
+	output := captureStdout(func() { printOutput(colors) })
+	if !strings.Contains(output, "Sky Blue") {
+		t.Errorf("Expected color name in table, got: %s", output)
+	}
+	if !strings.Contains(output, "#87CEEB") {
+		t.Errorf("Expected hex value in table, got: %s", output)
+	}
+}
+
+func TestPrintOutputListsTable(t *testing.T) {
+	outputFormat = outputTable
+	lists := []lib.List{
+		{ID: "l1", Title: "Shopping", Color: "green", Kind: "checklist", Items: []lib.ListItem{{}, {}}},
+	}
+	output := captureStdout(func() { printOutput(lists) })
+	if !strings.Contains(output, "Shopping") {
+		t.Errorf("Expected list title in table, got: %s", output)
+	}
+	if !strings.Contains(output, "2") {
+		t.Errorf("Expected item count in table, got: %s", output)
+	}
+}
+
+func TestPrintOutputMealCategoriesTable(t *testing.T) {
+	outputFormat = outputTable
+	cats := []lib.MealCategory{
+		{ID: "mc1", Name: "Dinner", Color: "red"},
+	}
+	output := captureStdout(func() { printOutput(cats) })
+	if !strings.Contains(output, "Dinner") {
+		t.Errorf("Expected meal category name in table, got: %s", output)
+	}
+}
+
+func TestPrintOutputRecipesTable(t *testing.T) {
+	outputFormat = outputTable
+	recipes := []lib.Recipe{
+		{ID: "rec1", Title: "Pasta", MealCategoryID: "mc1", URL: "https://example.com/pasta"},
+	}
+	output := captureStdout(func() { printOutput(recipes) })
+	if !strings.Contains(output, "Pasta") {
+		t.Errorf("Expected recipe title in table, got: %s", output)
+	}
+	if !strings.Contains(output, "URL") {
+		t.Errorf("Expected URL header in table, got: %s", output)
+	}
+}
+
+func TestPrintOutputMealSittingsTable(t *testing.T) {
+	outputFormat = outputTable
+	sittings := []lib.MealSitting{
+		{ID: "ms1", Summary: "Taco Tuesday", Date: "2026-04-28", RecipeID: "rec1", MealCategoryID: "mc1"},
+	}
+	output := captureStdout(func() { printOutput(sittings) })
+	if !strings.Contains(output, "Taco Tuesday") {
+		t.Errorf("Expected meal sitting summary in table, got: %s", output)
+	}
+}
+
+func TestPrintOutputPhotosTable(t *testing.T) {
+	outputFormat = outputTable
+	photos := []lib.Photo{
+		{ID: "p1", AssetType: "image/jpeg", Status: "active", CreatedAt: "2026-04-28T10:00:00Z"},
+	}
+	output := captureStdout(func() { printOutput(photos) })
+	if !strings.Contains(output, "p1") {
+		t.Errorf("Expected photo ID in table, got: %s", output)
+	}
+	if !strings.Contains(output, "image/jpeg") {
+		t.Errorf("Expected asset type in table, got: %s", output)
+	}
+}

--- a/cmd/photo_test.go
+++ b/cmd/photo_test.go
@@ -1,0 +1,29 @@
+package cmd
+
+import "testing"
+
+func TestPhotoAssetExt(t *testing.T) {
+	cases := []struct {
+		url       string
+		assetType string
+		want      string
+	}{
+		{"https://cdn.example.com/photos/abc.jpg", "image/jpeg", ".jpg"},
+		{"https://cdn.example.com/photos/abc.png", "image/png", ".png"},
+		{"https://cdn.example.com/photos/abc.mp4", "video/mp4", ".mp4"},
+		{"https://cdn.example.com/photos/abc.gif", "image/gif", ".gif"},
+		// no extension in URL: fall back to asset type
+		{"https://cdn.example.com/photos/abc", "video/mp4", ".mp4"},
+		{"https://cdn.example.com/photos/abc", "video/quicktime", ".mp4"},
+		{"https://cdn.example.com/photos/abc", "image/jpeg", ".jpg"},
+		// empty URL, video type maps to .mp4; non-video type defaults to .jpg regardless of subtype
+		{"", "video/quicktime", ".mp4"},
+		{"", "image/png", ".jpg"},
+	}
+	for _, c := range cases {
+		got := photoAssetExt(c.url, c.assetType)
+		if got != c.want {
+			t.Errorf("photoAssetExt(%q, %q) = %q, want %q", c.url, c.assetType, got, c.want)
+		}
+	}
+}

--- a/cmd/session_test.go
+++ b/cmd/session_test.go
@@ -1,0 +1,22 @@
+package cmd
+
+import (
+	"regexp"
+	"testing"
+)
+
+var uuidRe = regexp.MustCompile(`^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$`)
+
+func TestNewUUID_Format(t *testing.T) {
+	id := newUUID()
+	if !uuidRe.MatchString(id) {
+		t.Errorf("newUUID() = %q, want UUID v4 format", id)
+	}
+}
+
+func TestNewUUID_Unique(t *testing.T) {
+	a, b := newUUID(), newUUID()
+	if a == b {
+		t.Errorf("newUUID() returned identical values: %q", a)
+	}
+}

--- a/lib/photo_test.go
+++ b/lib/photo_test.go
@@ -1,0 +1,265 @@
+package lib
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestExtToContentType(t *testing.T) {
+	cases := []struct {
+		ext  string
+		want string
+	}{
+		{"jpg", "image/jpeg"},
+		{"JPG", "image/jpeg"},
+		{"jpeg", "image/jpeg"},
+		{"png", "image/png"},
+		{"PNG", "image/png"},
+		{"gif", "image/gif"},
+		{"webp", "image/webp"},
+		{"mp4", "video/mp4"},
+		{"MP4", "video/mp4"},
+		{"mov", "video/quicktime"},
+		{"MOV", "video/quicktime"},
+		{"bmp", "image/jpeg"},  // unknown falls back to jpeg
+		{"tiff", "image/jpeg"}, // unknown falls back to jpeg
+		{"", "image/jpeg"},     // empty falls back to jpeg
+	}
+	for _, c := range cases {
+		got := extToContentType(c.ext)
+		if got != c.want {
+			t.Errorf("extToContentType(%q) = %q, want %q", c.ext, got, c.want)
+		}
+	}
+}
+
+func TestListPhotos_Success(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/frames/frame1/messages" {
+			t.Errorf("unexpected path: %s", r.URL.Path)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		if err := json.NewEncoder(w).Encode(photoAPIResponse{
+			Data: []photoAPIEntry{
+				{ID: "p1", Attributes: struct {
+					Status       string `json:"status"`
+					AssetType    string `json:"asset_type"`
+					CreatedAt    string `json:"created_at"`
+					UpdatedAt    string `json:"updated_at"`
+					ThumbnailURL string `json:"thumbnail_url"`
+					AssetURL     string `json:"asset_url"`
+					SenderID     int    `json:"sender_id"`
+				}{Status: "active", AssetType: "image/jpeg"}},
+			},
+			Meta: &photoMeta{NextPageToken: "tok2"},
+		}); err != nil {
+			t.Errorf("encode: %v", err)
+		}
+	}))
+	defer srv.Close()
+
+	old := SkylightURL
+	SkylightURL = srv.URL + "/api"
+	defer func() { SkylightURL = old }()
+
+	client, _ := NewClientWithToken("u", "t")
+	photos, nextToken, err := client.ListPhotos("frame1", PhotoListOptions{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(photos) != 1 {
+		t.Fatalf("want 1 photo, got %d", len(photos))
+	}
+	if photos[0].ID != "p1" {
+		t.Errorf("ID: want p1, got %s", photos[0].ID)
+	}
+	if nextToken != "tok2" {
+		t.Errorf("nextToken: want tok2, got %s", nextToken)
+	}
+}
+
+func TestListPhotos_WithPageToken(t *testing.T) {
+	var gotToken string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotToken = r.URL.Query().Get("page_token")
+		w.Header().Set("Content-Type", "application/json")
+		if err := json.NewEncoder(w).Encode(photoAPIResponse{}); err != nil {
+			t.Errorf("encode: %v", err)
+		}
+	}))
+	defer srv.Close()
+
+	old := SkylightURL
+	SkylightURL = srv.URL + "/api"
+	defer func() { SkylightURL = old }()
+
+	client, _ := NewClientWithToken("u", "t")
+	_, _, err := client.ListPhotos("frame1", PhotoListOptions{PageToken: "mytoken"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if gotToken != "mytoken" {
+		t.Errorf("page_token: want mytoken, got %q", gotToken)
+	}
+}
+
+func TestListPhotos_DefaultPageToken(t *testing.T) {
+	var gotToken string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotToken = r.URL.Query().Get("page_token")
+		w.Header().Set("Content-Type", "application/json")
+		if err := json.NewEncoder(w).Encode(photoAPIResponse{}); err != nil {
+			t.Errorf("encode: %v", err)
+		}
+	}))
+	defer srv.Close()
+
+	old := SkylightURL
+	SkylightURL = srv.URL + "/api"
+	defer func() { SkylightURL = old }()
+
+	client, _ := NewClientWithToken("u", "t")
+	_, _, err := client.ListPhotos("frame1", PhotoListOptions{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if gotToken != "__START__" {
+		t.Errorf("page_token: want __START__, got %q", gotToken)
+	}
+}
+
+func TestListPhotos_NoNextToken(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if err := json.NewEncoder(w).Encode(photoAPIResponse{Data: []photoAPIEntry{}}); err != nil {
+			t.Errorf("encode: %v", err)
+		}
+	}))
+	defer srv.Close()
+
+	old := SkylightURL
+	SkylightURL = srv.URL + "/api"
+	defer func() { SkylightURL = old }()
+
+	client, _ := NewClientWithToken("u", "t")
+	_, nextToken, err := client.ListPhotos("frame1", PhotoListOptions{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if nextToken != "" {
+		t.Errorf("nextToken: want empty, got %q", nextToken)
+	}
+}
+
+func TestDeletePhotos_Success(t *testing.T) {
+	var gotIDs []int
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodDelete {
+			t.Errorf("method: want DELETE, got %s", r.Method)
+		}
+		var body photoDeleteRequest
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			t.Errorf("decode: %v", err)
+		}
+		gotIDs = body.MessageIDs
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	old := SkylightURL
+	SkylightURL = srv.URL + "/api"
+	defer func() { SkylightURL = old }()
+
+	client, _ := NewClientWithToken("u", "t")
+	err := client.DeletePhotos("frame1", []int{1, 2, 3})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(gotIDs) != 3 || gotIDs[0] != 1 || gotIDs[1] != 2 || gotIDs[2] != 3 {
+		t.Errorf("message IDs: want [1 2 3], got %v", gotIDs)
+	}
+}
+
+func TestDeletePhotos_Error(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusForbidden)
+	}))
+	defer srv.Close()
+
+	old := SkylightURL
+	SkylightURL = srv.URL + "/api"
+	defer func() { SkylightURL = old }()
+
+	client, _ := NewClientWithToken("u", "t")
+	err := client.DeletePhotos("frame1", []int{1})
+	if err == nil {
+		t.Error("expected error for 403 response, got nil")
+	}
+}
+
+func TestDownloadPhoto_Success(t *testing.T) {
+	imageData := []byte("fake-image-bytes")
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		if _, err := w.Write(imageData); err != nil {
+			t.Errorf("write: %v", err)
+		}
+	}))
+	defer srv.Close()
+
+	client, _ := NewClientWithToken("u", "t")
+	data, err := client.DownloadPhoto(srv.URL + "/photo.jpg")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if string(data) != string(imageData) {
+		t.Errorf("data: want %q, got %q", imageData, data)
+	}
+}
+
+func TestDownloadPhoto_ErrorStatus(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer srv.Close()
+
+	client, _ := NewClientWithToken("u", "t")
+	_, err := client.DownloadPhoto(srv.URL + "/photo.jpg")
+	if err == nil {
+		t.Error("expected error for 404, got nil")
+	}
+}
+
+func TestDownloadPhoto_BadURL(t *testing.T) {
+	client, _ := NewClientWithToken("u", "t")
+	_, err := client.DownloadPhoto("://bad-url")
+	if err == nil {
+		t.Error("expected error for bad URL, got nil")
+	}
+}
+
+func TestListPhotos_BadURL(t *testing.T) {
+	old := SkylightURL
+	SkylightURL = "://bad"
+	defer func() { SkylightURL = old }()
+
+	client, _ := NewClientWithToken("u", "t")
+	_, _, err := client.ListPhotos("frame1", PhotoListOptions{})
+	if err == nil {
+		t.Error("expected error for bad URL, got nil")
+	}
+}
+
+func TestDeletePhotos_BadURL(t *testing.T) {
+	old := SkylightURL
+	SkylightURL = "://bad"
+	defer func() { SkylightURL = old }()
+
+	client, _ := NewClientWithToken("u", "t")
+	err := client.DeletePhotos("frame1", []int{1})
+	if err == nil {
+		t.Error("expected error for bad URL, got nil")
+	}
+}

--- a/lib/session_test.go
+++ b/lib/session_test.go
@@ -1,0 +1,148 @@
+package lib
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestLogin_Success(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprint(w, `{"data":{"id":"uid1","type":"authenticated_user","attributes":{"token":"tok1"}}}`)
+	}))
+	defer srv.Close()
+
+	old := SkylightURL
+	SkylightURL = srv.URL + "/api"
+	defer func() { SkylightURL = old }()
+
+	client, _ := NewClientWithToken("u", "t")
+	sess, err := client.Login("user@example.com", "password")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if sess.UserID != "uid1" {
+		t.Errorf("UserID: want uid1, got %s", sess.UserID)
+	}
+	if sess.APIToken != "tok1" {
+		t.Errorf("APIToken: want tok1, got %s", sess.APIToken)
+	}
+}
+
+func TestLogin_Error(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusUnauthorized)
+		fmt.Fprint(w, `{"error":"invalid credentials"}`)
+	}))
+	defer srv.Close()
+
+	old := SkylightURL
+	SkylightURL = srv.URL + "/api"
+	defer func() { SkylightURL = old }()
+
+	client, _ := NewClientWithToken("u", "t")
+	_, err := client.Login("bad@example.com", "wrong")
+	if err == nil {
+		t.Error("expected error for unauthorized response, got nil")
+	}
+}
+
+func TestLogin_BadURL(t *testing.T) {
+	old := SkylightURL
+	SkylightURL = "://bad"
+	defer func() { SkylightURL = old }()
+
+	client, _ := NewClientWithToken("u", "t")
+	_, err := client.Login("u@example.com", "pw")
+	if err == nil {
+		t.Error("expected error for bad URL, got nil")
+	}
+}
+
+func TestRefreshOAuthToken_Success(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			t.Errorf("method: want POST, got %s", r.Method)
+		}
+		r.Body = http.MaxBytesReader(w, r.Body, 1<<20)
+		if err := r.ParseForm(); err != nil {
+			t.Errorf("parse form: %v", err)
+		}
+		if r.FormValue("grant_type") != "refresh_token" {
+			t.Errorf("grant_type: want refresh_token, got %s", r.FormValue("grant_type"))
+		}
+		if r.FormValue("refresh_token") != "myrefresh" {
+			t.Errorf("refresh_token: want myrefresh, got %s", r.FormValue("refresh_token"))
+		}
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprint(w, `{"access_token":"newaccess","refresh_token":"newrefresh","expires_in":3600}`)
+	}))
+	defer srv.Close()
+
+	old := OAuthURL
+	OAuthURL = srv.URL
+	defer func() { OAuthURL = old }()
+
+	tok, err := RefreshOAuthToken("myrefresh", "fp1")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if tok.AccessToken != "newaccess" {
+		t.Errorf("AccessToken: want newaccess, got %s", tok.AccessToken)
+	}
+	if tok.RefreshToken != "newrefresh" {
+		t.Errorf("RefreshToken: want newrefresh, got %s", tok.RefreshToken)
+	}
+}
+
+func TestRefreshOAuthToken_Error(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusUnauthorized)
+		fmt.Fprint(w, `{"error":"invalid_grant"}`)
+	}))
+	defer srv.Close()
+
+	old := OAuthURL
+	OAuthURL = srv.URL
+	defer func() { OAuthURL = old }()
+
+	_, err := RefreshOAuthToken("badtoken", "fp1")
+	if err == nil {
+		t.Error("expected error for 401 response, got nil")
+	}
+}
+
+func TestRefreshOAuthToken_MissingAccessToken(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprint(w, `{"refresh_token":"r1"}`)
+	}))
+	defer srv.Close()
+
+	old := OAuthURL
+	OAuthURL = srv.URL
+	defer func() { OAuthURL = old }()
+
+	_, err := RefreshOAuthToken("tok", "fp1")
+	if err == nil {
+		t.Error("expected error for missing access_token, got nil")
+	}
+}
+
+func TestLoginHeadless_CSRFFetchFailure(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprint(w, `<html><body>no token here</body></html>`)
+	}))
+	defer srv.Close()
+
+	oldAuth := AuthSessionURL
+	AuthSessionURL = srv.URL + "/auth/session"
+	defer func() { AuthSessionURL = oldAuth }()
+
+	_, err := LoginHeadless("u@example.com", "pw", "fp1")
+	if err == nil {
+		t.Error("expected error when CSRF token not found, got nil")
+	}
+}


### PR DESCRIPTION
## Summary

- `cmd/photo_test.go`: table-driven tests for `photoAssetExt` (URL extension, video/image type fallbacks)
- `cmd/session_test.go`: tests for `newUUID` — format validation, uniqueness, and UUID v4 version bit
- `lib/photo_test.go`: tests for `extToContentType`, `ListPhotos` (pagination, default token), `DownloadPhoto`, `DeletePhotos`
- `lib/session_test.go`: tests for `Login` (success/error/bad URL), `RefreshOAuthToken` (success/error/missing token), `LoginHeadless` CSRF failure path
- `cmd/helpers_test.go`: adds `validateDate` tests and table-output coverage for all previously untested types: bounties, source calendars, devices, avatars, colors, lists, meal categories, recipes, meal sittings, and photos

Closes #91

## Test plan

- [ ] `make test` passes
- [ ] `make lint` passes