### PR TITLE
feat: add watch command for live event polling

### DIFF
--- a/.github/workflows/integration.yaml
+++ b/.github/workflows/integration.yaml
@@ -1,0 +1,41 @@
+name: Integration Tests
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+  schedule:
+    - cron: '30 4 * * *'
+  workflow_dispatch:
+
+permissions: read-all
+
+jobs:
+  integration:
+    name: Integration Tests
+    runs-on: ubuntu-latest
+    if: >-
+      github.event_name != 'pull_request' ||
+      github.actor == 'sebrandon1' ||
+      github.actor == 'dependabot[bot]'
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v6
+
+    - name: Set up Go
+      uses: actions/setup-go@v6
+      with:
+        go-version-file: 'go.mod'
+
+    - name: Download dependencies
+      run: go mod download
+
+    - name: Run integration tests
+      env:
+        SKYLIGHT_REFRESH_TOKEN: ${{ secrets.SKYLIGHT_REFRESH_TOKEN }}
+        SKYLIGHT_DEVICE_FINGERPRINT: ${{ secrets.SKYLIGHT_DEVICE_FINGERPRINT }}
+        SKYLIGHT_FRAME_ID: ${{ secrets.SKYLIGHT_FRAME_ID }}
+        SKYLIGHT_EMAIL: ${{ secrets.SKYLIGHT_EMAIL }}
+        SKYLIGHT_PASSWORD: ${{ secrets.SKYLIGHT_PASSWORD }}
+      run: go test -v -tags integration -count=1 -timeout 5m ./lib/...

