### PR TITLE
feat: add list task-box-item create and watch --persist flag

### DIFF
--- a/cmd/list.go
+++ b/cmd/list.go
@@ -187,6 +187,25 @@ var listUpdateItemCmd = &cobra.Command{
 	},
 }
 
+var taskBoxItemCreateCmd = &cobra.Command{
+	Use:   "task-box-item",
+	Short: "Create a task box item",
+	Run: func(cmd *cobra.Command, args []string) {
+		requireFrameID()
+
+		client := getClient()
+
+		item, err := client.CreateTaskBoxItem(frameID, lib.TaskBoxItemData{
+			Title: listItemTitle,
+		})
+		if err != nil {
+			fatal("creating task box item", err)
+		}
+
+		printJSON(item)
+	},
+}
+
 var listClearCompletedCmd = &cobra.Command{
 	Use:   "clear-completed",
 	Short: "Delete all completed items from a list",
@@ -219,6 +238,10 @@ func init() {
 	listCmd.AddCommand(listUpdateItemCmd)
 	listCmd.AddCommand(listDeleteItemCmd)
 	listCmd.AddCommand(listClearCompletedCmd)
+	listCmd.AddCommand(taskBoxItemCreateCmd)
+
+	taskBoxItemCreateCmd.Flags().StringVar(&listItemTitle, "title", "", "Task box item title")
+	taskBoxItemCreateCmd.MarkFlagRequired("title") //nolint:errcheck
 
 	listGetCmd.Flags().StringVar(&listID, "list-id", "", "List ID")
 	listGetCmd.MarkFlagRequired("list-id") //nolint:errcheck

--- a/cmd/watch.go
+++ b/cmd/watch.go
@@ -21,6 +21,7 @@ const (
 var (
 	watchInterval  int
 	watchResources string
+	watchPersist   bool
 
 	allWatchResources = []string{watchResourceRewards, watchResourceChores, watchResourceCalendar}
 
@@ -42,6 +43,10 @@ Tracks previously-seen IDs in memory and emits only newly-observed changes:
   - rewards: newly redeemed rewards
   - chores:  chores newly marked complete
   - calendar: events starting within the next hour
+
+Use --persist to persist reward deduplication state to disk
+(~/.skylight/poller-state.json) so restarts do not re-emit already-seen
+reward redemptions. Has no effect unless rewards is in --resources.
 
 Press Ctrl+C to stop.`,
 	Run: func(cmd *cobra.Command, args []string) {
@@ -67,13 +72,39 @@ Press Ctrl+C to stop.`,
 			seenEventIDs:  make(map[string]struct{}),
 		}
 
-		// Seed state silently so existing items aren't reported as new.
+		// pollResources is what the ticker loop covers. When --persist is
+		// active, rewards are handled by the RewardsPoller instead.
+		pollResources := resources
+
+		var poller *lib.RewardsPoller
+		if watchPersist {
+			if containsResource(resources, watchResourceRewards) {
+				poller = lib.NewRewardsPoller(client, frameID, time.Duration(watchInterval)*time.Second, "")
+				poller.Start(ctx)
+				defer poller.Stop()
+				pollResources = filterOutResource(resources, watchResourceRewards)
+			} else {
+				fmt.Fprintln(os.Stderr, "Warning: --persist has no effect without rewards in --resources")
+			}
+		}
+
+		// Seed in-memory state silently so existing items aren't reported as new.
 		state.seeding = true
-		poll(client, state, resources)
+		poll(client, state, pollResources)
 		state.seeding = false
 
-		fmt.Printf("Watching %s (interval: %ds). Press Ctrl+C to stop.\n\n",
-			strings.Join(resources, ", "), watchInterval)
+		fmt.Printf("Watching %s (interval: %ds", strings.Join(resources, ", "), watchInterval)
+		if poller != nil {
+			fmt.Print(", rewards persisted")
+		}
+		fmt.Print("). Press Ctrl+C to stop.\n\n")
+
+		// pollerEvents is nil when the poller is not active; selecting on a
+		// nil channel blocks forever, which is what we want.
+		var pollerEvents <-chan lib.RedemptionEvent
+		if poller != nil {
+			pollerEvents = poller.Events()
+		}
 
 		for {
 			select {
@@ -81,7 +112,9 @@ Press Ctrl+C to stop.`,
 				fmt.Println("\nStopped.")
 				return
 			case <-ticker.C:
-				poll(client, state, resources)
+				poll(client, state, pollResources)
+			case e := <-pollerEvents:
+				printRedemptionEvent(e)
 			}
 		}
 	},
@@ -92,6 +125,41 @@ type watchState struct {
 	seenChoreIDs  map[string]struct{}
 	seenEventIDs  map[string]struct{}
 	seeding       bool
+}
+
+func containsResource(resources []string, target string) bool {
+	for _, r := range resources {
+		if r == target {
+			return true
+		}
+	}
+	return false
+}
+
+func filterOutResource(resources []string, target string) []string {
+	out := make([]string, 0, len(resources))
+	for _, r := range resources {
+		if r != target {
+			out = append(out, r)
+		}
+	}
+	return out
+}
+
+func printRedemptionEvent(e lib.RedemptionEvent) {
+	ts := e.ObservedAt.Format("15:04:05")
+	if outputFormat == outputJSON {
+		printJSON(map[string]any{
+			"type": "reward_redeemed", "id": e.RewardID, "title": e.RewardName,
+			"points": e.Points, "category_id": e.CategoryID, "child_name": e.ChildName, "ts": ts,
+		})
+	} else {
+		name := e.ChildName
+		if name == "" {
+			name = e.CategoryID
+		}
+		fmt.Printf("[%s] REWARD REDEEMED  %s (%d pts) — %s\n", ts, e.RewardName, e.Points, name)
+	}
 }
 
 func parseWatchResources(s string) []string {
@@ -230,4 +298,5 @@ func init() {
 	rootCmd.AddCommand(watchCmd)
 	watchCmd.Flags().IntVar(&watchInterval, "interval", 60, "Poll interval in seconds")
 	watchCmd.Flags().StringVar(&watchResources, "resources", "all", "Comma-separated resources to watch: rewards,chores,calendar")
+	watchCmd.Flags().BoolVar(&watchPersist, "persist", false, "Persist reward deduplication state to disk across restarts (~/.skylight/poller-state.json)")
 }

--- a/cmd/watch.go
+++ b/cmd/watch.go
@@ -72,8 +72,6 @@ Press Ctrl+C to stop.`,
 			seenEventIDs:  make(map[string]struct{}),
 		}
 
-		// pollResources is what the ticker loop covers. When --persist is
-		// active, rewards are handled by the RewardsPoller instead.
 		pollResources := resources
 
 		var poller *lib.RewardsPoller
@@ -93,18 +91,16 @@ Press Ctrl+C to stop.`,
 		poll(client, state, pollResources)
 		state.seeding = false
 
-		fmt.Printf("Watching %s (interval: %ds", strings.Join(resources, ", "), watchInterval)
-		if poller != nil {
-			fmt.Print(", rewards persisted")
-		}
-		fmt.Print("). Press Ctrl+C to stop.\n\n")
-
-		// pollerEvents is nil when the poller is not active; selecting on a
-		// nil channel blocks forever, which is what we want.
+		// nil channel is never selected in a select statement — used when poller is inactive.
 		var pollerEvents <-chan lib.RedemptionEvent
+		persistLabel := ""
 		if poller != nil {
 			pollerEvents = poller.Events()
+			persistLabel = ", rewards persisted"
 		}
+
+		fmt.Printf("Watching %s (interval: %ds%s). Press Ctrl+C to stop.\n\n",
+			strings.Join(resources, ", "), watchInterval, persistLabel)
 
 		for {
 			select {


### PR DESCRIPTION
Closes out the two remaining lib-vs-cmd gaps identified in the coverage audit.

## Changes

### `list task-box-item` subcommand
Exposes `lib.CreateTaskBoxItem` through the CLI:
```
skylight list task-box-item --title "Take out trash"
```

### `watch --persist` flag
When `--persist` is set with rewards in `--resources`, the `RewardsPoller` lib API is used instead of the in-memory map. Deduplication state is persisted to `~/.skylight/poller-state.json` so restarts don't re-emit already-seen reward redemptions. Chores and calendar continue using in-memory state as before.