### PR TITLE
fix: write all errors to stderr with operation context (issue #86)

### DIFF
--- a/cmd/analytics.go
+++ b/cmd/analytics.go
@@ -69,20 +69,16 @@ var analyticsCmd = &cobra.Command{
 		wg.Wait()
 
 		if catErr != nil {
-			fmt.Fprintf(os.Stderr, "Error listing categories: %v\n", catErr)
-			os.Exit(1)
+			fatal("listing categories", catErr)
 		}
 		if choreErr != nil {
-			fmt.Fprintf(os.Stderr, "Error listing chores: %v\n", choreErr)
-			os.Exit(1)
+			fatal("listing chores", choreErr)
 		}
 		if rewardErr != nil {
-			fmt.Fprintf(os.Stderr, "Error listing rewards: %v\n", rewardErr)
-			os.Exit(1)
+			fatal("listing rewards", rewardErr)
 		}
 		if pointsErr != nil {
-			fmt.Fprintf(os.Stderr, "Error getting reward points: %v\n", pointsErr)
-			os.Exit(1)
+			fatal("getting reward points", pointsErr)
 		}
 		if eventErr != nil {
 			fmt.Fprintf(os.Stderr, "Warning: calendar events unavailable: %v\n", eventErr)

--- a/cmd/bounty.go
+++ b/cmd/bounty.go
@@ -32,7 +32,7 @@ var bountyCreateCmd = &cobra.Command{
 		requireFrameID()
 
 		if err := validateDate(bountyDueDate); err != nil {
-			fmt.Println(err)
+			fmt.Fprintln(os.Stderr, err)
 			os.Exit(1)
 		}
 
@@ -48,8 +48,7 @@ var bountyCreateCmd = &cobra.Command{
 			EmojiIcon:   bountyEmojiIcon,
 		})
 		if err != nil {
-			fmt.Printf("Error creating bounty: %v\n", err)
-			os.Exit(1)
+			fatal("creating bounty", err)
 		}
 
 		printJSON(bounty)
@@ -66,8 +65,7 @@ var bountyListCmd = &cobra.Command{
 
 		bounties, err := client.ListBounties(frameID)
 		if err != nil {
-			fmt.Printf("Error listing bounties: %v\n", err)
-			os.Exit(1)
+			fatal("listing bounties", err)
 		}
 
 		printOutput(bounties)
@@ -83,8 +81,7 @@ var bountyDeleteCmd = &cobra.Command{
 		client := getClient()
 
 		if err := client.DeleteBounty(frameID, bountyChoreID, bountyRewardID); err != nil {
-			fmt.Printf("Error deleting bounty: %v\n", err)
-			os.Exit(1)
+			fatal("deleting bounty", err)
 		}
 
 		fmt.Println("Bounty deleted.")
@@ -99,7 +96,7 @@ var bountyUpdateCmd = &cobra.Command{
 
 		if cmd.Flags().Changed("due-date") {
 			if err := validateDate(bountyDueDate); err != nil {
-				fmt.Println(err)
+				fmt.Fprintln(os.Stderr, err)
 				os.Exit(1)
 			}
 		}
@@ -125,8 +122,7 @@ var bountyUpdateCmd = &cobra.Command{
 
 		bounty, err := client.UpdateBounty(frameID, bountyChoreID, bountyRewardID, data)
 		if err != nil {
-			fmt.Printf("Error updating bounty: %v\n", err)
-			os.Exit(1)
+			fatal("updating bounty", err)
 		}
 
 		printJSON(bounty)

--- a/cmd/calendar.go
+++ b/cmd/calendar.go
@@ -36,7 +36,7 @@ var calendarListCmd = &cobra.Command{
 		}{{"start-date", calendarStartDate}, {"end-date", calendarEndDate}} {
 			if cmd.Flags().Changed(f.name) {
 				if err := validateDate(f.val); err != nil {
-					fmt.Println(err)
+					fmt.Fprintln(os.Stderr, err)
 					os.Exit(1)
 				}
 			}
@@ -46,8 +46,7 @@ var calendarListCmd = &cobra.Command{
 
 		events, err := client.ListCalendarEvents(frameID, calendarStartDate, calendarEndDate)
 		if err != nil {
-			fmt.Printf("Error listing calendar events: %v\n", err)
-			os.Exit(1)
+			fatal("listing calendar events", err)
 		}
 
 		printOutput(events)
@@ -69,8 +68,7 @@ var calendarCreateCmd = &cobra.Command{
 			AllDay:  calendarAllDay,
 		})
 		if err != nil {
-			fmt.Printf("Error creating calendar event: %v\n", err)
-			os.Exit(1)
+			fatal("creating calendar event", err)
 		}
 
 		printJSON(event)
@@ -87,8 +85,7 @@ var calendarDeleteCmd = &cobra.Command{
 
 		err := client.DeleteCalendarEvent(frameID, calendarEventID)
 		if err != nil {
-			fmt.Printf("Error deleting calendar event: %v\n", err)
-			os.Exit(1)
+			fatal("deleting calendar event", err)
 		}
 
 		fmt.Println("Calendar event deleted successfully")
@@ -105,8 +102,7 @@ var sourceCalendarsCmd = &cobra.Command{
 
 		calendars, err := client.ListSourceCalendars(frameID)
 		if err != nil {
-			fmt.Printf("Error listing source calendars: %v\n", err)
-			os.Exit(1)
+			fatal("listing source calendars", err)
 		}
 
 		printOutput(calendars)
@@ -137,8 +133,7 @@ var calendarUpdateCmd = &cobra.Command{
 
 		event, err := client.UpdateCalendarEvent(frameID, calendarEventID, data)
 		if err != nil {
-			fmt.Printf("Error updating calendar event: %v\n", err)
-			os.Exit(1)
+			fatal("updating calendar event", err)
 		}
 
 		printJSON(event)
@@ -153,15 +148,14 @@ var calendarWeekCmd = &cobra.Command{
 
 		if cmd.Flags().Changed("date") {
 			if err := validateDate(calendarWeekDate); err != nil {
-				fmt.Println(err)
+				fmt.Fprintln(os.Stderr, err)
 				os.Exit(1)
 			}
 		}
 
 		monday, err := weekStart(calendarWeekDate)
 		if err != nil {
-			fmt.Printf("Error: %v\n", err)
-			os.Exit(1)
+			fatal("computing week start", err)
 		}
 		sunday := monday.AddDate(0, 0, 6)
 
@@ -173,8 +167,7 @@ var calendarWeekCmd = &cobra.Command{
 			sunday.Format(lib.DateFormat),
 		)
 		if err != nil {
-			fmt.Printf("Error listing calendar events: %v\n", err)
-			os.Exit(1)
+			fatal("listing calendar events", err)
 		}
 
 		days := buildCalendarWeeklyView(events, monday)

--- a/cmd/category.go
+++ b/cmd/category.go
@@ -1,9 +1,6 @@
 package cmd
 
 import (
-	"fmt"
-	"os"
-
 	"github.com/spf13/cobra"
 )
 
@@ -17,8 +14,7 @@ var categoryCmd = &cobra.Command{
 
 		categories, err := client.ListCategories(frameID)
 		if err != nil {
-			fmt.Printf("Error listing categories: %v\n", err)
-			os.Exit(1)
+			fatal("listing categories", err)
 		}
 
 		printOutput(categories)

--- a/cmd/chore.go
+++ b/cmd/chore.go
@@ -42,7 +42,7 @@ var choreListCmd = &cobra.Command{
 		}{{"date", choreDate}, {"after", choreAfter}, {"before", choreBefore}} {
 			if cmd.Flags().Changed(f.name) {
 				if err := validateDate(f.val); err != nil {
-					fmt.Println(err)
+					fmt.Fprintln(os.Stderr, err)
 					os.Exit(1)
 				}
 			}
@@ -51,8 +51,7 @@ var choreListCmd = &cobra.Command{
 		if cmd.Flags().Changed("week") {
 			monday, err := weekStart(choreWeek)
 			if err != nil {
-				fmt.Printf("Error: %v\n", err)
-				os.Exit(1)
+				fatal("computing week start", err)
 			}
 			sunday := monday.AddDate(0, 0, 6)
 			chores, err := client.ListChores(frameID, lib.ChoreListOptions{
@@ -61,8 +60,7 @@ var choreListCmd = &cobra.Command{
 				IncludeLate: true,
 			})
 			if err != nil {
-				fmt.Printf("Error listing chores: %v\n", err)
-				os.Exit(1)
+				fatal("listing chores", err)
 			}
 			days := buildWeeklyView(chores, monday)
 			printOutput(days)
@@ -79,8 +77,7 @@ var choreListCmd = &cobra.Command{
 			UpForGrabs:  choreUpForGrabs,
 		})
 		if err != nil {
-			fmt.Printf("Error listing chores: %v\n", err)
-			os.Exit(1)
+			fatal("listing chores", err)
 		}
 
 		printOutput(chores)
@@ -94,7 +91,7 @@ var choreCreateCmd = &cobra.Command{
 		requireFrameID()
 
 		if err := validateDate(choreDate); err != nil {
-			fmt.Println(err)
+			fmt.Fprintln(os.Stderr, err)
 			os.Exit(1)
 		}
 
@@ -118,8 +115,7 @@ var choreCreateCmd = &cobra.Command{
 			})
 		}
 		if err != nil {
-			fmt.Printf("Error creating chore: %v\n", err)
-			os.Exit(1)
+			fatal("creating chore", err)
 		}
 
 		printJSON(chore)
@@ -136,8 +132,7 @@ var choreDeleteCmd = &cobra.Command{
 
 		err := client.DeleteChore(frameID, choreID)
 		if err != nil {
-			fmt.Printf("Error deleting chore: %v\n", err)
-			os.Exit(1)
+			fatal("deleting chore", err)
 		}
 
 		fmt.Println("Chore deleted successfully")
@@ -153,8 +148,7 @@ var choreCompleteCmd = &cobra.Command{
 		client := getClient()
 
 		if err := client.CompleteChore(frameID, choreID); err != nil {
-			fmt.Printf("Error completing chore: %v\n", err)
-			os.Exit(1)
+			fatal("completing chore", err)
 		}
 
 		fmt.Println("Chore completed successfully")
@@ -169,7 +163,7 @@ var choreUpdateCmd = &cobra.Command{
 
 		if cmd.Flags().Changed("date") {
 			if err := validateDate(choreDate); err != nil {
-				fmt.Println(err)
+				fmt.Fprintln(os.Stderr, err)
 				os.Exit(1)
 			}
 		}
@@ -195,8 +189,7 @@ var choreUpdateCmd = &cobra.Command{
 
 		chore, err := client.UpdateChore(frameID, choreID, data)
 		if err != nil {
-			fmt.Printf("Error updating chore: %v\n", err)
-			os.Exit(1)
+			fatal("updating chore", err)
 		}
 
 		printJSON(chore)
@@ -212,8 +205,7 @@ var choreSkipCmd = &cobra.Command{
 		client := getClient()
 
 		if err := client.SkipChore(frameID, choreID); err != nil {
-			fmt.Printf("Error skipping chore: %v\n", err)
-			os.Exit(1)
+			fatal("skipping chore", err)
 		}
 
 		fmt.Println("Chore skipped successfully")
@@ -230,8 +222,7 @@ var choreClaimCmd = &cobra.Command{
 
 		chore, err := client.ClaimChore(frameID, choreID, choreAssigneeID)
 		if err != nil {
-			fmt.Printf("Error claiming chore: %v\n", err)
-			os.Exit(1)
+			fatal("claiming chore", err)
 		}
 
 		printJSON(chore)

--- a/cmd/chore_streak.go
+++ b/cmd/chore_streak.go
@@ -1,8 +1,6 @@
 package cmd
 
 import (
-	"fmt"
-	"os"
 	"sort"
 	"sync"
 	"time"
@@ -156,12 +154,10 @@ for a given member are ignored and do not break streaks.`,
 		wg.Wait()
 
 		if catErr != nil {
-			fmt.Printf("Error listing categories: %v\n", catErr)
-			os.Exit(1)
+			fatal("listing categories", catErr)
 		}
 		if choreErr != nil {
-			fmt.Printf("Error listing chores: %v\n", choreErr)
-			os.Exit(1)
+			fatal("listing chores", choreErr)
 		}
 
 		catNames := buildCatNames(categories)

--- a/cmd/frame.go
+++ b/cmd/frame.go
@@ -1,9 +1,6 @@
 package cmd
 
 import (
-	"fmt"
-	"os"
-
 	"github.com/spf13/cobra"
 )
 
@@ -20,8 +17,7 @@ var frameListCmd = &cobra.Command{
 
 		frames, err := client.ListFrames()
 		if err != nil {
-			fmt.Printf("Error listing frames: %v\n", err)
-			os.Exit(1)
+			fatal("listing frames", err)
 		}
 
 		printOutput(frames)
@@ -38,8 +34,7 @@ var frameInfoCmd = &cobra.Command{
 
 		frame, err := client.GetFrame(frameID)
 		if err != nil {
-			fmt.Printf("Error getting frame: %v\n", err)
-			os.Exit(1)
+			fatal("getting frame", err)
 		}
 
 		printJSON(frame)
@@ -56,8 +51,7 @@ var frameDevicesCmd = &cobra.Command{
 
 		devices, err := client.ListDevices(frameID)
 		if err != nil {
-			fmt.Printf("Error listing devices: %v\n", err)
-			os.Exit(1)
+			fatal("listing devices", err)
 		}
 
 		printOutput(devices)
@@ -72,8 +66,7 @@ var frameAvatarsCmd = &cobra.Command{
 
 		avatars, err := client.GetAvatars()
 		if err != nil {
-			fmt.Printf("Error getting avatars: %v\n", err)
-			os.Exit(1)
+			fatal("getting avatars", err)
 		}
 
 		printOutput(avatars)
@@ -88,8 +81,7 @@ var frameColorsCmd = &cobra.Command{
 
 		colors, err := client.GetColors()
 		if err != nil {
-			fmt.Printf("Error getting colors: %v\n", err)
-			os.Exit(1)
+			fatal("getting colors", err)
 		}
 
 		printOutput(colors)

--- a/cmd/helpers.go
+++ b/cmd/helpers.go
@@ -15,6 +15,11 @@ const (
 	boolNo  = "no"
 )
 
+func fatal(msg string, err error) {
+	fmt.Fprintf(os.Stderr, "Error: %s: %v\n", msg, err)
+	os.Exit(1)
+}
+
 // validateDate returns an error if date is non-empty and not in YYYY-MM-DD format.
 func validateDate(date string) error {
 	if date == "" {
@@ -37,8 +42,7 @@ func buildCatNames(categories []lib.Category) map[string]string {
 func printJSON(data any) {
 	output, err := json.MarshalIndent(data, "", "  ")
 	if err != nil {
-		fmt.Printf("Error marshaling JSON: %v\n", err)
-		os.Exit(1)
+		fatal("marshaling JSON", err)
 	}
 	fmt.Println(string(output))
 }

--- a/cmd/list.go
+++ b/cmd/list.go
@@ -2,7 +2,6 @@ package cmd
 
 import (
 	"fmt"
-	"os"
 
 	"github.com/sebrandon1/go-skylight/lib"
 	"github.com/spf13/cobra"
@@ -32,8 +31,7 @@ var listListCmd = &cobra.Command{
 
 		lists, err := client.ListLists(frameID)
 		if err != nil {
-			fmt.Printf("Error listing lists: %v\n", err)
-			os.Exit(1)
+			fatal("listing lists", err)
 		}
 
 		printOutput(lists)
@@ -50,8 +48,7 @@ var listGetCmd = &cobra.Command{
 
 		list, err := client.GetList(frameID, listID)
 		if err != nil {
-			fmt.Printf("Error getting list: %v\n", err)
-			os.Exit(1)
+			fatal("getting list", err)
 		}
 
 		printJSON(list)
@@ -71,8 +68,7 @@ var listCreateCmd = &cobra.Command{
 			Color: listColor,
 		})
 		if err != nil {
-			fmt.Printf("Error creating list: %v\n", err)
-			os.Exit(1)
+			fatal("creating list", err)
 		}
 
 		printJSON(list)
@@ -89,8 +85,7 @@ var listDeleteCmd = &cobra.Command{
 
 		err := client.DeleteList(frameID, listID)
 		if err != nil {
-			fmt.Printf("Error deleting list: %v\n", err)
-			os.Exit(1)
+			fatal("deleting list", err)
 		}
 
 		fmt.Println("List deleted successfully")
@@ -109,8 +104,7 @@ var listAddItemCmd = &cobra.Command{
 			Title: listItemTitle,
 		})
 		if err != nil {
-			fmt.Printf("Error adding list item: %v\n", err)
-			os.Exit(1)
+			fatal("adding list item", err)
 		}
 
 		printJSON(item)
@@ -127,8 +121,7 @@ var listDeleteItemCmd = &cobra.Command{
 
 		err := client.DeleteListItem(frameID, listID, listItemID)
 		if err != nil {
-			fmt.Printf("Error deleting list item: %v\n", err)
-			os.Exit(1)
+			fatal("deleting list item", err)
 		}
 
 		fmt.Println("List item deleted successfully")
@@ -153,8 +146,7 @@ var listUpdateCmd = &cobra.Command{
 
 		list, err := client.UpdateList(frameID, listID, data)
 		if err != nil {
-			fmt.Printf("Error updating list: %v\n", err)
-			os.Exit(1)
+			fatal("updating list", err)
 		}
 
 		printJSON(list)
@@ -179,8 +171,7 @@ var listUpdateItemCmd = &cobra.Command{
 
 		item, err := client.UpdateListItem(frameID, listID, listItemID, data)
 		if err != nil {
-			fmt.Printf("Error updating list item: %v\n", err)
-			os.Exit(1)
+			fatal("updating list item", err)
 		}
 
 		printJSON(item)

--- a/cmd/meal.go
+++ b/cmd/meal.go
@@ -38,8 +38,7 @@ var mealCategoriesCmd = &cobra.Command{
 
 		categories, err := client.ListMealCategories(frameID)
 		if err != nil {
-			fmt.Printf("Error listing meal categories: %v\n", err)
-			os.Exit(1)
+			fatal("listing meal categories", err)
 		}
 
 		printOutput(categories)
@@ -56,8 +55,7 @@ var mealRecipesCmd = &cobra.Command{
 
 		recipes, err := client.ListRecipes(frameID)
 		if err != nil {
-			fmt.Printf("Error listing recipes: %v\n", err)
-			os.Exit(1)
+			fatal("listing recipes", err)
 		}
 
 		printOutput(recipes)
@@ -74,8 +72,7 @@ var mealRecipeInfoCmd = &cobra.Command{
 
 		recipe, err := client.GetRecipe(frameID, recipeID)
 		if err != nil {
-			fmt.Printf("Error getting recipe: %v\n", err)
-			os.Exit(1)
+			fatal("getting recipe", err)
 		}
 
 		printJSON(recipe)
@@ -98,8 +95,7 @@ var mealCreateRecipeCmd = &cobra.Command{
 			MealCategoryID: recipeCategoryID,
 		})
 		if err != nil {
-			fmt.Printf("Error creating recipe: %v\n", err)
-			os.Exit(1)
+			fatal("creating recipe", err)
 		}
 
 		printJSON(recipe)
@@ -116,8 +112,7 @@ var mealDeleteRecipeCmd = &cobra.Command{
 
 		err := client.DeleteRecipe(frameID, recipeID)
 		if err != nil {
-			fmt.Printf("Error deleting recipe: %v\n", err)
-			os.Exit(1)
+			fatal("deleting recipe", err)
 		}
 
 		fmt.Println("Recipe deleted successfully")
@@ -136,7 +131,7 @@ var mealSittingsCmd = &cobra.Command{
 		}{{"date-min", sittingDateMin}, {"date-max", sittingDateMax}} {
 			if cmd.Flags().Changed(f.name) {
 				if err := validateDate(f.val); err != nil {
-					fmt.Println(err)
+					fmt.Fprintln(os.Stderr, err)
 					os.Exit(1)
 				}
 			}
@@ -149,8 +144,7 @@ var mealSittingsCmd = &cobra.Command{
 			DateMax: sittingDateMax,
 		})
 		if err != nil {
-			fmt.Printf("Error listing meal sittings: %v\n", err)
-			os.Exit(1)
+			fatal("listing meal sittings", err)
 		}
 
 		printOutput(sittings)
@@ -164,7 +158,7 @@ var mealCreateSittingCmd = &cobra.Command{
 		requireFrameID()
 
 		if err := validateDate(sittingDate); err != nil {
-			fmt.Println(err)
+			fmt.Fprintln(os.Stderr, err)
 			os.Exit(1)
 		}
 
@@ -177,8 +171,7 @@ var mealCreateSittingCmd = &cobra.Command{
 			MealCategoryID: mealCategoryID,
 		})
 		if err != nil {
-			fmt.Printf("Error creating meal sitting: %v\n", err)
-			os.Exit(1)
+			fatal("creating meal sitting", err)
 		}
 
 		printJSON(sitting)
@@ -192,7 +185,7 @@ var mealDeleteSittingCmd = &cobra.Command{
 		requireFrameID()
 
 		if err := validateDate(sittingDate); err != nil {
-			fmt.Println(err)
+			fmt.Fprintln(os.Stderr, err)
 			os.Exit(1)
 		}
 
@@ -200,8 +193,7 @@ var mealDeleteSittingCmd = &cobra.Command{
 
 		err := client.DeleteMealSitting(frameID, sittingID, sittingDate)
 		if err != nil {
-			fmt.Printf("Error deleting meal sitting: %v\n", err)
-			os.Exit(1)
+			fatal("deleting meal sitting", err)
 		}
 
 		fmt.Println("Meal sitting deleted successfully")
@@ -218,8 +210,7 @@ var mealAddToGroceryCmd = &cobra.Command{
 
 		err := client.AddRecipeToGroceryList(frameID, recipeID)
 		if err != nil {
-			fmt.Printf("Error adding to grocery list: %v\n", err)
-			os.Exit(1)
+			fatal("adding to grocery list", err)
 		}
 
 		fmt.Println("Recipe added to grocery list successfully")
@@ -250,8 +241,7 @@ var mealUpdateRecipeCmd = &cobra.Command{
 
 		recipe, err := client.UpdateRecipe(frameID, recipeID, data)
 		if err != nil {
-			fmt.Printf("Error updating recipe: %v\n", err)
-			os.Exit(1)
+			fatal("updating recipe", err)
 		}
 
 		printJSON(recipe)

--- a/cmd/photo.go
+++ b/cmd/photo.go
@@ -38,8 +38,7 @@ var photoListCmd = &cobra.Command{
 			PageToken: photoPageToken,
 		})
 		if err != nil {
-			fmt.Printf("Error listing photos: %v\n", err)
-			os.Exit(1)
+			fatal("listing photos", err)
 		}
 
 		printOutput(photos)
@@ -58,8 +57,7 @@ var photoUploadCmd = &cobra.Command{
 
 		data, err := os.ReadFile(photoFile)
 		if err != nil {
-			fmt.Printf("Error reading file: %v\n", err)
-			os.Exit(1)
+			fatal("reading file", err)
 		}
 
 		ext := strings.TrimPrefix(filepath.Ext(photoFile), ".")
@@ -71,8 +69,7 @@ var photoUploadCmd = &cobra.Command{
 
 		result, err := client.UploadPhoto(frameID, ext, data, photoCaption)
 		if err != nil {
-			fmt.Printf("Error uploading photo: %v\n", err)
-			os.Exit(1)
+			fatal("uploading photo", err)
 		}
 
 		printJSON(result)
@@ -89,8 +86,7 @@ var photoDeleteCmd = &cobra.Command{
 		for _, s := range photoMessageID {
 			id, err := strconv.Atoi(s)
 			if err != nil {
-				fmt.Printf("Invalid message ID %q: %v\n", s, err)
-				os.Exit(1)
+				fatal(fmt.Sprintf("invalid message ID %q", s), err)
 			}
 			ids = append(ids, id)
 		}
@@ -99,8 +95,7 @@ var photoDeleteCmd = &cobra.Command{
 
 		err := client.DeletePhotos(frameID, ids)
 		if err != nil {
-			fmt.Printf("Error deleting photos: %v\n", err)
-			os.Exit(1)
+			fatal("deleting photos", err)
 		}
 
 		fmt.Println("Photos deleted successfully")
@@ -114,7 +109,7 @@ var photoDownloadCmd = &cobra.Command{
 		requireFrameID()
 
 		if !photoDownloadAll && len(photoMessageID) == 0 {
-			fmt.Println("Error: specify --message-id or --all")
+			fmt.Fprintln(os.Stderr, "Error: specify --message-id or --all")
 			os.Exit(1)
 		}
 
@@ -130,8 +125,7 @@ var photoDownloadCmd = &cobra.Command{
 		for {
 			photos, nextToken, err := client.ListPhotos(frameID, lib.PhotoListOptions{PageToken: pageToken})
 			if err != nil {
-				fmt.Printf("Error listing photos: %v\n", err)
-				os.Exit(1)
+				fatal("listing photos", err)
 			}
 			for _, p := range photos {
 				if photoDownloadAll || wantIDs[p.ID] {
@@ -150,20 +144,19 @@ var photoDownloadCmd = &cobra.Command{
 		}
 
 		if err := os.MkdirAll(photoOutputDir, 0o755); err != nil {
-			fmt.Printf("Error creating output directory: %v\n", err)
-			os.Exit(1)
+			fatal("creating output directory", err)
 		}
 
 		for _, p := range toDownload {
 			data, err := client.DownloadPhoto(p.AssetURL)
 			if err != nil {
-				fmt.Printf("Error downloading %s: %v\n", p.ID, err)
+				fmt.Fprintf(os.Stderr, "Error: downloading %s: %v\n", p.ID, err)
 				continue
 			}
 			ext := photoAssetExt(p.AssetURL, p.AssetType)
 			filename := filepath.Join(photoOutputDir, p.ID+ext)
 			if err := os.WriteFile(filename, data, 0o600); err != nil {
-				fmt.Printf("Error writing %s: %v\n", filename, err)
+				fmt.Fprintf(os.Stderr, "Error: writing %s: %v\n", filename, err)
 				continue
 			}
 			fmt.Printf("Saved %s\n", filename)

--- a/cmd/reward.go
+++ b/cmd/reward.go
@@ -2,7 +2,6 @@ package cmd
 
 import (
 	"fmt"
-	"os"
 
 	"github.com/sebrandon1/go-skylight/lib"
 	"github.com/spf13/cobra"
@@ -32,8 +31,7 @@ var rewardListCmd = &cobra.Command{
 
 		rewards, err := client.ListRewards(frameID)
 		if err != nil {
-			fmt.Printf("Error listing rewards: %v\n", err)
-			os.Exit(1)
+			fatal("listing rewards", err)
 		}
 
 		printOutput(rewards)
@@ -64,8 +62,7 @@ var rewardCreateCmd = &cobra.Command{
 		}
 		reward, err := client.CreateReward(frameID, data)
 		if err != nil {
-			fmt.Printf("Error creating reward: %v\n", err)
-			os.Exit(1)
+			fatal("creating reward", err)
 		}
 
 		printJSON(reward)
@@ -82,8 +79,7 @@ var rewardDeleteCmd = &cobra.Command{
 
 		err := client.DeleteReward(frameID, rewardID)
 		if err != nil {
-			fmt.Printf("Error deleting reward: %v\n", err)
-			os.Exit(1)
+			fatal("deleting reward", err)
 		}
 
 		fmt.Println("Reward deleted successfully")
@@ -100,8 +96,7 @@ var rewardRedeemCmd = &cobra.Command{
 
 		err := client.RedeemReward(frameID, rewardID)
 		if err != nil {
-			fmt.Printf("Error redeeming reward: %v\n", err)
-			os.Exit(1)
+			fatal("redeeming reward", err)
 		}
 
 		fmt.Println("Reward redeemed successfully")
@@ -118,8 +113,7 @@ var rewardUnredeemCmd = &cobra.Command{
 
 		err := client.UnredeemReward(frameID, rewardID)
 		if err != nil {
-			fmt.Printf("Error unredeeming reward: %v\n", err)
-			os.Exit(1)
+			fatal("unredeeming reward", err)
 		}
 
 		fmt.Println("Reward unredeemed successfully")
@@ -136,8 +130,7 @@ var rewardPointsCmd = &cobra.Command{
 
 		points, err := client.GetRewardPoints(frameID)
 		if err != nil {
-			fmt.Printf("Error getting reward points: %v\n", err)
-			os.Exit(1)
+			fatal("getting reward points", err)
 		}
 
 		printJSON(points)
@@ -165,8 +158,7 @@ var rewardUpdateCmd = &cobra.Command{
 
 		reward, err := client.UpdateReward(frameID, rewardID, data)
 		if err != nil {
-			fmt.Printf("Error updating reward: %v\n", err)
-			os.Exit(1)
+			fatal("updating reward", err)
 		}
 
 		printJSON(reward)

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -121,7 +121,7 @@ func init() {
 
 func requireFrameID() {
 	if frameID == "" {
-		fmt.Println("Error: --frame-id is required")
+		fmt.Fprintln(os.Stderr, "Error: --frame-id is required")
 		os.Exit(1)
 	}
 }
@@ -132,8 +132,7 @@ func getClient() *lib.Client {
 	}
 	client, err := lib.NewClientWithToken(userID, token)
 	if err != nil {
-		fmt.Printf("Error creating client: %v\n", err)
-		os.Exit(1)
+		fatal("creating client", err)
 	}
 	return client
 }

--- a/cmd/rotation.go
+++ b/cmd/rotation.go
@@ -37,9 +37,9 @@ var rotationCreateCmd = &cobra.Command{
 			Points:      rotationPoints,
 		})
 		if err != nil {
-			fmt.Printf("Error creating rotation: %v\n", err)
+			fmt.Fprintf(os.Stderr, "Error: creating rotation: %v\n", err)
 			if result != nil && len(result.Chores) > 0 {
-				fmt.Printf("Partial result (%d chores created):\n", len(result.Chores))
+				fmt.Fprintf(os.Stderr, "Partial result (%d chores created):\n", len(result.Chores))
 				printJSON(result)
 			}
 			os.Exit(1)

--- a/cmd/session.go
+++ b/cmd/session.go
@@ -19,7 +19,7 @@ the refresh token and device fingerprint to the config file. Use --save to
 persist the credentials so subsequent commands authenticate automatically.`,
 	Run: func(cmd *cobra.Command, args []string) {
 		if email == "" || password == "" {
-			fmt.Println("Error: --email and --password are required for login")
+			fmt.Fprintln(os.Stderr, "Error: --email and --password are required for login")
 			os.Exit(1)
 		}
 
@@ -32,8 +32,7 @@ persist the credentials so subsequent commands authenticate automatically.`,
 		fmt.Printf("Logging in as %s...\n", email)
 		tok, err := lib.LoginHeadless(email, password, fingerprint)
 		if err != nil {
-			fmt.Printf("Error logging in: %v\n", err)
-			os.Exit(1)
+			fatal("logging in", err)
 		}
 
 		fmt.Println("Login successful!")

--- a/cmd/status.go
+++ b/cmd/status.go
@@ -2,7 +2,6 @@ package cmd
 
 import (
 	"fmt"
-	"os"
 	"strconv"
 	"strings"
 	"time"
@@ -21,8 +20,7 @@ var statusCmd = &cobra.Command{
 
 		frame, err := client.GetFrame(frameID)
 		if err != nil {
-			fmt.Printf("Error getting frame: %v\n", err)
-			os.Exit(1)
+			fatal("getting frame", err)
 		}
 
 		chores, err := client.ListChores(frameID, lib.ChoreListOptions{
@@ -30,26 +28,22 @@ var statusCmd = &cobra.Command{
 			Status: "pending",
 		})
 		if err != nil {
-			fmt.Printf("Error listing chores: %v\n", err)
-			os.Exit(1)
+			fatal("listing chores", err)
 		}
 
 		events, err := client.ListCalendarEvents(frameID, today, today)
 		if err != nil {
-			fmt.Printf("Error listing calendar events: %v\n", err)
-			os.Exit(1)
+			fatal("listing calendar events", err)
 		}
 
 		categories, err := client.ListCategories(frameID)
 		if err != nil {
-			fmt.Printf("Error listing categories: %v\n", err)
-			os.Exit(1)
+			fatal("listing categories", err)
 		}
 
 		points, err := client.GetRewardPoints(frameID)
 		if err != nil {
-			fmt.Printf("Error getting reward points: %v\n", err)
-			os.Exit(1)
+			fatal("getting reward points", err)
 		}
 
 		catNames := make(map[int]string, len(categories))


### PR DESCRIPTION
## Summary

- Adds `fatal(msg string, err error)` helper in `cmd/helpers.go` that writes `Error: <msg>: <err>` to stderr and exits with code 1
- Replaces 60+ `fmt.Printf("Error XYZ: %v\n", err) + os.Exit(1)` sites across 14 cmd/ files with `fatal("XYZ", err)`
- Converts `analytics.go` error sites to use `fatal()` for consistency
- Moves validation errors (`validateDate`, flag checks) from stdout to `fmt.Fprintln(os.Stderr, err)` — these keep their existing self-contained message format to avoid redundant context wrapping
- Non-fatal per-photo download/write errors in `photo.go` also redirected to stderr via `fmt.Fprintf(os.Stderr, ...)`
- Special case in `rotation.go` (partial-result print before exit) uses `fmt.Fprintf(os.Stderr, ...)` directly since `fatal()` exits immediately

Closes #86

## Test plan

- [x] `make test` passes
- [x] `make lint` passes (0 issues)
- [x] `go-skylight analytics --frame-id bad-id 2>/dev/null` produces no stdout error output
- [x] `go-skylight analytics --frame-id bad-id 2>&1` shows `Error: listing categories: ...` on stderr