--- a/cmd/watch.go
+++ b/cmd/watch.go
@@ -1,0 +1,233 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+	"os/signal"
+	"strings"
+	"syscall"
+	"time"
+
+	"github.com/sebrandon1/go-skylight/lib"
+	"github.com/spf13/cobra"
+)
+
+const (
+	watchResourceRewards  = "rewards"
+	watchResourceChores   = "chores"
+	watchResourceCalendar = "calendar"
+)
+
+var (
+	watchInterval  int
+	watchResources string
+
+	allWatchResources = []string{watchResourceRewards, watchResourceChores, watchResourceCalendar}
+
+	validWatchResources = func() map[string]struct{} {
+		m := make(map[string]struct{}, len(allWatchResources))
+		for _, r := range allWatchResources {
+			m[r] = struct{}{}
+		}
+		return m
+	}()
+)
+
+var watchCmd = &cobra.Command{
+	Use:   "watch",
+	Short: "Poll for changes and print events as they happen",
+	Long: `Poll Skylight resources at a regular interval and print new events.
+
+Tracks previously-seen IDs in memory and emits only newly-observed changes:
+  - rewards: newly redeemed rewards
+  - chores:  chores newly marked complete
+  - calendar: events starting within the next hour
+
+Press Ctrl+C to stop.`,
+	Run: func(cmd *cobra.Command, args []string) {
+		if watchInterval < 1 {
+			fmt.Fprintln(os.Stderr, "Error: --interval must be at least 1")
+			os.Exit(1)
+		}
+
+		requireFrameID()
+		client := getClient()
+
+		resources := parseWatchResources(watchResources)
+
+		ctx, stop := signal.NotifyContext(cmd.Context(), os.Interrupt, syscall.SIGTERM)
+		defer stop()
+
+		ticker := time.NewTicker(time.Duration(watchInterval) * time.Second)
+		defer ticker.Stop()
+
+		state := &watchState{
+			seenRewardIDs: make(map[string]struct{}),
+			seenChoreIDs:  make(map[string]struct{}),
+			seenEventIDs:  make(map[string]struct{}),
+		}
+
+		// Seed state silently so existing items aren't reported as new.
+		state.seeding = true
+		poll(client, state, resources)
+		state.seeding = false
+
+		fmt.Printf("Watching %s (interval: %ds). Press Ctrl+C to stop.\n\n",
+			strings.Join(resources, ", "), watchInterval)
+
+		for {
+			select {
+			case <-ctx.Done():
+				fmt.Println("\nStopped.")
+				return
+			case <-ticker.C:
+				poll(client, state, resources)
+			}
+		}
+	},
+}
+
+type watchState struct {
+	seenRewardIDs map[string]struct{}
+	seenChoreIDs  map[string]struct{}
+	seenEventIDs  map[string]struct{}
+	seeding       bool
+}
+
+func parseWatchResources(s string) []string {
+	if s == "" || s == "all" {
+		return allWatchResources
+	}
+	var out []string
+	for _, r := range strings.Split(s, ",") {
+		r = strings.TrimSpace(r)
+		if r == "" {
+			continue
+		}
+		if _, ok := validWatchResources[r]; !ok {
+			fmt.Fprintf(os.Stderr, "Warning: unknown resource %q (valid: %s)\n", r, strings.Join(allWatchResources, ", "))
+			continue
+		}
+		out = append(out, r)
+	}
+	if len(out) == 0 {
+		fmt.Fprintln(os.Stderr, "Error: no valid resources specified")
+		os.Exit(1)
+	}
+	return out
+}
+
+func poll(client *lib.Client, state *watchState, resources []string) {
+	now := time.Now()
+	ts := now.Format("15:04:05")
+	for _, r := range resources {
+		switch r {
+		case watchResourceRewards:
+			pollRewards(client, state, ts)
+		case watchResourceChores:
+			pollChores(client, state, now, ts)
+		case watchResourceCalendar:
+			pollCalendar(client, state, now, ts)
+		}
+	}
+}
+
+func pollRewards(client *lib.Client, state *watchState, ts string) {
+	rewards, err := client.ListRewards(frameID)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "[%s] Error listing rewards: %v\n", ts, err)
+		return
+	}
+	for _, r := range rewards {
+		if !r.Redeemed {
+			continue
+		}
+		if _, seen := state.seenRewardIDs[r.ID]; seen {
+			continue
+		}
+		state.seenRewardIDs[r.ID] = struct{}{}
+		if state.seeding {
+			continue
+		}
+		if outputFormat == outputJSON {
+			printJSON(map[string]any{
+				"type": "reward_redeemed", "id": r.ID, "title": r.Title,
+				"points": r.Points, "category_id": r.CategoryID, "ts": ts,
+			})
+		} else {
+			fmt.Printf("[%s] REWARD REDEEMED  %s (%d pts) — category %s\n",
+				ts, r.Title, r.Points, r.CategoryID)
+		}
+	}
+}
+
+func pollChores(client *lib.Client, state *watchState, now time.Time, ts string) {
+	today := now.Format(lib.DateFormat)
+	chores, err := client.ListChores(frameID, lib.ChoreListOptions{After: today, Before: today, Status: lib.ChoreStatusComplete})
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "[%s] Error listing chores: %v\n", ts, err)
+		return
+	}
+	for _, c := range chores {
+		if _, seen := state.seenChoreIDs[c.ID]; seen {
+			continue
+		}
+		state.seenChoreIDs[c.ID] = struct{}{}
+		if state.seeding {
+			continue
+		}
+		if outputFormat == outputJSON {
+			printJSON(map[string]any{
+				"type": "chore_completed", "id": c.ID, "title": c.Title,
+				"assignee_id": c.AssigneeID, "ts": ts,
+			})
+		} else {
+			fmt.Printf("[%s] CHORE COMPLETED  %s — assignee %s\n",
+				ts, c.Title, c.AssigneeID)
+		}
+	}
+}
+
+func pollCalendar(client *lib.Client, state *watchState, now time.Time, ts string) {
+	today := now.Format(lib.DateFormat)
+	events, err := client.ListCalendarEvents(frameID, today, today)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "[%s] Error listing calendar events: %v\n", ts, err)
+		return
+	}
+	for _, e := range events {
+		if _, seen := state.seenEventIDs[e.ID]; seen {
+			continue
+		}
+		if e.AllDay || e.StartAt == "" {
+			continue
+		}
+		start, err := time.Parse(time.RFC3339, e.StartAt)
+		if err != nil {
+			continue
+		}
+		diff := time.Until(start)
+		if diff <= 0 || diff > time.Hour {
+			continue
+		}
+		state.seenEventIDs[e.ID] = struct{}{}
+		if state.seeding {
+			continue
+		}
+		if outputFormat == outputJSON {
+			printJSON(map[string]any{
+				"type": "event_soon", "id": e.ID, "title": e.Title,
+				"start_at": e.StartAt, "minutes_until": int(diff.Minutes()), "ts": ts,
+			})
+		} else {
+			fmt.Printf("[%s] EVENT SOON       %s starts in %d min\n",
+				ts, e.Title, int(diff.Minutes()))
+		}
+	}
+}
+
+func init() {
+	rootCmd.AddCommand(watchCmd)
+	watchCmd.Flags().IntVar(&watchInterval, "interval", 60, "Poll interval in seconds")
+	watchCmd.Flags().StringVar(&watchResources, "resources", "all", "Comma-separated resources to watch: rewards,chores,calendar")
+}

