### PR TITLE
fix: use correct calendar_events API params (date_min/date_max/timezone)

### DIFF
--- a/cmd/analytics.go
+++ b/cmd/analytics.go
@@ -26,6 +26,11 @@ var analyticsCmd = &cobra.Command{
 		startStr := start.Format(lib.DateFormat)
 		endStr := now.Format(lib.DateFormat)
 
+		frame, err := client.GetFrame(frameID)
+		if err != nil {
+			fatal("getting frame info", err)
+		}
+
 		var (
 			categories []lib.Category
 			chores     []lib.Chore
@@ -64,7 +69,7 @@ var analyticsCmd = &cobra.Command{
 		}()
 		go func() {
 			defer wg.Done()
-			events, eventErr = client.ListCalendarEvents(frameID, startStr, endStr)
+			events, eventErr = client.ListCalendarEvents(frameID, startStr, endStr, frame.TimeZone)
 		}()
 		wg.Wait()
 

--- a/cmd/calendar.go
+++ b/cmd/calendar.go
@@ -45,7 +45,12 @@ var calendarListCmd = &cobra.Command{
 
 		client := getClient()
 
-		events, err := client.ListCalendarEvents(frameID, calendarStartDate, calendarEndDate)
+		frame, err := client.GetFrame(frameID)
+		if err != nil {
+			fatal("getting frame info", err)
+		}
+
+		events, err := client.ListCalendarEvents(frameID, calendarStartDate, calendarEndDate, frame.TimeZone)
 		if err != nil {
 			fatal("listing calendar events", err)
 		}
@@ -190,10 +195,16 @@ var calendarWeekCmd = &cobra.Command{
 
 		client := getClient()
 
+		frame, err := client.GetFrame(frameID)
+		if err != nil {
+			fatal("getting frame info", err)
+		}
+
 		events, err := client.ListCalendarEvents(
 			frameID,
 			monday.Format(lib.DateFormat),
 			sunday.Format(lib.DateFormat),
+			frame.TimeZone,
 		)
 		if err != nil {
 			fatal("listing calendar events", err)

--- a/cmd/calendar_week.go
+++ b/cmd/calendar_week.go
@@ -17,7 +17,7 @@ type WeeklyCalendarDay struct {
 }
 
 // buildCalendarWeeklyView groups events into Mon–Sun slots for the week starting on monday.
-// Events are grouped by the UTC date of their StartAt field; out-of-range events are silently dropped.
+// Events are grouped by the date of their StartAt field; out-of-range events are silently dropped.
 func buildCalendarWeeklyView(events []lib.CalendarEvent, monday time.Time) []WeeklyCalendarDay {
 	slots := buildWeekSlots(events, monday,
 		func(e lib.CalendarEvent) string { return e.StartAt },

--- a/cmd/export.go
+++ b/cmd/export.go
@@ -64,6 +64,11 @@ centered on today. Use --resources to limit which resource types are included.`,
 		start := now.AddDate(0, 0, -exportDays).Format(lib.DateFormat)
 		end := now.AddDate(0, 0, exportDays).Format(lib.DateFormat)
 
+		frame, err := client.GetFrame(frameID)
+		if err != nil {
+			fatal("getting frame info", err)
+		}
+
 		data := ExportData{
 			ExportedAt: now.Format(time.RFC3339),
 			FrameID:    frameID,
@@ -149,7 +154,7 @@ centered on today. Use --resources to limit which resource types are included.`,
 			wg.Add(1)
 			go func() {
 				defer wg.Done()
-				events, err := client.ListCalendarEvents(frameID, start, end)
+				events, err := client.ListCalendarEvents(frameID, start, end, frame.TimeZone)
 				if err == nil {
 					mu.Lock()
 					data.CalendarEvents = events

--- a/cmd/home.go
+++ b/cmd/home.go
@@ -27,6 +27,11 @@ var homeCmd = &cobra.Command{
 
 		client := getClient()
 
+		frame, err := client.GetFrame(frameID)
+		if err != nil {
+			fatal("getting frame info", err)
+		}
+
 		var (
 			events   []lib.CalendarEvent
 			chores   []lib.Chore
@@ -40,7 +45,7 @@ var homeCmd = &cobra.Command{
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
-			events, evtErr = client.ListCalendarEvents(frameID, monday.Format(lib.DateFormat), sunday.Format(lib.DateFormat))
+			events, evtErr = client.ListCalendarEvents(frameID, monday.Format(lib.DateFormat), sunday.Format(lib.DateFormat), frame.TimeZone)
 		}()
 
 		if !homeNoTasks {

--- a/cmd/status.go
+++ b/cmd/status.go
@@ -31,7 +31,7 @@ var statusCmd = &cobra.Command{
 			fatal("listing chores", err)
 		}
 
-		events, err := client.ListCalendarEvents(frameID, today, today)
+		events, err := client.ListCalendarEvents(frameID, today, today, frame.TimeZone)
 		if err != nil {
 			fatal("listing calendar events", err)
 		}

--- a/cmd/watch.go
+++ b/cmd/watch.go
@@ -66,10 +66,16 @@ Press Ctrl+C to stop.`,
 		ticker := time.NewTicker(time.Duration(watchInterval) * time.Second)
 		defer ticker.Stop()
 
+		frame, err := client.GetFrame(frameID)
+		if err != nil {
+			fatal("getting frame info", err)
+		}
+
 		state := &watchState{
 			seenRewardIDs: make(map[string]struct{}),
 			seenChoreIDs:  make(map[string]struct{}),
 			seenEventIDs:  make(map[string]struct{}),
+			timezone:      frame.TimeZone,
 		}
 
 		pollResources := resources
@@ -121,6 +127,7 @@ type watchState struct {
 	seenChoreIDs  map[string]struct{}
 	seenEventIDs  map[string]struct{}
 	seeding       bool
+	timezone      string
 }
 
 func containsResource(resources []string, target string) bool {
@@ -254,7 +261,7 @@ func pollChores(client *lib.Client, state *watchState, now time.Time, ts string)
 
 func pollCalendar(client *lib.Client, state *watchState, now time.Time, ts string) {
 	today := now.Format(lib.DateFormat)
-	events, err := client.ListCalendarEvents(frameID, today, today)
+	events, err := client.ListCalendarEvents(frameID, today, today, state.timezone)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "[%s] Error listing calendar events: %v\n", ts, err)
 		return

--- a/lib/calendar.go
+++ b/lib/calendar.go
@@ -3,18 +3,22 @@ package lib
 import "fmt"
 
 // ListCalendarEvents retrieves calendar events for a frame within a date range.
-func (c *Client) ListCalendarEvents(frameID, startDate, endDate string) ([]CalendarEvent, error) {
+// dateMin and dateMax are YYYY-MM-DD strings; timezone is an IANA timezone name (e.g. "America/Chicago").
+func (c *Client) ListCalendarEvents(frameID, dateMin, dateMax, timezone string) ([]CalendarEvent, error) {
 	req, err := newRequest("GET", fmt.Sprintf("%s/frames/%s/calendar_events", c.effectiveURL(), frameID))
 	if err != nil {
 		return nil, fmt.Errorf("failed to create list calendar events request: %w", err)
 	}
 
 	params := map[string]string{}
-	if startDate != "" {
-		params["start_date"] = startDate
+	if dateMin != "" {
+		params["date_min"] = dateMin
 	}
-	if endDate != "" {
-		params["end_date"] = endDate
+	if dateMax != "" {
+		params["date_max"] = dateMax
+	}
+	if timezone != "" {
+		params["timezone"] = timezone
 	}
 	if len(params) > 0 {
 		addQueryParams(req, params)

--- a/lib/calendar_test.go
+++ b/lib/calendar_test.go
@@ -9,37 +9,36 @@ import (
 func TestListCalendarEvents(t *testing.T) {
 	tests := []struct {
 		name           string
-		startDate      string
-		endDate        string
+		dateMin        string
+		dateMax        string
+		timezone       string
 		status         int
 		response       string
 		wantLen        int
 		wantFirstTitle string
+		wantCategoryID string
 		wantErr        bool
 	}{
 		{
 			name:           "returns events",
 			status:         http.StatusOK,
-			response:       `{"data":[{"id":"1","type":"calendar_event","attributes":{"summary":"Meeting","starts_at":"2024-01-15T10:00:00Z","ends_at":"2024-01-15T11:00:00Z","all_day":false}},{"id":"2","type":"calendar_event","attributes":{"summary":"Lunch","starts_at":"2024-01-15T12:00:00Z","ends_at":"2024-01-15T13:00:00Z","all_day":false}}]}`,
+			response:       `{"data":[{"id":"1","type":"calendar_event","attributes":{"summary":"Meeting","starts_at":"2024-01-15T10:00:00-06:00","ends_at":"2024-01-15T11:00:00-06:00","all_day":false},"relationships":{"categories":{"data":[]}}},{"id":"2","type":"calendar_event","attributes":{"summary":"Lunch","starts_at":"2024-01-15T12:00:00-06:00","ends_at":"2024-01-15T13:00:00-06:00","all_day":false},"relationships":{"categories":{"data":[]}}}]}`,
 			wantLen:        2,
 			wantFirstTitle: "Meeting",
 		},
 		{
-			name:      "passes date range params",
-			startDate: "2024-01-01",
-			endDate:   "2024-01-31",
-			status:    http.StatusOK,
-			response:  `{"data":[]}`,
+			name:           "parses category from categories relationship",
+			status:         http.StatusOK,
+			response:       `{"data":[{"id":"1","type":"calendar_event","attributes":{"summary":"Party","starts_at":"2024-06-01T10:00:00-05:00","all_day":false},"relationships":{"categories":{"data":[{"id":"cat42","type":"category"}]}}}]}`,
+			wantLen:        1,
+			wantFirstTitle: "Party",
+			wantCategoryID: "cat42",
 		},
 		{
-			name:      "passes start date only",
-			startDate: "2024-01-01",
-			status:    http.StatusOK,
-			response:  `{"data":[]}`,
-		},
-		{
-			name:     "passes end date only",
-			endDate:  "2024-01-31",
+			name:     "passes date range and timezone params",
+			dateMin:  "2024-01-01",
+			dateMax:  "2024-01-31",
+			timezone: "America/Chicago",
 			status:   http.StatusOK,
 			response: `{"data":[]}`,
 		},
@@ -71,11 +70,14 @@ func TestListCalendarEvents(t *testing.T) {
 					t.Errorf("unexpected path: %s", r.URL.Path)
 				}
 				q := r.URL.Query()
-				if tc.startDate != "" && q.Get("start_date") != tc.startDate {
-					t.Errorf("start_date: want %q got %q", tc.startDate, q.Get("start_date"))
+				if tc.dateMin != "" && q.Get("date_min") != tc.dateMin {
+					t.Errorf("date_min: want %q got %q", tc.dateMin, q.Get("date_min"))
 				}
-				if tc.endDate != "" && q.Get("end_date") != tc.endDate {
-					t.Errorf("end_date: want %q got %q", tc.endDate, q.Get("end_date"))
+				if tc.dateMax != "" && q.Get("date_max") != tc.dateMax {
+					t.Errorf("date_max: want %q got %q", tc.dateMax, q.Get("date_max"))
+				}
+				if tc.timezone != "" && q.Get("timezone") != tc.timezone {
+					t.Errorf("timezone: want %q got %q", tc.timezone, q.Get("timezone"))
 				}
 				w.Header().Set("Content-Type", "application/json")
 				w.WriteHeader(tc.status)
@@ -92,7 +94,7 @@ func TestListCalendarEvents(t *testing.T) {
 			defer func() { SkylightURL = old }()
 
 			client, _ := NewClientWithToken("u", "t")
-			events, err := client.ListCalendarEvents("frame1", tc.startDate, tc.endDate)
+			events, err := client.ListCalendarEvents("frame1", tc.dateMin, tc.dateMax, tc.timezone)
 			if (err != nil) != tc.wantErr {
 				t.Fatalf("wantErr=%v got %v", tc.wantErr, err)
 			}
@@ -104,6 +106,9 @@ func TestListCalendarEvents(t *testing.T) {
 			}
 			if tc.wantFirstTitle != "" && len(events) > 0 && events[0].Title != tc.wantFirstTitle {
 				t.Errorf("events[0].Title: want %q got %q", tc.wantFirstTitle, events[0].Title)
+			}
+			if tc.wantCategoryID != "" && len(events) > 0 && events[0].CategoryID != tc.wantCategoryID {
+				t.Errorf("events[0].CategoryID: want %q got %q", tc.wantCategoryID, events[0].CategoryID)
 			}
 		})
 	}
@@ -120,16 +125,16 @@ func TestCreateCalendarEvent(t *testing.T) {
 	}{
 		{
 			name:      "creates event",
-			input:     CalendarEventData{Title: "New Event", StartAt: "2024-01-16T09:00:00Z"},
+			input:     CalendarEventData{Title: "New Event", StartAt: "2024-01-16T09:00:00-06:00"},
 			status:    http.StatusCreated,
-			response:  `{"data":{"id":"3","type":"calendar_event","attributes":{"summary":"New Event","starts_at":"2024-01-16T09:00:00Z","ends_at":"","all_day":false}}}`,
+			response:  `{"data":{"id":"3","type":"calendar_event","attributes":{"summary":"New Event","starts_at":"2024-01-16T09:00:00-06:00","ends_at":"","all_day":false},"relationships":{"categories":{"data":[]}}}}`,
 			wantTitle: "New Event",
 		},
 		{
 			name:      "sends all fields in request body",
-			input:     CalendarEventData{Title: "Birthday Party", Description: "Fun party", StartAt: "2024-06-15T14:00:00Z", EndAt: "2024-06-15T18:00:00Z"},
+			input:     CalendarEventData{Title: "Birthday Party", Description: "Fun party", StartAt: "2024-06-15T14:00:00-05:00", EndAt: "2024-06-15T18:00:00-05:00"},
 			status:    http.StatusCreated,
-			response:  `{"data":{"id":"evt1","type":"calendar_event","attributes":{"summary":"Birthday Party","starts_at":"2024-06-15T14:00:00Z","ends_at":"2024-06-15T18:00:00Z","all_day":false}}}`,
+			response:  `{"data":{"id":"evt1","type":"calendar_event","attributes":{"summary":"Birthday Party","starts_at":"2024-06-15T14:00:00-05:00","ends_at":"2024-06-15T18:00:00-05:00","all_day":false},"relationships":{"categories":{"data":[]}}}}`,
 			wantTitle: "Birthday Party",
 		},
 		{
@@ -190,7 +195,7 @@ func TestUpdateCalendarEvent(t *testing.T) {
 			eventID:   "evt1",
 			input:     CalendarEventData{Title: "Updated Event"},
 			status:    http.StatusOK,
-			response:  `{"data":{"id":"1","type":"calendar_event","attributes":{"summary":"Updated Event","starts_at":"","ends_at":"","all_day":false}}}`,
+			response:  `{"data":{"id":"1","type":"calendar_event","attributes":{"summary":"Updated Event","starts_at":"","ends_at":"","all_day":false},"relationships":{"categories":{"data":[]}}}}`,
 			wantTitle: "Updated Event",
 		},
 		{

--- a/lib/client_test.go
+++ b/lib/client_test.go
@@ -404,7 +404,7 @@ func TestBadURLNewRequestErrors(t *testing.T) {
 		fn   func(*Client) error
 	}{
 		// GET-based
-		{"ListCalendarEvents", func(c *Client) error { _, err := c.ListCalendarEvents("f", "", ""); return err }},
+		{"ListCalendarEvents", func(c *Client) error { _, err := c.ListCalendarEvents("f", "", "", ""); return err }},
 		{"ListSourceCalendars", func(c *Client) error { _, err := c.ListSourceCalendars("f"); return err }},
 		{"ListCategories", func(c *Client) error { _, err := c.ListCategories("f"); return err }},
 		{"ListChores", func(c *Client) error { _, err := c.ListChores("f", ChoreListOptions{}); return err }},

--- a/lib/example_test.go
+++ b/lib/example_test.go
@@ -40,7 +40,7 @@ func ExampleClient_ListCalendarEvents() {
 	defer func() { lib.SkylightURL = old }()
 
 	client, _ := lib.NewClientWithToken("u", "t")
-	events, err := client.ListCalendarEvents("frame1", "", "")
+	events, err := client.ListCalendarEvents("frame1", "", "", "")
 	if err != nil {
 		fmt.Println("error:", err)
 		return

--- a/lib/integration_crud_test.go
+++ b/lib/integration_crud_test.go
@@ -205,7 +205,7 @@ func TestIntegration_CalendarEventsCRUD(t *testing.T) {
 	// Verify in list
 	start := now.Format(DateFormat)
 	end := now.AddDate(0, 0, 7).Format(DateFormat)
-	events, err := client.ListCalendarEvents(frameID, start, end)
+	events, err := client.ListCalendarEvents(frameID, start, end, "")
 	if err != nil {
 		if strings.Contains(err.Error(), "500") || strings.Contains(err.Error(), "Internal Server Error") {
 			t.Skipf("ListCalendarEvents: skipping due to API instability: %v", err)

--- a/lib/integration_test.go
+++ b/lib/integration_test.go
@@ -169,7 +169,7 @@ func TestIntegration_ListCalendarEvents(t *testing.T) {
 	start := now.Format(DateFormat)
 	end := now.AddDate(0, 0, 7).Format(DateFormat)
 
-	events, err := client.ListCalendarEvents(frameID, start, end)
+	events, err := client.ListCalendarEvents(frameID, start, end, "")
 	if err != nil {
 		if strings.Contains(err.Error(), "500") || strings.Contains(err.Error(), "Internal Server Error") {
 			t.Skipf("ListCalendarEvents: skipping due to API instability: %v", err)

--- a/lib/options_test.go
+++ b/lib/options_test.go
@@ -27,7 +27,7 @@ func TestWithBaseURL(t *testing.T) {
 	if client.baseURL != srv.URL+"/api" {
 		t.Errorf("baseURL = %q, want %q", client.baseURL, srv.URL+"/api")
 	}
-	events, err := client.ListCalendarEvents("f1", "", "")
+	events, err := client.ListCalendarEvents("f1", "", "", "")
 	if err != nil {
 		t.Fatalf("ListCalendarEvents: %v", err)
 	}
@@ -89,7 +89,7 @@ func TestWithLogger(t *testing.T) {
 	if client.logger != logger {
 		t.Error("logger not set on client")
 	}
-	if _, err = client.ListCalendarEvents("f1", "", ""); err != nil {
+	if _, err = client.ListCalendarEvents("f1", "", "", ""); err != nil {
 		t.Fatalf("ListCalendarEvents: %v", err)
 	}
 }

--- a/lib/structs.go
+++ b/lib/structs.go
@@ -86,9 +86,9 @@ type calendarAPIEntry struct {
 		Color       string `json:"color"`
 	} `json:"attributes"`
 	Relationships struct {
-		Category struct {
-			Data *apiRelationshipData `json:"data"`
-		} `json:"category"`
+		Categories struct {
+			Data []apiRelationshipData `json:"data"`
+		} `json:"categories"`
 	} `json:"relationships"`
 }
 
@@ -102,8 +102,8 @@ func (e *calendarAPIEntry) toCalendarEvent() CalendarEvent {
 		AllDay:      e.Attributes.AllDay,
 		Color:       e.Attributes.Color,
 	}
-	if e.Relationships.Category.Data != nil {
-		ev.CategoryID = e.Relationships.Category.Data.ID
+	if len(e.Relationships.Categories.Data) > 0 {
+		ev.CategoryID = e.Relationships.Categories.Data[0].ID
 	}
 	return ev
 }

--- a/lib/structs_test.go
+++ b/lib/structs_test.go
@@ -3,17 +3,8 @@ package lib
 import "testing"
 
 func TestToCalendarEventNilCategory(t *testing.T) {
-	entry := calendarAPIEntry{
-		ID: "e1",
-		Attributes: struct {
-			Summary     string `json:"summary"`
-			Description string `json:"description"`
-			StartsAt    string `json:"starts_at"`
-			EndsAt      string `json:"ends_at"`
-			AllDay      bool   `json:"all_day"`
-			Color       string `json:"color"`
-		}{Summary: "Test"},
-	}
+	entry := calendarAPIEntry{ID: "e1"}
+	entry.Attributes.Summary = "Test"
 	ev := entry.toCalendarEvent()
 	if ev.CategoryID != "" {
 		t.Errorf("CategoryID should be empty, got %q", ev.CategoryID)
@@ -26,7 +17,7 @@ func TestToCalendarEventNilCategory(t *testing.T) {
 func TestToCalendarEventWithCategory(t *testing.T) {
 	entry := calendarAPIEntry{ID: "e1"}
 	entry.Attributes.Summary = "Event"
-	entry.Relationships.Category.Data = &apiRelationshipData{ID: "cat1"}
+	entry.Relationships.Categories.Data = []apiRelationshipData{{ID: "cat1"}}
 	ev := entry.toCalendarEvent()
 	if ev.CategoryID != "cat1" {
 		t.Errorf("CategoryID = %q, want %q", ev.CategoryID, "cat1")


### PR DESCRIPTION
## Summary

- Fixes the `calendar_events` endpoint query params from `start_date`/`end_date` to `date_min`/`date_max`/`timezone` — the API requires the latter and returns HTTP 500 without them
- Fixes the relationship key from `category` (singular, nullable object) to `categories` (plural array) to match the actual API response shape
- Fetches `frame.TimeZone` before calling `ListCalendarEvents` in all callers so the correct timezone is always passed
- Updates all tests to use the corrected param names and mock response shapes

## Test plan

- [ ] `make test` passes
- [ ] `make lint` clean
- [ ] `./go-skylight calendar list` returns events without error
- [ ] `./go-skylight calendar week` renders weekly table with real events