### PR TITLE
feat: add routine command for CRUD and reorder (issue #77)

### DIFF
--- a/cmd/helpers.go
+++ b/cmd/helpers.go
@@ -102,6 +102,8 @@ func printTableOutputExtended(data any) bool {
 		printMealSittingsTable(v)
 	case []lib.Photo:
 		printPhotosTable(v)
+	case []lib.Routine:
+		printRoutinesTable(v)
 	default:
 		return false
 	}
@@ -265,6 +267,15 @@ func printPhotosTable(photos []lib.Photo) {
 	fmt.Fprintln(w, "ID\tTYPE\tSTATUS\tCREATED")
 	for _, p := range photos {
 		fmt.Fprintf(w, "%s\t%s\t%s\t%s\n", p.ID, p.AssetType, p.Status, p.CreatedAt)
+	}
+	w.Flush()
+}
+
+func printRoutinesTable(routines []lib.Routine) {
+	w := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
+	fmt.Fprintln(w, "ID\tTITLE\tASSIGNEE\tSTEPS")
+	for _, r := range routines {
+		fmt.Fprintf(w, "%s\t%s\t%s\t%d\n", r.ID, r.Title, r.AssigneeID, len(r.Steps))
 	}
 	w.Flush()
 }

--- a/cmd/routine.go
+++ b/cmd/routine.go
@@ -1,0 +1,162 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/sebrandon1/go-skylight/lib"
+	"github.com/spf13/cobra"
+)
+
+var (
+	routineID       string
+	routineTitle    string
+	routineAssignee string
+	routineSteps    []string
+	routineIDs      []string
+)
+
+var routineCmd = &cobra.Command{
+	Use:   "routine",
+	Short: "Routine management commands",
+}
+
+var routineListCmd = &cobra.Command{
+	Use:   "list",
+	Short: "List routines",
+	Run: func(cmd *cobra.Command, args []string) {
+		requireFrameID()
+
+		client := getClient()
+
+		routines, err := client.ListRoutines(frameID)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Error listing routines: %v\n", err)
+			os.Exit(1)
+		}
+
+		printOutput(routines)
+	},
+}
+
+var routineCreateCmd = &cobra.Command{
+	Use:   "create",
+	Short: "Create a routine",
+	Run: func(cmd *cobra.Command, args []string) {
+		requireFrameID()
+
+		client := getClient()
+
+		routine, err := client.CreateRoutine(frameID, lib.RoutineData{
+			Title:      routineTitle,
+			AssigneeID: routineAssignee,
+			Steps:      filterEmptyStrings(routineSteps),
+		})
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Error creating routine: %v\n", err)
+			os.Exit(1)
+		}
+
+		printJSON(routine)
+	},
+}
+
+var routineUpdateCmd = &cobra.Command{
+	Use:   "update",
+	Short: "Update a routine",
+	Run: func(cmd *cobra.Command, args []string) {
+		requireFrameID()
+
+		client := getClient()
+
+		data := lib.RoutineData{}
+		if cmd.Flags().Changed("title") {
+			data.Title = routineTitle
+		}
+		if cmd.Flags().Changed("assignee-id") {
+			data.AssigneeID = routineAssignee
+		}
+		if cmd.Flags().Changed("steps") {
+			data.Steps = filterEmptyStrings(routineSteps)
+		}
+
+		routine, err := client.UpdateRoutine(frameID, routineID, data)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Error updating routine: %v\n", err)
+			os.Exit(1)
+		}
+
+		printJSON(routine)
+	},
+}
+
+var routineDeleteCmd = &cobra.Command{
+	Use:   "delete",
+	Short: "Delete a routine",
+	Run: func(cmd *cobra.Command, args []string) {
+		requireFrameID()
+
+		client := getClient()
+
+		if err := client.DeleteRoutine(frameID, routineID); err != nil {
+			fmt.Fprintf(os.Stderr, "Error deleting routine: %v\n", err)
+			os.Exit(1)
+		}
+
+		fmt.Println("Routine deleted successfully")
+	},
+}
+
+var routineReorderCmd = &cobra.Command{
+	Use:   "reorder",
+	Short: "Set the display order of routines",
+	Run: func(cmd *cobra.Command, args []string) {
+		requireFrameID()
+
+		client := getClient()
+
+		if err := client.ReorderRoutines(frameID, routineIDs); err != nil {
+			fmt.Fprintf(os.Stderr, "Error reordering routines: %v\n", err)
+			os.Exit(1)
+		}
+
+		fmt.Println("Routines reordered successfully")
+	},
+}
+
+func filterEmptyStrings(ss []string) []string {
+	out := ss[:0:0]
+	for _, s := range ss {
+		if s != "" {
+			out = append(out, s)
+		}
+	}
+	return out
+}
+
+func init() {
+	rootCmd.AddCommand(routineCmd)
+
+	routineCmd.AddCommand(routineListCmd)
+	routineCmd.AddCommand(routineCreateCmd)
+	routineCmd.AddCommand(routineUpdateCmd)
+	routineCmd.AddCommand(routineDeleteCmd)
+	routineCmd.AddCommand(routineReorderCmd)
+
+	routineCreateCmd.Flags().StringVar(&routineTitle, "title", "", "Routine title")
+	routineCreateCmd.Flags().StringVar(&routineAssignee, "assignee-id", "", "Assignee ID")
+	routineCreateCmd.Flags().StringSliceVar(&routineSteps, "steps", nil, "Step titles (comma-separated)")
+	routineCreateCmd.MarkFlagRequired("title") //nolint:errcheck
+
+	routineUpdateCmd.Flags().StringVar(&routineID, "routine-id", "", "Routine ID")
+	routineUpdateCmd.Flags().StringVar(&routineTitle, "title", "", "Routine title")
+	routineUpdateCmd.Flags().StringVar(&routineAssignee, "assignee-id", "", "Assignee ID")
+	routineUpdateCmd.Flags().StringSliceVar(&routineSteps, "steps", nil, "Step titles (comma-separated)")
+	routineUpdateCmd.MarkFlagRequired("routine-id") //nolint:errcheck
+
+	routineDeleteCmd.Flags().StringVar(&routineID, "routine-id", "", "Routine ID")
+	routineDeleteCmd.MarkFlagRequired("routine-id") //nolint:errcheck
+
+	routineReorderCmd.Flags().StringSliceVar(&routineIDs, "routine-ids", nil, "Routine IDs in desired order (comma-separated)")
+	routineReorderCmd.MarkFlagRequired("routine-ids") //nolint:errcheck
+}