--- a/cmd/watch_test.go
+++ b/cmd/watch_test.go
@@ -1,0 +1,132 @@
+package cmd
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestParseWatchResources_All(t *testing.T) {
+	cases := []string{"", "all"}
+	for _, c := range cases {
+		got := parseWatchResources(c)
+		if len(got) != 3 {
+			t.Errorf("parseWatchResources(%q): expected 3 resources, got %d: %v", c, len(got), got)
+		}
+	}
+}
+
+func TestParseWatchResources_Specific(t *testing.T) {
+	got := parseWatchResources("rewards,chores")
+	if len(got) != 2 {
+		t.Fatalf("expected 2 resources, got %d: %v", len(got), got)
+	}
+	if got[0] != "rewards" || got[1] != "chores" {
+		t.Errorf("unexpected resources: %v", got)
+	}
+}
+
+func TestParseWatchResources_Single(t *testing.T) {
+	got := parseWatchResources("calendar")
+	if len(got) != 1 || got[0] != "calendar" {
+		t.Errorf("expected [calendar], got %v", got)
+	}
+}
+
+func TestParseWatchResources_TrimsSpaces(t *testing.T) {
+	got := parseWatchResources(" rewards , chores ")
+	if len(got) != 2 {
+		t.Fatalf("expected 2 resources, got %d: %v", len(got), got)
+	}
+	if got[0] != "rewards" || got[1] != "chores" {
+		t.Errorf("expected trimmed resources, got %v", got)
+	}
+}
+
+func TestWatchState_TracksSeenRewards(t *testing.T) {
+	state := &watchState{
+		seenRewardIDs: make(map[string]struct{}),
+		seenChoreIDs:  make(map[string]struct{}),
+		seenEventIDs:  make(map[string]struct{}),
+	}
+
+	if _, seen := state.seenRewardIDs["r1"]; seen {
+		t.Error("expected r1 not yet seen")
+	}
+	state.seenRewardIDs["r1"] = struct{}{}
+	if _, seen := state.seenRewardIDs["r1"]; !seen {
+		t.Error("expected r1 to be seen after marking")
+	}
+}
+
+func TestWatchState_TracksSeenChores(t *testing.T) {
+	state := &watchState{
+		seenRewardIDs: make(map[string]struct{}),
+		seenChoreIDs:  make(map[string]struct{}),
+		seenEventIDs:  make(map[string]struct{}),
+	}
+
+	if _, seen := state.seenChoreIDs["c1"]; seen {
+		t.Error("expected c1 not yet seen")
+	}
+	state.seenChoreIDs["c1"] = struct{}{}
+	if _, seen := state.seenChoreIDs["c1"]; !seen {
+		t.Error("expected c1 to be seen after marking")
+	}
+}
+
+func TestWatchState_TracksSeenEvents(t *testing.T) {
+	state := &watchState{
+		seenRewardIDs: make(map[string]struct{}),
+		seenChoreIDs:  make(map[string]struct{}),
+		seenEventIDs:  make(map[string]struct{}),
+	}
+
+	if _, seen := state.seenEventIDs["e1"]; seen {
+		t.Error("expected e1 not yet seen")
+	}
+	state.seenEventIDs["e1"] = struct{}{}
+	if _, seen := state.seenEventIDs["e1"]; !seen {
+		t.Error("expected e1 to be seen after marking")
+	}
+}
+
+func TestParseWatchResources_IgnoresInvalid(t *testing.T) {
+	got := parseWatchResources("rewards,bogus,chores")
+	if len(got) != 2 {
+		t.Fatalf("expected 2 valid resources, got %d: %v", len(got), got)
+	}
+	if got[0] != "rewards" || got[1] != "chores" {
+		t.Errorf("expected [rewards chores], got %v", got)
+	}
+}
+
+func TestWatchCmdExists(t *testing.T) {
+	found := false
+	for _, c := range rootCmd.Commands() {
+		if c.Use == "watch" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Error("watch command not registered on root")
+	}
+}
+
+func TestWatchCmdHasFlags(t *testing.T) {
+	if f := watchCmd.Flags().Lookup("interval"); f == nil {
+		t.Error("expected --interval flag on watch command")
+	}
+	if f := watchCmd.Flags().Lookup("resources"); f == nil {
+		t.Error("expected --resources flag on watch command")
+	}
+}
+
+func TestWatchCmdLong_ContainsResources(t *testing.T) {
+	long := watchCmd.Long
+	for _, r := range []string{"rewards", "chores", "calendar"} {
+		if !strings.Contains(long, r) {
+			t.Errorf("expected %q mentioned in watch command long description", r)
+		}
+	}
+}

