### PR TITLE
feat: add list hide-from-frame flag and clear-completed command (issue #71)

### DIFF
--- a/cmd/list.go
+++ b/cmd/list.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"fmt"
+	"os"
 
 	"github.com/sebrandon1/go-skylight/lib"
 	"github.com/spf13/cobra"
@@ -14,6 +15,7 @@ var (
 	listItemID        string
 	listItemTitle     string
 	listItemCompleted bool
+	listHideFromFrame bool
 )
 
 var listCmd = &cobra.Command{
@@ -63,10 +65,14 @@ var listCreateCmd = &cobra.Command{
 
 		client := getClient()
 
-		list, err := client.CreateList(frameID, lib.ListData{
+		data := lib.ListData{
 			Title: listTitle,
 			Color: listColor,
-		})
+		}
+		if cmd.Flags().Changed("hide-from-frame") {
+			data.HideFromFrame = &listHideFromFrame
+		}
+		list, err := client.CreateList(frameID, data)
 		if err != nil {
 			fatal("creating list", err)
 		}
@@ -143,6 +149,9 @@ var listUpdateCmd = &cobra.Command{
 		if cmd.Flags().Changed("color") {
 			data.Color = listColor
 		}
+		if cmd.Flags().Changed("hide-from-frame") {
+			data.HideFromFrame = &listHideFromFrame
+		}
 
 		list, err := client.UpdateList(frameID, listID, data)
 		if err != nil {
@@ -178,6 +187,28 @@ var listUpdateItemCmd = &cobra.Command{
 	},
 }
 
+var listClearCompletedCmd = &cobra.Command{
+	Use:   "clear-completed",
+	Short: "Delete all completed items from a list",
+	Run: func(cmd *cobra.Command, args []string) {
+		requireFrameID()
+
+		client := getClient()
+
+		deleted, err := client.ClearCompletedListItems(frameID, listID)
+		if err != nil {
+			if deleted > 0 {
+				fmt.Fprintf(os.Stderr, "Deleted %d item(s) before error: %v\n", deleted, err)
+			} else {
+				fmt.Fprintf(os.Stderr, "Error clearing completed items: %v\n", err)
+			}
+			os.Exit(1)
+		}
+
+		fmt.Printf("Deleted %d completed item(s)\n", deleted)
+	},
+}
+
 func init() {
 	listCmd.AddCommand(listListCmd)
 	listCmd.AddCommand(listGetCmd)
@@ -187,12 +218,14 @@ func init() {
 	listCmd.AddCommand(listAddItemCmd)
 	listCmd.AddCommand(listUpdateItemCmd)
 	listCmd.AddCommand(listDeleteItemCmd)
+	listCmd.AddCommand(listClearCompletedCmd)
 
 	listGetCmd.Flags().StringVar(&listID, "list-id", "", "List ID")
 	listGetCmd.MarkFlagRequired("list-id") //nolint:errcheck
 
 	listCreateCmd.Flags().StringVar(&listTitle, "title", "", "List title")
 	listCreateCmd.Flags().StringVar(&listColor, "color", "", "List color")
+	listCreateCmd.Flags().BoolVar(&listHideFromFrame, "hide-from-frame", false, "Hide list from calendar devices")
 	listCreateCmd.MarkFlagRequired("title") //nolint:errcheck
 
 	listDeleteCmd.Flags().StringVar(&listID, "list-id", "", "List ID")
@@ -201,6 +234,8 @@ func init() {
 	listUpdateCmd.Flags().StringVar(&listID, "list-id", "", "List ID")
 	listUpdateCmd.Flags().StringVar(&listTitle, "title", "", "List title")
 	listUpdateCmd.Flags().StringVar(&listColor, "color", "", "List color")
+	listUpdateCmd.Flags().BoolVar(&listHideFromFrame, "hide-from-frame", false, "Hide list from calendar devices")
+	listUpdateCmd.MarkFlagRequired("list-id") //nolint:errcheck
 
 	listAddItemCmd.Flags().StringVar(&listID, "list-id", "", "List ID")
 	listAddItemCmd.Flags().StringVar(&listItemTitle, "title", "", "Item title")
@@ -218,4 +253,7 @@ func init() {
 	listDeleteItemCmd.Flags().StringVar(&listItemID, "item-id", "", "Item ID")
 	listDeleteItemCmd.MarkFlagRequired("list-id") //nolint:errcheck
 	listDeleteItemCmd.MarkFlagRequired("item-id") //nolint:errcheck
+
+	listClearCompletedCmd.Flags().StringVar(&listID, "list-id", "", "List ID")
+	listClearCompletedCmd.MarkFlagRequired("list-id") //nolint:errcheck
 }

--- a/lib/list.go
+++ b/lib/list.go
@@ -167,6 +167,25 @@ func (c *Client) DeleteListItem(frameID, listID, itemID string) error {
 	return nil
 }
 
+// ClearCompletedListItems deletes all completed items from a list.
+func (c *Client) ClearCompletedListItems(frameID, listID string) (int, error) {
+	list, err := c.GetList(frameID, listID)
+	if err != nil {
+		return 0, fmt.Errorf("failed to get list: %w", err)
+	}
+
+	var deleted int
+	for _, item := range list.Items {
+		if item.Completed {
+			if err := c.DeleteListItem(frameID, listID, item.ID); err != nil {
+				return deleted, fmt.Errorf("failed to delete item %s: %w", item.ID, err)
+			}
+			deleted++
+		}
+	}
+	return deleted, nil
+}
+
 // CreateTaskBoxItem creates a new task box item on a frame.
 func (c *Client) CreateTaskBoxItem(frameID string, item TaskBoxItemData) (*TaskBoxItem, error) {
 	reqBody := TaskBoxItemRequest{TaskBoxItem: item}

--- a/lib/structs.go
+++ b/lib/structs.go
@@ -211,13 +211,14 @@ type ChoreData struct {
 
 // List represents a list (e.g., grocery list, todo list).
 type List struct {
-	ID        string     `json:"id,omitempty"`
-	Title     string     `json:"label,omitempty"`
-	Color     string     `json:"color,omitempty"`
-	Kind      string     `json:"kind,omitempty"`
-	Items     []ListItem `json:"list_items,omitempty"`
-	CreatedAt string     `json:"created_at,omitempty"`
-	UpdatedAt string     `json:"updated_at,omitempty"`
+	ID            string     `json:"id,omitempty"`
+	Title         string     `json:"label,omitempty"`
+	Color         string     `json:"color,omitempty"`
+	Kind          string     `json:"kind,omitempty"`
+	HideFromFrame bool       `json:"hide_from_frame"`
+	Items         []ListItem `json:"list_items,omitempty"`
+	CreatedAt     string     `json:"created_at,omitempty"`
+	UpdatedAt     string     `json:"updated_at,omitempty"`
 }
 
 // ListItem represents an item within a list.
@@ -233,9 +234,10 @@ type ListItem struct {
 
 // ListData holds the list fields for create/update requests.
 type ListData struct {
-	Title string `json:"label,omitempty"`
-	Color string `json:"color,omitempty"`
-	Kind  string `json:"kind,omitempty"`
+	Title         string `json:"label,omitempty"`
+	Color         string `json:"color,omitempty"`
+	Kind          string `json:"kind,omitempty"`
+	HideFromFrame *bool  `json:"hide_from_frame,omitempty"`
 }
 
 // ListItemData holds the list item fields for create/update requests.
@@ -267,18 +269,20 @@ type listAPISingleResponse struct {
 type listAPIEntry struct {
 	ID         string `json:"id"`
 	Attributes struct {
-		Label string `json:"label"`
-		Color string `json:"color"`
-		Kind  string `json:"kind"`
+		Label         string `json:"label"`
+		Color         string `json:"color"`
+		Kind          string `json:"kind"`
+		HideFromFrame bool   `json:"hide_from_frame"`
 	} `json:"attributes"`
 }
 
 func (e *listAPIEntry) toList() List {
 	return List{
-		ID:    e.ID,
-		Title: e.Attributes.Label,
-		Color: e.Attributes.Color,
-		Kind:  e.Attributes.Kind,
+		ID:            e.ID,
+		Title:         e.Attributes.Label,
+		Color:         e.Attributes.Color,
+		Kind:          e.Attributes.Kind,
+		HideFromFrame: e.Attributes.HideFromFrame,
 	}
 }
 


### PR DESCRIPTION
Closes #71

## Summary
- Adds `--hide-from-frame` flag to `list create` and `list update` — maps to `hide_from_frame` JSON field via pointer bool (same pattern as `RewardData.RespawnOnRedemption`)
- Adds `HideFromFrame` to `List`, `ListData`, and `listAPIEntry.Attributes`
- Adds `list clear-completed --list-id ID` subcommand
- Adds `ClearCompletedListItems` to lib/list.go — fetches list then deletes each completed item individually (no bulk API exists)
- Fixes missing `MarkFlagRequired("list-id")` on `list update`

## Test plan
- [ ] `make build` passes
- [ ] `make test` passes
- [ ] `make lint` clean