--- a/lib/routine.go
+++ b/lib/routine.go
@@ -1,0 +1,138 @@
+package lib
+
+import "fmt"
+
+// Routine represents a Skylight routine (ordered recurring task list).
+type Routine struct {
+	ID         string        `json:"id,omitempty"`
+	Title      string        `json:"title,omitempty"`
+	AssigneeID string        `json:"assignee_id,omitempty"`
+	Steps      []RoutineStep `json:"steps,omitempty"`
+	CreatedAt  string        `json:"created_at,omitempty"`
+	UpdatedAt  string        `json:"updated_at,omitempty"`
+}
+
+// RoutineStep represents a single step within a routine.
+type RoutineStep struct {
+	ID       string `json:"id,omitempty"`
+	Title    string `json:"title,omitempty"`
+	Position int    `json:"position,omitempty"`
+}
+
+// RoutineData holds the fields for create/update routine requests.
+type RoutineData struct {
+	Title      string   `json:"title,omitempty"`
+	AssigneeID string   `json:"assignee_id,omitempty"`
+	Steps      []string `json:"steps,omitempty"`
+}
+
+type reorderRoutinesRequest struct {
+	IDs []string `json:"ids"`
+}
+
+type routineAPIResponse struct {
+	Data []routineAPIEntry `json:"data"`
+}
+
+type routineAPISingleResponse struct {
+	Data routineAPIEntry `json:"data"`
+}
+
+type routineAPIEntry struct {
+	ID         string `json:"id"`
+	Attributes struct {
+		Title      string        `json:"title"`
+		AssigneeID string        `json:"assignee_id"`
+		Steps      []RoutineStep `json:"steps"`
+		CreatedAt  string        `json:"created_at"`
+		UpdatedAt  string        `json:"updated_at"`
+	} `json:"attributes"`
+}
+
+func (e *routineAPIEntry) toRoutine() Routine {
+	return Routine{
+		ID:         e.ID,
+		Title:      e.Attributes.Title,
+		AssigneeID: e.Attributes.AssigneeID,
+		Steps:      e.Attributes.Steps,
+		CreatedAt:  e.Attributes.CreatedAt,
+		UpdatedAt:  e.Attributes.UpdatedAt,
+	}
+}
+
+func (c *Client) ListRoutines(frameID string) ([]Routine, error) {
+	req, err := newRequest("GET", fmt.Sprintf("%s/frames/%s/routines", c.effectiveURL(), frameID))
+	if err != nil {
+		return nil, fmt.Errorf("failed to create list routines request: %w", err)
+	}
+
+	var apiResp routineAPIResponse
+	if err := c.get(req, &apiResp); err != nil {
+		return nil, fmt.Errorf("failed to list routines: %w", err)
+	}
+
+	routines := make([]Routine, len(apiResp.Data))
+	for i := range apiResp.Data {
+		routines[i] = apiResp.Data[i].toRoutine()
+	}
+	return routines, nil
+}
+
+func (c *Client) CreateRoutine(frameID string, data RoutineData) (*Routine, error) {
+	req, err := newRequestWithBody("POST", fmt.Sprintf("%s/frames/%s/routines", c.effectiveURL(), frameID), data)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create routine request: %w", err)
+	}
+
+	var apiResp routineAPISingleResponse
+	if err := c.post(req, &apiResp); err != nil {
+		return nil, fmt.Errorf("failed to create routine: %w", err)
+	}
+
+	result := apiResp.Data.toRoutine()
+	return &result, nil
+}
+
+func (c *Client) UpdateRoutine(frameID, routineID string, data RoutineData) (*Routine, error) {
+	req, err := newRequestWithBody("PUT", fmt.Sprintf("%s/frames/%s/routines/%s", c.effectiveURL(), frameID, routineID), data)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create update routine request: %w", err)
+	}
+
+	var apiResp routineAPISingleResponse
+	if err := c.put(req, &apiResp); err != nil {
+		return nil, fmt.Errorf("failed to update routine: %w", err)
+	}
+
+	result := apiResp.Data.toRoutine()
+	return &result, nil
+}
+
+func (c *Client) DeleteRoutine(frameID, routineID string) error {
+	req, err := newRequest("DELETE", fmt.Sprintf("%s/frames/%s/routines/%s", c.effectiveURL(), frameID, routineID))
+	if err != nil {
+		return fmt.Errorf("failed to create delete routine request: %w", err)
+	}
+
+	if err := c.doDelete(req); err != nil {
+		return fmt.Errorf("failed to delete routine: %w", err)
+	}
+
+	return nil
+}
+
+func (c *Client) ReorderRoutines(frameID string, routineIDs []string) error {
+	body := reorderRoutinesRequest{IDs: routineIDs}
+
+	req, err := newRequestWithBody("PATCH", fmt.Sprintf("%s/frames/%s/routines/reorder", c.effectiveURL(), frameID), body)
+	if err != nil {
+		return fmt.Errorf("failed to create reorder routines request: %w", err)
+	}
+
+	var result any
+	if err := c.patch(req, &result); err != nil {
+		return fmt.Errorf("failed to reorder routines: %w", err)
+	}
+
+	return nil
+}


### PR DESCRIPTION
Closes #77

## Summary
- Adds `routine list/create/update/delete/reorder` subcommands
- `lib/routine.go`: ListRoutines, CreateRoutine, UpdateRoutine, DeleteRoutine, ReorderRoutines (PATCH `/routines/reorder`)
- `cmd/routine.go`: Cobra commands with required flags; update uses `cmd.Flags().Changed` for partial updates
- Adds `printRoutinesTable` to `cmd/helpers.go` for table output

## Test plan
- [ ] `make build` passes
- [ ] `make test` passes
- [ ] `make lint` clean