### PR TITLE
feat: add export and import commands for frame data backup and migration

### DIFF
--- a/cmd/export.go
+++ b/cmd/export.go
@@ -1,0 +1,229 @@
+package cmd
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/sebrandon1/go-skylight/lib"
+	"github.com/spf13/cobra"
+)
+
+const (
+	exportResourceChores   = "chores"
+	exportResourceRewards  = "rewards"
+	exportResourceLists    = "lists"
+	exportResourceRecipes  = "recipes"
+	exportResourceSittings = "sittings"
+	exportResourceCalendar = "calendar"
+)
+
+var allExportResources = []string{
+	exportResourceChores,
+	exportResourceRewards,
+	exportResourceLists,
+	exportResourceRecipes,
+	exportResourceSittings,
+	exportResourceCalendar,
+}
+
+type ExportData struct {
+	ExportedAt     string              `json:"exported_at"`
+	FrameID        string              `json:"frame_id"`
+	Chores         []lib.Chore         `json:"chores,omitempty"`
+	Rewards        []lib.Reward        `json:"rewards,omitempty"`
+	Lists          []lib.List          `json:"lists,omitempty"`
+	Recipes        []lib.Recipe        `json:"recipes,omitempty"`
+	MealSittings   []lib.MealSitting   `json:"meal_sittings,omitempty"`
+	CalendarEvents []lib.CalendarEvent `json:"calendar_events,omitempty"`
+}
+
+var (
+	exportOutputFile string
+	exportResources  string
+	exportDays       int
+)
+
+var exportCmd = &cobra.Command{
+	Use:   "export",
+	Short: "Dump frame data to a JSON file",
+	Long: `Export frame data to a JSON file for backup or migration.
+
+Resources exported: chores, rewards, lists, recipes, sittings, calendar.
+Time-bounded resources (chores, sittings, calendar) use --days to set the window
+centered on today. Use --resources to limit which resource types are included.`,
+	Run: func(cmd *cobra.Command, args []string) {
+		requireFrameID()
+		client := getClient()
+
+		resources := parseResourceList(exportResources, allExportResources)
+		now := time.Now()
+		start := now.AddDate(0, 0, -exportDays).Format(lib.DateFormat)
+		end := now.AddDate(0, 0, exportDays).Format(lib.DateFormat)
+
+		data := ExportData{
+			ExportedAt: now.Format(time.RFC3339),
+			FrameID:    frameID,
+		}
+
+		type result struct {
+			name string
+			err  error
+		}
+		results := make(chan result, len(resources))
+
+		var mu sync.Mutex
+		var wg sync.WaitGroup
+
+		want := toWantMap(resources)
+
+		if want[exportResourceChores] {
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+				chores, err := client.ListChores(frameID, lib.ChoreListOptions{After: start, Before: end, IncludeLate: true})
+				if err == nil {
+					mu.Lock()
+					data.Chores = chores
+					mu.Unlock()
+				}
+				results <- result{exportResourceChores, err}
+			}()
+		}
+		if want[exportResourceRewards] {
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+				rewards, err := client.ListRewards(frameID)
+				if err == nil {
+					mu.Lock()
+					data.Rewards = rewards
+					mu.Unlock()
+				}
+				results <- result{exportResourceRewards, err}
+			}()
+		}
+		if want[exportResourceLists] {
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+				lists, err := client.ListLists(frameID)
+				if err == nil {
+					mu.Lock()
+					data.Lists = lists
+					mu.Unlock()
+				}
+				results <- result{exportResourceLists, err}
+			}()
+		}
+		if want[exportResourceRecipes] {
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+				recipes, err := client.ListRecipes(frameID)
+				if err == nil {
+					mu.Lock()
+					data.Recipes = recipes
+					mu.Unlock()
+				}
+				results <- result{exportResourceRecipes, err}
+			}()
+		}
+		if want[exportResourceSittings] {
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+				sittings, err := client.ListMealSittings(frameID, lib.MealSittingListOptions{DateMin: start, DateMax: end})
+				if err == nil {
+					mu.Lock()
+					data.MealSittings = sittings
+					mu.Unlock()
+				}
+				results <- result{exportResourceSittings, err}
+			}()
+		}
+		if want[exportResourceCalendar] {
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+				events, err := client.ListCalendarEvents(frameID, start, end)
+				if err == nil {
+					mu.Lock()
+					data.CalendarEvents = events
+					mu.Unlock()
+				}
+				results <- result{exportResourceCalendar, err}
+			}()
+		}
+
+		go func() {
+			wg.Wait()
+			close(results)
+		}()
+
+		var errs []string
+		for r := range results {
+			if r.err != nil {
+				errs = append(errs, fmt.Sprintf("%s: %v", r.name, r.err))
+			}
+		}
+		if len(errs) > 0 {
+			for _, e := range errs {
+				fmt.Fprintf(os.Stderr, "Error exporting %s\n", e)
+			}
+			os.Exit(1)
+		}
+
+		out, err := json.MarshalIndent(data, "", "  ")
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Error encoding export: %v\n", err)
+			os.Exit(1)
+		}
+
+		if exportOutputFile == "" || exportOutputFile == "-" {
+			fmt.Println(string(out))
+			return
+		}
+		if err := os.WriteFile(exportOutputFile, out, 0o600); err != nil {
+			fmt.Fprintf(os.Stderr, "Error writing %s: %v\n", exportOutputFile, err)
+			os.Exit(1)
+		}
+		fmt.Printf("Exported to %s\n", exportOutputFile)
+	},
+}
+
+func toWantMap(resources []string) map[string]bool {
+	m := make(map[string]bool, len(resources))
+	for _, r := range resources {
+		m[r] = true
+	}
+	return m
+}
+
+func parseExportResources(s string) []string {
+	return parseResourceList(s, allExportResources)
+}
+
+func parseResourceList(s string, all []string) []string {
+	if s == "" || s == "all" {
+		return all
+	}
+	var out []string
+	for _, r := range strings.Split(s, ",") {
+		r = strings.TrimSpace(r)
+		if r != "" {
+			out = append(out, r)
+		}
+	}
+	return out
+}
+
+func init() {
+	rootCmd.AddCommand(exportCmd)
+	exportCmd.Flags().StringVar(&exportOutputFile, "output-file", "", "Output file path (default: stdout)")
+	exportCmd.Flags().StringVar(&exportResources, "resources", "all", "Comma-separated resource types: chores,rewards,lists,recipes,sittings,calendar")
+	exportCmd.Flags().IntVar(&exportDays, "days", 90, "Window (in days before/after today) for time-bounded resources")
+}