--- a/lib/integration_test.go
+++ b/lib/integration_test.go
@@ -1,0 +1,236 @@
+//go:build integration
+
+package lib
+
+import (
+	"os"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"golang.org/x/time/rate"
+)
+
+var (
+	sharedClient  *Client
+	sharedFrameID string
+	clientOnce    sync.Once
+	clientErr     error
+)
+
+func integrationClient(t *testing.T) (*Client, string) {
+	t.Helper()
+
+	refreshToken := os.Getenv("SKYLIGHT_REFRESH_TOKEN")
+	fingerprint := os.Getenv("SKYLIGHT_DEVICE_FINGERPRINT")
+	frameID := os.Getenv("SKYLIGHT_FRAME_ID")
+
+	if refreshToken == "" || fingerprint == "" || frameID == "" {
+		t.Skip("skipping: SKYLIGHT_REFRESH_TOKEN, SKYLIGHT_DEVICE_FINGERPRINT, and SKYLIGHT_FRAME_ID must be set")
+	}
+
+	clientOnce.Do(func() {
+		sharedClient, clientErr = NewClientWithRefreshToken(refreshToken, fingerprint,
+			WithRateLimit(rate.Limit(2), 5),
+			WithRetry(3, 500*time.Millisecond, 10*time.Second),
+		)
+		sharedFrameID = frameID
+	})
+
+	if clientErr != nil {
+		t.Fatalf("NewClientWithRefreshToken: %v", clientErr)
+	}
+
+	return sharedClient, sharedFrameID
+}
+
+func TestIntegration_GetFrame(t *testing.T) {
+	client, frameID := integrationClient(t)
+
+	frame, err := client.GetFrame(frameID)
+	if err != nil {
+		t.Fatalf("GetFrame: %v", err)
+	}
+
+	if frame.ID != frameID {
+		t.Errorf("expected frame ID %s, got %s", frameID, frame.ID)
+	}
+
+	if frame.Name == "" {
+		t.Error("expected non-empty frame name")
+	}
+
+	t.Logf("frame: %s (%s)", frame.Name, frame.ID)
+}
+
+func TestIntegration_ListDevices(t *testing.T) {
+	client, frameID := integrationClient(t)
+
+	devices, err := client.ListDevices(frameID)
+	if err != nil {
+		t.Fatalf("ListDevices: %v", err)
+	}
+
+	t.Logf("devices: %d", len(devices))
+
+	for _, d := range devices {
+		if d.ID == "" {
+			t.Error("device has empty ID")
+		}
+	}
+}
+
+func TestIntegration_ListCategories(t *testing.T) {
+	client, frameID := integrationClient(t)
+
+	categories, err := client.ListCategories(frameID)
+	if err != nil {
+		t.Fatalf("ListCategories: %v", err)
+	}
+
+	if len(categories) == 0 {
+		t.Fatal("expected at least one category (family member)")
+	}
+
+	t.Logf("categories: %d", len(categories))
+
+	for _, c := range categories {
+		if c.ID == "" {
+			t.Error("category has empty ID")
+		}
+		if c.Name == "" {
+			t.Error("category has empty Name")
+		}
+	}
+}
+
+func TestIntegration_ListRewards(t *testing.T) {
+	client, frameID := integrationClient(t)
+
+	rewards, err := client.ListRewards(frameID)
+	if err != nil {
+		t.Fatalf("ListRewards: %v", err)
+	}
+
+	t.Logf("rewards: %d", len(rewards))
+
+	for _, r := range rewards {
+		if r.ID == "" {
+			t.Error("reward has empty ID")
+		}
+		if r.Title == "" {
+			t.Error("reward has empty Title")
+		}
+	}
+}
+
+func TestIntegration_ListChores(t *testing.T) {
+	client, frameID := integrationClient(t)
+
+	now := time.Now()
+	opts := ChoreListOptions{
+		After:  now.Format(DateFormat),
+		Before: now.AddDate(0, 0, 30).Format(DateFormat),
+	}
+
+	chores, err := client.ListChores(frameID, opts)
+	if err != nil {
+		t.Fatalf("ListChores: %v", err)
+	}
+
+	t.Logf("chores: %d", len(chores))
+
+	for _, c := range chores {
+		if c.ID == "" {
+			t.Error("chore has empty ID")
+		}
+		if c.Title == "" {
+			t.Error("chore has empty Title")
+		}
+	}
+}
+
+func TestIntegration_ListCalendarEvents(t *testing.T) {
+	client, frameID := integrationClient(t)
+
+	now := time.Now()
+	start := now.Format(DateFormat)
+	end := now.AddDate(0, 0, 7).Format(DateFormat)
+
+	events, err := client.ListCalendarEvents(frameID, start, end)
+	if err != nil {
+		if strings.Contains(err.Error(), "500") || strings.Contains(err.Error(), "Internal Server Error") {
+			t.Skipf("ListCalendarEvents: skipping due to API instability: %v", err)
+		}
+		t.Fatalf("ListCalendarEvents: %v", err)
+	}
+
+	t.Logf("calendar events: %d", len(events))
+
+	for _, e := range events {
+		if e.ID == "" {
+			t.Error("event has empty ID")
+		}
+		if e.Title == "" {
+			t.Error("event has empty Title")
+		}
+	}
+}
+
+func TestIntegration_ListLists(t *testing.T) {
+	client, frameID := integrationClient(t)
+
+	lists, err := client.ListLists(frameID)
+	if err != nil {
+		t.Fatalf("ListLists: %v", err)
+	}
+
+	t.Logf("lists: %d", len(lists))
+
+	for _, l := range lists {
+		if l.ID == "" {
+			t.Error("list has empty ID")
+		}
+		if l.Title == "" {
+			t.Error("list has empty Title")
+		}
+	}
+}
+
+func TestIntegration_ListRecipes(t *testing.T) {
+	client, frameID := integrationClient(t)
+
+	recipes, err := client.ListRecipes(frameID)
+	if err != nil {
+		t.Fatalf("ListRecipes: %v", err)
+	}
+
+	t.Logf("recipes: %d", len(recipes))
+
+	for _, r := range recipes {
+		if r.ID == "" {
+			t.Error("recipe has empty ID")
+		}
+		if r.Title == "" {
+			t.Error("recipe has empty Title")
+		}
+	}
+}
+
+func TestIntegration_ListMealCategories(t *testing.T) {
+	client, frameID := integrationClient(t)
+
+	categories, err := client.ListMealCategories(frameID)
+	if err != nil {
+		t.Fatalf("ListMealCategories: %v", err)
+	}
+
+	t.Logf("meal categories: %d", len(categories))
+
+	for _, c := range categories {
+		if c.ID == "" {
+			t.Error("meal category has empty ID")
+		}
+	}
+}


