### PR TITLE
refactor: extract shared generic week-view builder (issue #89)

### DIFF
--- a/cmd/calendar_week.go
+++ b/cmd/calendar_week.go
@@ -3,7 +3,6 @@ package cmd
 import (
 	"fmt"
 	"os"
-	"sort"
 	"text/tabwriter"
 	"time"
 
@@ -20,35 +19,14 @@ type WeeklyCalendarDay struct {
 // buildCalendarWeeklyView groups events into Mon–Sun slots for the week starting on monday.
 // Events are grouped by the UTC date of their StartAt field; out-of-range events are silently dropped.
 func buildCalendarWeeklyView(events []lib.CalendarEvent, monday time.Time) []WeeklyCalendarDay {
-	days := make([]WeeklyCalendarDay, 7)
-	for i := 0; i < 7; i++ {
-		d := monday.AddDate(0, 0, i)
-		days[i] = WeeklyCalendarDay{
-			Day:     d.Format("Mon"),
-			Date:    d.Format(lib.DateFormat),
-			Display: d.Format("Jan 02"),
-			Events:  []lib.CalendarEvent{},
-		}
+	slots := buildWeekSlots(events, monday,
+		func(e lib.CalendarEvent) string { return e.StartAt },
+		func(a, b lib.CalendarEvent) bool { return a.StartAt < b.StartAt },
+	)
+	days := make([]WeeklyCalendarDay, len(slots))
+	for i, s := range slots {
+		days[i] = WeeklyCalendarDay{Day: s.day, Date: s.date, Display: s.display, Events: s.items}
 	}
-
-	byDate := make(map[string][]lib.CalendarEvent, 7)
-	for _, e := range events {
-		date := e.StartAt
-		if len(date) >= 10 {
-			date = date[:10]
-		}
-		byDate[date] = append(byDate[date], e)
-	}
-
-	for i, day := range days {
-		if evs, ok := byDate[day.Date]; ok {
-			sort.Slice(evs, func(a, b int) bool {
-				return evs[a].StartAt < evs[b].StartAt
-			})
-			days[i].Events = evs
-		}
-	}
-
 	return days
 }
 

--- a/cmd/chore_week.go
+++ b/cmd/chore_week.go
@@ -3,7 +3,6 @@ package cmd
 import (
 	"fmt"
 	"os"
-	"sort"
 	"text/tabwriter"
 	"time"
 
@@ -18,56 +17,16 @@ type WeeklyChoreDay struct {
 	Chores  []lib.Chore `json:"chores"`
 }
 
-// weekStart returns the Monday of the week containing the given date string.
-// "current" or "" resolves to the current week.
-func weekStart(date string) (time.Time, error) {
-	var t time.Time
-	if date == "" || date == "current" {
-		t = time.Now()
-	} else {
-		var err error
-		t, err = time.Parse(lib.DateFormat, date)
-		if err != nil {
-			return time.Time{}, fmt.Errorf("invalid date %q: use YYYY-MM-DD format", date)
-		}
-	}
-	wd := int(t.Weekday())
-	if wd == 0 {
-		wd = 7 // Sunday = 7 in ISO week
-	}
-	monday := t.AddDate(0, 0, -(wd - 1))
-	return time.Date(monday.Year(), monday.Month(), monday.Day(), 0, 0, 0, 0, time.UTC), nil
-}
-
 // buildWeeklyView groups chores into Mon–Sun slots for the week starting on monday.
 func buildWeeklyView(chores []lib.Chore, monday time.Time) []WeeklyChoreDay {
-	days := make([]WeeklyChoreDay, 7)
-	for i := 0; i < 7; i++ {
-		d := monday.AddDate(0, 0, i)
-		days[i] = WeeklyChoreDay{
-			Day:     d.Format("Mon"),
-			Date:    d.Format(lib.DateFormat),
-			Display: d.Format("Jan 02"),
-			Chores:  []lib.Chore{},
-		}
+	slots := buildWeekSlots(chores, monday,
+		func(c lib.Chore) string { return c.DueDate },
+		func(a, b lib.Chore) bool { return a.Title < b.Title },
+	)
+	days := make([]WeeklyChoreDay, len(slots))
+	for i, s := range slots {
+		days[i] = WeeklyChoreDay{Day: s.day, Date: s.date, Display: s.display, Chores: s.items}
 	}
-
-	byDate := make(map[string][]lib.Chore, 7)
-	for _, c := range chores {
-		date := c.DueDate
-		if len(date) >= 10 {
-			date = date[:10]
-		}
-		byDate[date] = append(byDate[date], c)
-	}
-
-	for i, day := range days {
-		if cs, ok := byDate[day.Date]; ok {
-			sort.Slice(cs, func(a, b int) bool { return cs[a].Title < cs[b].Title })
-			days[i].Chores = cs
-		}
-	}
-
 	return days
 }
 

--- a/cmd/week.go
+++ b/cmd/week.go
@@ -1,0 +1,72 @@
+package cmd
+
+import (
+	"fmt"
+	"sort"
+	"time"
+
+	"github.com/sebrandon1/go-skylight/lib"
+)
+
+type weekSlot[T any] struct {
+	day     string
+	date    string
+	display string
+	items   []T
+}
+
+// weekStart returns the Monday of the week containing date.
+// "current" or "" resolves to the current week.
+func weekStart(date string) (time.Time, error) {
+	var t time.Time
+	if date == "" || date == "current" {
+		t = time.Now()
+	} else {
+		var err error
+		t, err = time.Parse(lib.DateFormat, date)
+		if err != nil {
+			return time.Time{}, fmt.Errorf("invalid date %q: use YYYY-MM-DD format", date)
+		}
+	}
+	wd := int(t.Weekday())
+	if wd == 0 {
+		wd = 7 // Sunday = 7 in ISO week
+	}
+	monday := t.AddDate(0, 0, -(wd - 1))
+	return time.Date(monday.Year(), monday.Month(), monday.Day(), 0, 0, 0, 0, time.UTC), nil
+}
+
+// buildWeekSlots creates 7 Mon–Sun slots, groups items by date, and sorts each
+// slot. dateOf extracts the ISO date from an item (truncated to 10 chars when
+// longer). less is the sort comparator applied within each slot.
+func buildWeekSlots[T any](items []T, monday time.Time, dateOf func(T) string, less func(a, b T) bool) []weekSlot[T] {
+	slots := make([]weekSlot[T], 7)
+	for i := range slots {
+		d := monday.AddDate(0, 0, i)
+		slots[i] = weekSlot[T]{
+			day:     d.Format("Mon"),
+			date:    d.Format(lib.DateFormat),
+			display: d.Format("Jan 02"),
+		}
+	}
+
+	byDate := make(map[string][]T, 7)
+	for _, item := range items {
+		date := dateOf(item)
+		if len(date) >= 10 {
+			date = date[:10]
+		}
+		byDate[date] = append(byDate[date], item)
+	}
+
+	for i, s := range slots {
+		if its, ok := byDate[s.date]; ok {
+			sort.Slice(its, func(a, b int) bool { return less(its[a], its[b]) })
+			slots[i].items = its
+		} else {
+			slots[i].items = []T{}
+		}
+	}
+
+	return slots
+}


### PR DESCRIPTION
Closes #89

## Summary
- Adds `cmd/week.go` with a generic `buildWeekSlots[T]` function and shared `weekStart` helper
- `cmd/chore_week.go` and `cmd/calendar_week.go` become thin adapters that call `buildWeekSlots`
- Eliminates ~60 lines of near-identical slot-building logic

## Test plan
- [ ] `make build` passes
- [ ] `make test` passes (existing week-view tests unchanged)
- [ ] `make lint` clean (0 issues)