### PR TITLE
feat: add grocery subcommand for list management

### DIFF
--- a/cmd/grocery.go
+++ b/cmd/grocery.go
@@ -1,0 +1,124 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/sebrandon1/go-skylight/lib"
+	"github.com/spf13/cobra"
+)
+
+var (
+	groceryListID   string
+	groceryTitle    string
+	groceryRetailer string
+)
+
+var groceryCmd = &cobra.Command{
+	Use:   "grocery",
+	Short: "Grocery list management commands",
+}
+
+var groceryListCmd = &cobra.Command{
+	Use:   "list",
+	Short: "List grocery lists",
+	Run: func(cmd *cobra.Command, args []string) {
+		requireFrameID()
+
+		client := getClient()
+
+		all, err := client.ListLists(frameID)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Error listing lists: %v\n", err)
+			os.Exit(1)
+		}
+
+		grocery := []lib.List{}
+		for _, l := range all {
+			if l.Kind == lib.ListKindGrocery {
+				grocery = append(grocery, l)
+			}
+		}
+
+		printOutput(grocery)
+	},
+}
+
+var groceryCreateCmd = &cobra.Command{
+	Use:   "create",
+	Short: "Create a grocery list",
+	Run: func(cmd *cobra.Command, args []string) {
+		requireFrameID()
+
+		client := getClient()
+
+		list, err := client.CreateList(frameID, lib.ListData{
+			Title: groceryTitle,
+			Kind:  lib.ListKindGrocery,
+		})
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Error creating grocery list: %v\n", err)
+			os.Exit(1)
+		}
+
+		printJSON(list)
+	},
+}
+
+var groceryOrganizeCmd = &cobra.Command{
+	Use:   "organize",
+	Short: "Deduplicate and sort a grocery list by aisle",
+	Run: func(cmd *cobra.Command, args []string) {
+		requireFrameID()
+
+		client := getClient()
+
+		if err := client.OrganizeGroceryList(frameID, groceryListID); err != nil {
+			fmt.Fprintf(os.Stderr, "Error organizing grocery list: %v\n", err)
+			os.Exit(1)
+		}
+
+		fmt.Println("Grocery list organized successfully")
+	},
+}
+
+var groceryOrderCmd = &cobra.Command{
+	Use:   "order",
+	Short: "Send grocery list to Instacart",
+	Run: func(cmd *cobra.Command, args []string) {
+		requireFrameID()
+
+		client := getClient()
+
+		url, err := client.OrderGroceryList(frameID, groceryListID, groceryRetailer)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Error ordering grocery list: %v\n", err)
+			os.Exit(1)
+		}
+
+		if url != "" {
+			fmt.Printf("Order URL: %s\n", url)
+		} else {
+			fmt.Println("Order submitted successfully")
+		}
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(groceryCmd)
+
+	groceryCmd.AddCommand(groceryListCmd)
+	groceryCmd.AddCommand(groceryCreateCmd)
+	groceryCmd.AddCommand(groceryOrganizeCmd)
+	groceryCmd.AddCommand(groceryOrderCmd)
+
+	groceryCreateCmd.Flags().StringVar(&groceryTitle, "title", "", "Grocery list title")
+	groceryCreateCmd.MarkFlagRequired("title") //nolint:errcheck
+
+	groceryOrganizeCmd.Flags().StringVar(&groceryListID, "list-id", "", "List ID")
+	groceryOrganizeCmd.MarkFlagRequired("list-id") //nolint:errcheck
+
+	groceryOrderCmd.Flags().StringVar(&groceryListID, "list-id", "", "List ID")
+	groceryOrderCmd.Flags().StringVar(&groceryRetailer, "retailer", "", "Retailer slug (e.g. costco)")
+	groceryOrderCmd.MarkFlagRequired("list-id") //nolint:errcheck
+}

--- a/lib/list.go
+++ b/lib/list.go
@@ -5,6 +5,9 @@ import "fmt"
 const listItemStatusCompleted = "completed"
 const listItemStatusPending = "pending"
 
+// ListKindGrocery is the list kind value for grocery lists.
+const ListKindGrocery = "grocery"
+
 // ListLists retrieves all lists for a frame.
 func (c *Client) ListLists(frameID string) ([]List, error) {
 	req, err := newRequest("GET", fmt.Sprintf("%s/frames/%s/lists", c.effectiveURL(), frameID))
@@ -184,6 +187,43 @@ func (c *Client) ClearCompletedListItems(frameID, listID string) (int, error) {
 		}
 	}
 	return deleted, nil
+}
+
+// OrganizeGroceryList deduplicates and sorts a grocery list by aisle.
+func (c *Client) OrganizeGroceryList(frameID, listID string) error {
+	req, err := newRequest("POST", fmt.Sprintf("%s/frames/%s/lists/%s/organize", c.effectiveURL(), frameID, listID))
+	if err != nil {
+		return fmt.Errorf("failed to create organize list request: %w", err)
+	}
+
+	var result any
+	if err := c.post(req, &result); err != nil {
+		return fmt.Errorf("failed to organize list: %w", err)
+	}
+
+	return nil
+}
+
+// OrderGroceryList sends the grocery list to an Instacart order.
+// retailer may be empty (default) or a specific retailer slug (e.g. "costco").
+func (c *Client) OrderGroceryList(frameID, listID, retailer string) (string, error) {
+	body := struct {
+		Retailer string `json:"retailer,omitempty"`
+	}{Retailer: retailer}
+
+	req, err := newRequestWithBody("POST", fmt.Sprintf("%s/frames/%s/lists/%s/order", c.effectiveURL(), frameID, listID), body)
+	if err != nil {
+		return "", fmt.Errorf("failed to create order list request: %w", err)
+	}
+
+	var result struct {
+		RedirectURL string `json:"redirect_url"`
+	}
+	if err := c.post(req, &result); err != nil {
+		return "", fmt.Errorf("failed to order list: %w", err)
+	}
+
+	return result.RedirectURL, nil
 }
 
 // CreateTaskBoxItem creates a new task box item on a frame.


### PR DESCRIPTION
## Summary
- Adds `grocery list/create/organize/order` subcommands under a new `grocery` top-level command
- `grocery list` fetches all lists and filters by `kind=="grocery"`
- `grocery create` creates a new list with `kind="grocery"` hardcoded
- `grocery organize` calls `POST .../organize` to deduplicate and sort by aisle
- `grocery order` calls `POST .../order` to send the list to Instacart, printing the redirect URL if returned

Closes #76

## Test plan
- [ ] `go-skylight grocery list --frame-id <id>` returns only grocery-kind lists
- [ ] `go-skylight grocery create --frame-id <id> --title "Weekly Shop"` creates a grocery list
- [ ] `go-skylight grocery organize --frame-id <id> --list-id <id>` succeeds silently
- [ ] `go-skylight grocery order --frame-id <id> --list-id <id>` prints redirect URL or success message
- [ ] `make lint` passes (0 issues)