### PR DESCRIPTION
## Summary

- Adds `watch` command that polls rewards, chores, and calendar resources at a configurable interval and prints only newly-observed changes
- In-memory dedup via `map[string]struct{}` sets prevent duplicate output within a session
- Silent first poll seeds state so existing items aren't reported as new
- Server-side filtering via `Status: lib.ChoreStatusComplete` avoids client-side filtering overhead
- Calendar events deduped so upcoming events are announced only once per session
- Graceful shutdown via `signal.NotifyContext` (Ctrl+C)
- `--interval` flag (default 60s) and `--resources` flag (default "all"; accepts comma-separated `rewards,chores,calendar`)
- Resource name validation warns on unknown names, exits if none valid
- Interval validation prevents ticker panic on zero/negative values

## Integration Tests

- Adds `lib/integration_test.go` behind `//go:build integration` build tag
- 9 read-only tests covering all major API endpoints (GetFrame, ListDevices, ListCategories, ListRewards, ListChores, ListCalendarEvents, ListLists, ListRecipes, ListMealCategories)
- Shared client via `sync.Once` to handle OAuth refresh token rotation
- Calendar test skips on 500 (known Skylight API instability)
- New CI workflow (`.github/workflows/integration.yaml`) runs on PRs from owner/dependabot only, pushes to main, and daily schedule

## Test plan

- [x] `TestParseWatchResources_All` — empty/all → 3 resources
- [x] `TestParseWatchResources_Specific` — comma-separated → correct slice
- [x] `TestParseWatchResources_Single` — single resource
- [x] `TestParseWatchResources_TrimsSpaces` — whitespace trimmed
- [x] `TestParseWatchResources_IgnoresInvalid` — unknown names warned and skipped
- [x] `TestWatchState_TracksSeenRewards` — dedup map works
- [x] `TestWatchState_TracksSeenChores` — dedup map works
- [x] `TestWatchState_TracksSeenEvents` — calendar dedup map works
- [x] `TestWatchCmdExists` — command registered on root
- [x] `TestWatchCmdHasFlags` — `--interval` and `--resources` flags present
- [x] `TestWatchCmdLong_ContainsResources` — long description mentions all resource names
- [x] Integration tests pass locally (8 pass, 1 skip for calendar 500)
- [x] Verified locally: watch command polls correctly, seeds silently, shuts down cleanly

Closes #47