--- a/cmd/export_import_test.go
+++ b/cmd/export_import_test.go
@@ -1,0 +1,148 @@
+package cmd
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/sebrandon1/go-skylight/lib"
+)
+
+func TestParseExportResources_All(t *testing.T) {
+	for _, input := range []string{"", "all"} {
+		got := parseExportResources(input)
+		if len(got) != len(allExportResources) {
+			t.Errorf("parseExportResources(%q): expected %d resources, got %d", input, len(allExportResources), len(got))
+		}
+	}
+}
+
+func TestParseExportResources_Specific(t *testing.T) {
+	got := parseExportResources("chores,rewards")
+	if len(got) != 2 || got[0] != exportResourceChores || got[1] != exportResourceRewards {
+		t.Errorf("unexpected result: %v", got)
+	}
+}
+
+func TestParseExportResources_TrimsSpaces(t *testing.T) {
+	got := parseExportResources(" chores , rewards ")
+	if len(got) != 2 || got[0] != exportResourceChores || got[1] != exportResourceRewards {
+		t.Errorf("unexpected result: %v", got)
+	}
+}
+
+func TestExportCmdExists(t *testing.T) {
+	found := false
+	for _, c := range rootCmd.Commands() {
+		if c.Use == "export" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Error("export command not registered on root")
+	}
+}
+
+func TestImportCmdExists(t *testing.T) {
+	found := false
+	for _, c := range rootCmd.Commands() {
+		if c.Use == "import" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Error("import command not registered on root")
+	}
+}
+
+func TestExportCmdHasFlags(t *testing.T) {
+	flags := []string{"output-file", "resources", "days"}
+	for _, f := range flags {
+		if exportCmd.Flags().Lookup(f) == nil {
+			t.Errorf("expected --%s flag on export command", f)
+		}
+	}
+}
+
+func TestImportCmdHasFlags(t *testing.T) {
+	flags := []string{"file", "dry-run", "resources"}
+	for _, f := range flags {
+		if importCmd.Flags().Lookup(f) == nil {
+			t.Errorf("expected --%s flag on import command", f)
+		}
+	}
+}
+
+func TestRunImportDryRun_PrintsCounts(t *testing.T) {
+	old := os.Stdout
+	r, w, _ := os.Pipe()
+	os.Stdout = w
+
+	origFrameID := frameID
+	frameID = "test-frame"
+	t.Cleanup(func() { frameID = origFrameID })
+
+	data := ExportData{
+		Chores:  []lib.Chore{{ID: "1"}, {ID: "2"}},
+		Rewards: []lib.Reward{{ID: "r1"}},
+	}
+	want := map[string]bool{
+		exportResourceChores:  true,
+		exportResourceRewards: true,
+	}
+	runImportDryRun(data, want)
+
+	w.Close()
+	os.Stdout = old
+
+	buf := make([]byte, 4096)
+	n, _ := r.Read(buf)
+	out := string(buf[:n])
+
+	if !strings.Contains(out, "2 items") {
+		t.Errorf("expected chores count 2 in output, got: %s", out)
+	}
+	if !strings.Contains(out, "1 items") {
+		t.Errorf("expected rewards count 1 in output, got: %s", out)
+	}
+}
+
+func TestExportDataRoundTrip(t *testing.T) {
+	data := ExportData{
+		ExportedAt: "2026-05-02T00:00:00Z",
+		FrameID:    "frame-abc",
+		Chores:     []lib.Chore{{ID: "1", Title: "Walk the dog"}},
+		Rewards:    []lib.Reward{{ID: "r1", Title: "Ice cream"}},
+	}
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, "export.json")
+
+	out, err := json.MarshalIndent(data, "", "  ")
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	if err := os.WriteFile(path, out, 0o600); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	var got ExportData
+	if err := json.Unmarshal(raw, &got); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+
+	if got.FrameID != data.FrameID {
+		t.Errorf("frame_id: got %q, want %q", got.FrameID, data.FrameID)
+	}
+	if len(got.Chores) != 1 || got.Chores[0].Title != "Walk the dog" {
+		t.Errorf("chores mismatch: %+v", got.Chores)
+	}
+}

