### PR TITLE
refactor: extract getFrameOrFail helper and remove redundant comment

### DIFF
--- a/cmd/analytics.go
+++ b/cmd/analytics.go
@@ -26,10 +26,7 @@ var analyticsCmd = &cobra.Command{
 		startStr := start.Format(lib.DateFormat)
 		endStr := now.Format(lib.DateFormat)
 
-		frame, err := client.GetFrame(frameID)
-		if err != nil {
-			fatal("getting frame info", err)
-		}
+		frame := getFrameOrFail(client, frameID)
 
 		var (
 			categories []lib.Category

--- a/cmd/calendar.go
+++ b/cmd/calendar.go
@@ -45,10 +45,7 @@ var calendarListCmd = &cobra.Command{
 
 		client := getClient()
 
-		frame, err := client.GetFrame(frameID)
-		if err != nil {
-			fatal("getting frame info", err)
-		}
+		frame := getFrameOrFail(client, frameID)
 
 		events, err := client.ListCalendarEvents(frameID, calendarStartDate, calendarEndDate, frame.TimeZone)
 		if err != nil {
@@ -195,10 +192,7 @@ var calendarWeekCmd = &cobra.Command{
 
 		client := getClient()
 
-		frame, err := client.GetFrame(frameID)
-		if err != nil {
-			fatal("getting frame info", err)
-		}
+		frame := getFrameOrFail(client, frameID)
 
 		events, err := client.ListCalendarEvents(
 			frameID,

--- a/cmd/export.go
+++ b/cmd/export.go
@@ -64,10 +64,7 @@ centered on today. Use --resources to limit which resource types are included.`,
 		start := now.AddDate(0, 0, -exportDays).Format(lib.DateFormat)
 		end := now.AddDate(0, 0, exportDays).Format(lib.DateFormat)
 
-		frame, err := client.GetFrame(frameID)
-		if err != nil {
-			fatal("getting frame info", err)
-		}
+		frame := getFrameOrFail(client, frameID)
 
 		data := ExportData{
 			ExportedAt: now.Format(time.RFC3339),

--- a/cmd/helpers.go
+++ b/cmd/helpers.go
@@ -20,6 +20,14 @@ func fatal(msg string, err error) {
 	os.Exit(1)
 }
 
+func getFrameOrFail(client *lib.Client, id string) *lib.Frame {
+	frame, err := client.GetFrame(id)
+	if err != nil {
+		fatal("getting frame info", err)
+	}
+	return frame
+}
+
 // validateDate returns an error if date is non-empty and not in YYYY-MM-DD format.
 func validateDate(date string) error {
 	if date == "" {

--- a/cmd/home.go
+++ b/cmd/home.go
@@ -27,10 +27,7 @@ var homeCmd = &cobra.Command{
 
 		client := getClient()
 
-		frame, err := client.GetFrame(frameID)
-		if err != nil {
-			fatal("getting frame info", err)
-		}
+		frame := getFrameOrFail(client, frameID)
 
 		var (
 			events   []lib.CalendarEvent

--- a/cmd/watch.go
+++ b/cmd/watch.go
@@ -66,10 +66,7 @@ Press Ctrl+C to stop.`,
 		ticker := time.NewTicker(time.Duration(watchInterval) * time.Second)
 		defer ticker.Stop()
 
-		frame, err := client.GetFrame(frameID)
-		if err != nil {
-			fatal("getting frame info", err)
-		}
+		frame := getFrameOrFail(client, frameID)
 
 		state := &watchState{
 			seenRewardIDs: make(map[string]struct{}),

--- a/lib/calendar.go
+++ b/lib/calendar.go
@@ -3,7 +3,6 @@ package lib
 import "fmt"
 
 // ListCalendarEvents retrieves calendar events for a frame within a date range.
-// dateMin and dateMax are YYYY-MM-DD strings; timezone is an IANA timezone name (e.g. "America/Chicago").
 func (c *Client) ListCalendarEvents(frameID, dateMin, dateMax, timezone string) ([]CalendarEvent, error) {
 	req, err := newRequest("GET", fmt.Sprintf("%s/frames/%s/calendar_events", c.effectiveURL(), frameID))
 	if err != nil {


### PR DESCRIPTION
## Summary

- Extracts a `getFrameOrFail(client, frameID)` helper into `cmd/helpers.go`, replacing the repeated 4-line `GetFrame` + error check + `fatal` block that appeared identically in `analytics.go`, `calendar.go` (×2), `export.go`, `home.go`, and `watch.go`
- Removes the redundant second doc line on `ListCalendarEvents` — the param names `dateMin`, `dateMax`, `timezone` already convey their format

## Test plan

- [ ] `make lint` clean
- [ ] `make test` passes