### PR TITLE
feat: add --description flag to chore create and update

### DIFF
--- a/cmd/chore.go
+++ b/cmd/chore.go
@@ -14,6 +14,7 @@ var (
 	choreAssigneeID  string
 	choreID          string
 	choreTitle       string
+	choreDescription string
 	chorePoints      int
 	choreAfter       string
 	choreBefore      string
@@ -97,22 +98,20 @@ var choreCreateCmd = &cobra.Command{
 
 		client := getClient()
 
+		data := lib.ChoreData{
+			Title:       choreTitle,
+			Description: choreDescription,
+			DueDate:     choreDate,
+			Points:      chorePoints,
+		}
 		var chore *lib.Chore
 		var err error
 		if choreUpForGrabs {
-			chore, err = client.CreateUpForGrabsChore(frameID, lib.ChoreData{
-				Title:   choreTitle,
-				DueDate: choreDate,
-				Points:  chorePoints,
-			})
+			chore, err = client.CreateUpForGrabsChore(frameID, data)
 		} else {
-			chore, err = client.CreateChore(frameID, lib.ChoreData{
-				Title:      choreTitle,
-				DueDate:    choreDate,
-				AssigneeID: choreAssigneeID,
-				Points:     chorePoints,
-				Recurring:  choreRecurring,
-			})
+			data.AssigneeID = choreAssigneeID
+			data.Recurring = choreRecurring
+			chore, err = client.CreateChore(frameID, data)
 		}
 		if err != nil {
 			fatal("creating chore", err)
@@ -186,6 +185,9 @@ var choreUpdateCmd = &cobra.Command{
 		if cmd.Flags().Changed("date") {
 			data.DueDate = choreDate
 		}
+		if cmd.Flags().Changed("description") {
+			data.Description = choreDescription
+		}
 
 		chore, err := client.UpdateChore(frameID, choreID, data)
 		if err != nil {
@@ -250,6 +252,7 @@ func init() {
 	choreListCmd.Flags().Lookup("week").NoOptDefVal = "current"
 
 	choreCreateCmd.Flags().StringVar(&choreTitle, "title", "", "Chore title")
+	choreCreateCmd.Flags().StringVar(&choreDescription, "description", "", "Chore description")
 	choreCreateCmd.Flags().StringVar(&choreDate, "date", "", "Due date")
 	choreCreateCmd.Flags().StringVar(&choreAssigneeID, "assignee-id", "", "Assignee ID")
 	choreCreateCmd.Flags().IntVar(&chorePoints, "points", 0, "Points value")
@@ -259,6 +262,7 @@ func init() {
 
 	choreUpdateCmd.Flags().StringVar(&choreID, "chore-id", "", "Chore ID to update")
 	choreUpdateCmd.Flags().StringVar(&choreTitle, "title", "", "Chore title")
+	choreUpdateCmd.Flags().StringVar(&choreDescription, "description", "", "Chore description")
 	choreUpdateCmd.Flags().StringVar(&choreStatus, "status", "", "Chore status")
 	choreUpdateCmd.Flags().IntVar(&chorePoints, "points", 0, "Points value")
 	choreUpdateCmd.Flags().StringVar(&choreAssigneeID, "assignee-id", "", "Assignee ID")

--- a/lib/bounty_test.go
+++ b/lib/bounty_test.go
@@ -29,14 +29,7 @@ func TestCreateBounty(t *testing.T) {
 				case r.Method == http.MethodPost && r.URL.Path == "/api/frames/frame1/chores":
 					w.WriteHeader(http.StatusCreated)
 					if err := json.NewEncoder(w).Encode(choreAPISingleResponse{
-						Data: choreAPIEntry{ID: "ch1", Attributes: struct {
-							Summary      string `json:"summary"`
-							Status       string `json:"status"`
-							Start        string `json:"start"`
-							RewardPoints int    `json:"reward_points"`
-							Recurring    bool   `json:"recurring"`
-							UpForGrabs   bool   `json:"up_for_grabs"`
-						}{Summary: "Task", RewardPoints: 5}},
+						Data: choreAPIEntry{ID: "ch1", Attributes: choreAPIAttributes{Summary: "Task", RewardPoints: 5}},
 					}); err != nil {
 						http.Error(w, err.Error(), http.StatusInternalServerError)
 					}
@@ -82,14 +75,7 @@ func TestCreateBounty(t *testing.T) {
 				case r.Method == http.MethodPost && r.URL.Path == "/api/frames/frame1/chores":
 					w.WriteHeader(http.StatusCreated)
 					if err := json.NewEncoder(w).Encode(choreAPISingleResponse{
-						Data: choreAPIEntry{ID: "ch1", Attributes: struct {
-							Summary      string `json:"summary"`
-							Status       string `json:"status"`
-							Start        string `json:"start"`
-							RewardPoints int    `json:"reward_points"`
-							Recurring    bool   `json:"recurring"`
-							UpForGrabs   bool   `json:"up_for_grabs"`
-						}{Summary: "Task", RewardPoints: 5}},
+						Data: choreAPIEntry{ID: "ch1", Attributes: choreAPIAttributes{Summary: "Task", RewardPoints: 5}},
 					}); err != nil {
 						http.Error(w, err.Error(), http.StatusInternalServerError)
 					}
@@ -133,15 +119,8 @@ func TestCreateBounty(t *testing.T) {
 					w.WriteHeader(http.StatusCreated)
 					if err := json.NewEncoder(w).Encode(choreAPISingleResponse{
 						Data: choreAPIEntry{
-							ID: "ch1",
-							Attributes: struct {
-								Summary      string `json:"summary"`
-								Status       string `json:"status"`
-								Start        string `json:"start"`
-								RewardPoints int    `json:"reward_points"`
-								Recurring    bool   `json:"recurring"`
-								UpForGrabs   bool   `json:"up_for_grabs"`
-							}{Summary: "Do dishes", RewardPoints: 10},
+							ID:         "ch1",
+							Attributes: choreAPIAttributes{Summary: "Do dishes", RewardPoints: 10},
 						},
 					}); err != nil {
 						http.Error(w, err.Error(), http.StatusInternalServerError)
@@ -210,15 +189,8 @@ func TestCreateBountyCleanupOnRewardFailure(t *testing.T) {
 			w.WriteHeader(http.StatusCreated)
 			if err := json.NewEncoder(w).Encode(choreAPISingleResponse{
 				Data: choreAPIEntry{
-					ID: "ch1",
-					Attributes: struct {
-						Summary      string `json:"summary"`
-						Status       string `json:"status"`
-						Start        string `json:"start"`
-						RewardPoints int    `json:"reward_points"`
-						Recurring    bool   `json:"recurring"`
-						UpForGrabs   bool   `json:"up_for_grabs"`
-					}{Summary: "Test"},
+					ID:         "ch1",
+					Attributes: choreAPIAttributes{Summary: "Test"},
 				},
 			}); err != nil {
 				http.Error(w, err.Error(), http.StatusInternalServerError)
@@ -386,22 +358,8 @@ func TestListBounties(t *testing.T) {
 				case "/api/frames/frame1/chores":
 					if err := json.NewEncoder(w).Encode(choreAPIResponse{
 						Data: []choreAPIEntry{
-							{ID: "ch1", Attributes: struct {
-								Summary      string `json:"summary"`
-								Status       string `json:"status"`
-								Start        string `json:"start"`
-								RewardPoints int    `json:"reward_points"`
-								Recurring    bool   `json:"recurring"`
-								UpForGrabs   bool   `json:"up_for_grabs"`
-							}{Summary: "Task A", Status: "pending", RewardPoints: 10}},
-							{ID: "ch2", Attributes: struct {
-								Summary      string `json:"summary"`
-								Status       string `json:"status"`
-								Start        string `json:"start"`
-								RewardPoints int    `json:"reward_points"`
-								Recurring    bool   `json:"recurring"`
-								UpForGrabs   bool   `json:"up_for_grabs"`
-							}{Summary: "Task B", Status: "pending", RewardPoints: 0}},
+							{ID: "ch1", Attributes: choreAPIAttributes{Summary: "Task A", Status: "pending", RewardPoints: 10}},
+							{ID: "ch2", Attributes: choreAPIAttributes{Summary: "Task B", Status: "pending"}},
 						},
 					}); err != nil {
 						http.Error(w, err.Error(), http.StatusInternalServerError)

--- a/lib/chore_test.go
+++ b/lib/chore_test.go
@@ -16,6 +16,7 @@ func TestListChores(t *testing.T) {
 		wantLen    int
 		wantTitle  string
 		wantAssign string
+		wantDesc   string
 		wantErr    bool
 	}{
 		{
@@ -24,6 +25,14 @@ func TestListChores(t *testing.T) {
 			response:  `{"data":[{"id":"1","attributes":{"summary":"Clean room","status":"pending"}},{"id":"2","attributes":{"summary":"Do homework","status":"completed"}}]}`,
 			wantLen:   2,
 			wantTitle: "Clean room",
+		},
+		{
+			name:      "returns chore with description",
+			status:    http.StatusOK,
+			response:  `{"data":[{"id":"1","attributes":{"summary":"Clean room","description":"Vacuum and mop","status":"pending"}}]}`,
+			wantLen:   1,
+			wantTitle: "Clean room",
+			wantDesc:  "Vacuum and mop",
 		},
 		{
 			name:     "passes date filter",
@@ -114,6 +123,9 @@ func TestListChores(t *testing.T) {
 			if tc.wantAssign != "" && len(chores) > 0 && chores[0].AssigneeID != tc.wantAssign {
 				t.Errorf("AssigneeID: want %q got %q", tc.wantAssign, chores[0].AssigneeID)
 			}
+			if tc.wantDesc != "" && len(chores) > 0 && chores[0].Description != tc.wantDesc {
+				t.Errorf("Description: want %q got %q", tc.wantDesc, chores[0].Description)
+			}
 		})
 	}
 }
@@ -140,6 +152,13 @@ func TestCreateChore(t *testing.T) {
 			status:    http.StatusCreated,
 			response:  `{"data":{"id":"c1","attributes":{"summary":"Walk the dog"}}}`,
 			wantTitle: "Walk the dog",
+		},
+		{
+			name:      "sends description in request body",
+			input:     ChoreData{Title: "Clean room", Description: "Vacuum and mop the floor"},
+			status:    http.StatusCreated,
+			response:  `{"data":{"id":"c2","attributes":{"summary":"Clean room","description":"Vacuum and mop the floor"}}}`,
+			wantTitle: "Clean room",
 		},
 		{
 			name:    "server error returns error",

--- a/lib/rotation_test.go
+++ b/lib/rotation_test.go
@@ -26,14 +26,7 @@ func TestCreateChoreRotation(t *testing.T) {
 		if err := json.NewEncoder(w).Encode(choreAPISingleResponse{
 			Data: choreAPIEntry{
 				ID: fmt.Sprintf("ch%d", idx),
-				Attributes: struct {
-					Summary      string `json:"summary"`
-					Status       string `json:"status"`
-					Start        string `json:"start"`
-					RewardPoints int    `json:"reward_points"`
-					Recurring    bool   `json:"recurring"`
-					UpForGrabs   bool   `json:"up_for_grabs"`
-				}{
+				Attributes: choreAPIAttributes{
 					Summary: body["summary"].(string),
 					Start:   body["start"].(string),
 				},
@@ -108,15 +101,8 @@ func TestCreateChoreRotationPartialFailure(t *testing.T) {
 		w.WriteHeader(http.StatusCreated)
 		if err := json.NewEncoder(w).Encode(choreAPISingleResponse{
 			Data: choreAPIEntry{
-				ID: "ch1",
-				Attributes: struct {
-					Summary      string `json:"summary"`
-					Status       string `json:"status"`
-					Start        string `json:"start"`
-					RewardPoints int    `json:"reward_points"`
-					Recurring    bool   `json:"recurring"`
-					UpForGrabs   bool   `json:"up_for_grabs"`
-				}{Summary: "Task"},
+				ID:         "ch1",
+				Attributes: choreAPIAttributes{Summary: "Task"},
 			},
 		}); err != nil {
 			t.Errorf("encode: %v", err)

--- a/lib/structs.go
+++ b/lib/structs.go
@@ -142,14 +142,15 @@ func (e *sourceCalendarAPIEntry) toSourceCalendar() SourceCalendar {
 
 // Chore represents a chore/task (flattened from JSON-API response).
 type Chore struct {
-	ID         string `json:"id,omitempty"`
-	Title      string `json:"title,omitempty"`
-	Status     string `json:"status,omitempty"`
-	DueDate    string `json:"due_date,omitempty"`
-	Points     int    `json:"points,omitempty"`
-	Recurring  bool   `json:"recurring"`
-	AssigneeID string `json:"assignee_id,omitempty"`
-	UpForGrabs bool   `json:"up_for_grabs,omitempty"`
+	ID          string `json:"id,omitempty"`
+	Title       string `json:"title,omitempty"`
+	Description string `json:"description,omitempty"`
+	Status      string `json:"status,omitempty"`
+	DueDate     string `json:"due_date,omitempty"`
+	Points      int    `json:"points,omitempty"`
+	Recurring   bool   `json:"recurring"`
+	AssigneeID  string `json:"assignee_id,omitempty"`
+	UpForGrabs  bool   `json:"up_for_grabs,omitempty"`
 }
 
 // choreAPIResponse wraps the JSON-API envelope for chore list responses.
@@ -157,17 +158,20 @@ type choreAPIResponse struct {
 	Data []choreAPIEntry `json:"data"`
 }
 
+type choreAPIAttributes struct {
+	Summary      string `json:"summary"`
+	Description  string `json:"description"`
+	Status       string `json:"status"`
+	Start        string `json:"start"`
+	RewardPoints int    `json:"reward_points"`
+	Recurring    bool   `json:"recurring"`
+	UpForGrabs   bool   `json:"up_for_grabs"`
+}
+
 // choreAPIEntry represents a single chore in JSON-API format.
 type choreAPIEntry struct {
-	ID         string `json:"id"`
-	Attributes struct {
-		Summary      string `json:"summary"`
-		Status       string `json:"status"`
-		Start        string `json:"start"`
-		RewardPoints int    `json:"reward_points"`
-		Recurring    bool   `json:"recurring"`
-		UpForGrabs   bool   `json:"up_for_grabs"`
-	} `json:"attributes"`
+	ID            string             `json:"id"`
+	Attributes    choreAPIAttributes `json:"attributes"`
 	Relationships struct {
 		Category struct {
 			Data *apiRelationshipData `json:"data"`
@@ -183,13 +187,14 @@ type choreAPISingleResponse struct {
 // toChore converts a JSON-API chore entry to a flat Chore struct.
 func (e *choreAPIEntry) toChore() Chore {
 	c := Chore{
-		ID:         e.ID,
-		Title:      e.Attributes.Summary,
-		Status:     e.Attributes.Status,
-		DueDate:    e.Attributes.Start,
-		Points:     e.Attributes.RewardPoints,
-		Recurring:  e.Attributes.Recurring,
-		UpForGrabs: e.Attributes.UpForGrabs,
+		ID:          e.ID,
+		Title:       e.Attributes.Summary,
+		Description: e.Attributes.Description,
+		Status:      e.Attributes.Status,
+		DueDate:     e.Attributes.Start,
+		Points:      e.Attributes.RewardPoints,
+		Recurring:   e.Attributes.Recurring,
+		UpForGrabs:  e.Attributes.UpForGrabs,
 	}
 	if e.Relationships.Category.Data != nil {
 		c.AssigneeID = e.Relationships.Category.Data.ID
@@ -200,13 +205,14 @@ func (e *choreAPIEntry) toChore() Chore {
 // ChoreData holds the chore fields for create/update requests.
 // JSON tags match the Skylight API field names.
 type ChoreData struct {
-	Title      string `json:"summary,omitempty"`
-	DueDate    string `json:"start,omitempty"`
-	Points     int    `json:"reward_points,omitempty"`
-	Status     string `json:"status,omitempty"`
-	AssigneeID string `json:"category_id,omitempty"`
-	Recurring  bool   `json:"recurring,omitempty"`
-	UpForGrabs bool   `json:"up_for_grabs,omitempty"`
+	Title       string `json:"summary,omitempty"`
+	Description string `json:"description,omitempty"`
+	DueDate     string `json:"start,omitempty"`
+	Points      int    `json:"reward_points,omitempty"`
+	Status      string `json:"status,omitempty"`
+	AssigneeID  string `json:"category_id,omitempty"`
+	Recurring   bool   `json:"recurring,omitempty"`
+	UpForGrabs  bool   `json:"up_for_grabs,omitempty"`
 }
 
 // List represents a list (e.g., grocery list, todo list).


### PR DESCRIPTION
Closes #124

## Summary
- Adds `Description` field to `Chore`, `choreAPIAttributes`, and `ChoreData` structs in `lib/structs.go`, mapped through `toChore()`
- Extracts `choreAPIAttributes` named type from the previously anonymous struct in `choreAPIEntry`, eliminating 8 repeated inline struct type signatures across tests
- Wires `--description` flag on `chore create` (sent unconditionally) and `chore update` (only sent when flag is explicitly provided, consistent with the existing update pattern)
- Adds test coverage for description round-trip in `TestListChores` and `TestCreateChore`

## Test plan
- [x] `make test` passes
- [x] `make lint` passes
- [x] `go-skylight chore create --title "Clean room" --description "Vacuum and mop"` sends `description` in the request body
- [x] `go-skylight chore update --chore-id ID --description "Updated notes"` sends `description` only when flag is set
- [x] `go-skylight chore list` output includes `description` field when returned by API