--- a/cmd/import.go
+++ b/cmd/import.go
@@ -1,0 +1,181 @@
+package cmd
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+
+	"github.com/sebrandon1/go-skylight/lib"
+	"github.com/spf13/cobra"
+)
+
+var (
+	importFile      string
+	importDryRun    bool
+	importResources string
+)
+
+var importCmd = &cobra.Command{
+	Use:   "import",
+	Short: "Restore frame data from an export file",
+	Long: `Restore frame data from a JSON file produced by the export command.
+
+Each resource type is created in the target frame. IDs from the source frame are
+ignored — new IDs are assigned by the API. Use --resources to import only specific
+types. Use --dry-run to preview what would be created without making API calls.`,
+	Run: func(cmd *cobra.Command, args []string) {
+		requireFrameID()
+
+		raw, err := os.ReadFile(importFile)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Error reading %s: %v\n", importFile, err)
+			os.Exit(1)
+		}
+
+		var data ExportData
+		if err := json.Unmarshal(raw, &data); err != nil {
+			fmt.Fprintf(os.Stderr, "Error parsing export file: %v\n", err)
+			os.Exit(1)
+		}
+
+		resources := parseResourceList(importResources, allExportResources)
+		want := toWantMap(resources)
+
+		if importDryRun {
+			runImportDryRun(data, want)
+			return
+		}
+
+		client := getClient()
+		runImport(client, data, want)
+	},
+}
+
+func runImportDryRun(data ExportData, want map[string]bool) {
+	counts := map[string]int{
+		exportResourceChores:   len(data.Chores),
+		exportResourceRewards:  len(data.Rewards),
+		exportResourceLists:    len(data.Lists),
+		exportResourceRecipes:  len(data.Recipes),
+		exportResourceSittings: len(data.MealSittings),
+		exportResourceCalendar: len(data.CalendarEvents),
+	}
+	fmt.Printf("Dry run — would import into frame %s:\n", frameID)
+	for _, r := range allExportResources {
+		if want[r] {
+			fmt.Printf("  %-10s %d items\n", r, counts[r])
+		}
+	}
+}
+
+func runImport(client *lib.Client, data ExportData, want map[string]bool) {
+	var total, failed int
+	add := func(t, f int) { total += t; failed += f }
+
+	if want[exportResourceRewards] {
+		add(importRewards(client, data.Rewards))
+	}
+	if want[exportResourceChores] {
+		add(importChores(client, data.Chores))
+	}
+	if want[exportResourceLists] {
+		add(importLists(client, data.Lists))
+	}
+	if want[exportResourceRecipes] {
+		add(importRecipes(client, data.Recipes))
+	}
+	if want[exportResourceSittings] {
+		add(importSittings(client, data.MealSittings))
+	}
+	if want[exportResourceCalendar] {
+		add(importCalendarEvents(client, data.CalendarEvents))
+	}
+
+	fmt.Printf("Imported %d/%d items successfully.\n", total-failed, total)
+	if failed > 0 {
+		os.Exit(1)
+	}
+}
+
+func importRewards(client *lib.Client, rewards []lib.Reward) (total, failed int) {
+	for _, r := range rewards {
+		total++
+		if _, err := client.CreateReward(frameID, lib.RewardData{Title: r.Title, Points: r.Points, EmojiIcon: r.EmojiIcon}); err != nil {
+			fmt.Fprintf(os.Stderr, "Error creating reward %q: %v\n", r.Title, err)
+			failed++
+		}
+	}
+	return
+}
+
+func importChores(client *lib.Client, chores []lib.Chore) (total, failed int) {
+	for _, c := range chores {
+		total++
+		if _, err := client.CreateChore(frameID, lib.ChoreData{Title: c.Title, DueDate: c.DueDate, Points: c.Points, AssigneeID: c.AssigneeID}); err != nil {
+			fmt.Fprintf(os.Stderr, "Error creating chore %q: %v\n", c.Title, err)
+			failed++
+		}
+	}
+	return
+}
+
+func importLists(client *lib.Client, lists []lib.List) (total, failed int) {
+	for _, l := range lists {
+		total++
+		created, err := client.CreateList(frameID, lib.ListData{Title: l.Title, Color: l.Color, Kind: l.Kind})
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Error creating list %q: %v\n", l.Title, err)
+			failed++
+			continue
+		}
+		for _, item := range l.Items {
+			total++
+			if _, err := client.AddListItem(frameID, created.ID, lib.ListItemData{Title: item.Title}); err != nil {
+				fmt.Fprintf(os.Stderr, "Error adding item %q to list %q: %v\n", item.Title, l.Title, err)
+				failed++
+			}
+		}
+	}
+	return
+}
+
+func importRecipes(client *lib.Client, recipes []lib.Recipe) (total, failed int) {
+	for _, r := range recipes {
+		total++
+		if _, err := client.CreateRecipe(frameID, lib.RecipeData{Title: r.Title, Description: r.Description, Ingredients: r.Ingredients, URL: r.URL}); err != nil {
+			fmt.Fprintf(os.Stderr, "Error creating recipe %q: %v\n", r.Title, err)
+			failed++
+		}
+	}
+	return
+}
+
+func importSittings(client *lib.Client, sittings []lib.MealSitting) (total, failed int) {
+	for _, s := range sittings {
+		total++
+		if _, err := client.CreateMealSitting(frameID, lib.MealSittingData{Summary: s.Summary, Date: s.Date}); err != nil {
+			fmt.Fprintf(os.Stderr, "Error creating meal sitting %q: %v\n", s.Summary, err)
+			failed++
+		}
+	}
+	return
+}
+
+func importCalendarEvents(client *lib.Client, events []lib.CalendarEvent) (total, failed int) {
+	for _, e := range events {
+		total++
+		if _, err := client.CreateCalendarEvent(frameID, lib.CalendarEventData{Title: e.Title, StartAt: e.StartAt, EndAt: e.EndAt, AllDay: e.AllDay}); err != nil {
+			fmt.Fprintf(os.Stderr, "Error creating calendar event %q: %v\n", e.Title, err)
+			failed++
+		}
+	}
+	return
+}
+
+func init() {
+	rootCmd.AddCommand(importCmd)
+	importCmd.Flags().StringVar(&importFile, "file", "", "Path to export JSON file")
+	importCmd.Flags().BoolVar(&importDryRun, "dry-run", false, "Preview what would be imported without making API calls")
+	importCmd.Flags().StringVar(&importResources, "resources", "all", "Comma-separated resource types to import")
+	importCmd.MarkFlagRequired("file") //nolint:errcheck
+}


### PR DESCRIPTION
## Summary

- Adds `export` command: dumps chores, rewards, lists, recipes, meal sittings, and calendar events to a JSON file (or stdout). Fetches all resource types in parallel via goroutines.
- Adds `import` command: restores data from an export file into a target frame. Supports `--dry-run` to preview counts without making API calls. Ignores source IDs — new IDs are assigned by the API.
- Both commands accept `--resources` to limit which types are included/restored.
- Adds `export_import_test.go` with 9 tests covering flag registration, resource parsing, dry-run output, and JSON round-trip.

## Test plan

- [ ] `make build` — binary compiles cleanly
- [ ] `make lint` — 0 issues
- [ ] `make test` — all tests pass including new export/import tests
- [ ] `./skylight export --help` and `./skylight import --help` show correct flags