### PR TITLE
feat: add calendar create-countdown command (issue #72)

### DIFF
--- a/cmd/calendar.go
+++ b/cmd/calendar.go
@@ -9,14 +9,15 @@ import (
 )
 
 var (
-	calendarStartDate string
-	calendarEndDate   string
-	calendarEventID   string
-	calendarTitle     string
-	calendarStartAt   string
-	calendarEndAt     string
-	calendarAllDay    bool
-	calendarWeekDate  string
+	calendarStartDate     string
+	calendarEndDate       string
+	calendarEventID       string
+	calendarTitle         string
+	calendarStartAt       string
+	calendarEndAt         string
+	calendarAllDay        bool
+	calendarWeekDate      string
+	calendarCountdownDate string
 )
 
 var calendarCmd = &cobra.Command{
@@ -140,6 +141,34 @@ var calendarUpdateCmd = &cobra.Command{
 	},
 }
 
+var calendarCreateCountdownCmd = &cobra.Command{
+	Use:   "create-countdown",
+	Short: "Create a countdown event",
+	Run: func(cmd *cobra.Command, args []string) {
+		requireFrameID()
+
+		if err := validateDate(calendarCountdownDate); err != nil {
+			fmt.Fprintln(os.Stderr, err)
+			os.Exit(1)
+		}
+
+		client := getClient()
+
+		event, err := client.CreateCalendarEvent(frameID, lib.CalendarEventData{
+			Title:     calendarTitle,
+			StartAt:   calendarCountdownDate,
+			AllDay:    true,
+			EventType: lib.CalendarEventTypeCountdown,
+		})
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Error: creating countdown event: %v\n", err)
+			os.Exit(1)
+		}
+
+		printJSON(event)
+	},
+}
+
 var calendarWeekCmd = &cobra.Command{
 	Use:   "week",
 	Short: "Show a 7-day Mon-Sun view of calendar events",
@@ -178,6 +207,7 @@ var calendarWeekCmd = &cobra.Command{
 func init() {
 	calendarCmd.AddCommand(calendarListCmd)
 	calendarCmd.AddCommand(calendarCreateCmd)
+	calendarCmd.AddCommand(calendarCreateCountdownCmd)
 	calendarCmd.AddCommand(calendarUpdateCmd)
 	calendarCmd.AddCommand(calendarDeleteCmd)
 	calendarCmd.AddCommand(sourceCalendarsCmd)
@@ -202,6 +232,11 @@ func init() {
 
 	calendarDeleteCmd.Flags().StringVar(&calendarEventID, "event-id", "", "Event ID to delete")
 	calendarDeleteCmd.MarkFlagRequired("event-id") //nolint:errcheck
+
+	calendarCreateCountdownCmd.Flags().StringVar(&calendarTitle, "title", "", "Countdown event title")
+	calendarCreateCountdownCmd.Flags().StringVar(&calendarCountdownDate, "date", "", "Target date (YYYY-MM-DD)")
+	calendarCreateCountdownCmd.MarkFlagRequired("title") //nolint:errcheck
+	calendarCreateCountdownCmd.MarkFlagRequired("date")  //nolint:errcheck
 
 	calendarWeekCmd.Flags().StringVar(&calendarWeekDate, "date", "", "Week containing this date (YYYY-MM-DD, default current week)")
 }

--- a/lib/structs.go
+++ b/lib/structs.go
@@ -49,6 +49,8 @@ type CalendarEvent struct {
 	UpdatedAt   string `json:"updated_at,omitempty"`
 }
 
+const CalendarEventTypeCountdown = "countdown"
+
 // CalendarEventData holds the event fields for create/update requests.
 // Field names match the Skylight API JSON field names.
 type CalendarEventData struct {
@@ -59,6 +61,7 @@ type CalendarEventData struct {
 	AllDay      bool   `json:"all_day,omitempty"`
 	Color       string `json:"color,omitempty"`
 	CategoryID  string `json:"category_id,omitempty"`
+	EventType   string `json:"event_type,omitempty"`
 }
 
 // calendarAPIResponse wraps the JSON-API envelope for calendar event list responses.


### PR DESCRIPTION
Closes #72

## Summary
- Adds `calendar create-countdown --title TITLE --date YYYY-MM-DD` subcommand
- Adds `EventType` field to `CalendarEventData` (maps to `event_type` JSON)
- Adds `CalendarEventTypeCountdown` constant in `lib/structs.go`
- Date is validated via `validateDate` before the API call

## Test plan
- [ ] `make build` passes
- [ ] `make test` passes
- [ ] `make lint` clean