### PR TITLE
feat: add local integration test runner with config file fallback

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -80,3 +80,31 @@ make vet          # go vet
 make build        # CLI binary
 make build-trigger # alpaca-trigger binary
 ```
+
+## Running Integration Tests
+
+Integration tests call the live Skylight API. They require credentials and a frame ID.
+
+### Setup (one-time)
+
+Add your credentials to `~/.skylight/config` (same file used by the CLI):
+
+```
+SKYLIGHT_EMAIL=you@example.com
+SKYLIGHT_PASSWORD=yourpassword
+SKYLIGHT_FRAME_ID=your-frame-id
+```
+
+`SKYLIGHT_FRAME_ID` is already written by `skylight login --save`. You only need
+to add `SKYLIGHT_EMAIL` and `SKYLIGHT_PASSWORD`. Environment variables override
+the config file if set.
+
+### Running
+
+```bash
+make integration-read   # read-only tests — safe to run repeatedly
+make integration        # all tests including CRUD — creates and deletes real data
+```
+
+CRUD tests always clean up after themselves via `t.Cleanup`, but prefer
+`integration-read` for routine local verification.

--- a/Makefile
+++ b/Makefile
@@ -20,4 +20,10 @@ build-trigger:
 clean:
 	rm -f $(APP_NAME) alpaca-trigger
 
-.PHONY: vet build build-trigger lint test clean
+integration:
+	go test -v -tags integration -count=1 -timeout 5m ./lib/...
+
+integration-read:
+	go test -v -tags integration -count=1 -timeout 5m -run 'TestIntegration_(Get|List[A-Z])' ./lib/...
+
+.PHONY: vet build build-trigger lint test clean integration integration-read

--- a/lib/config_loader_test.go
+++ b/lib/config_loader_test.go
@@ -1,0 +1,45 @@
+//go:build integration
+
+package lib
+
+import (
+	"bufio"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// loadSkylightConfig reads ~/.skylight/config and populates the provided
+// pointers only when the corresponding value is currently empty.
+// Env vars take precedence — call this after os.Getenv.
+func loadSkylightConfig(email, password, frameID *string) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return
+	}
+	f, err := os.Open(filepath.Join(home, ".skylight", "config"))
+	if err != nil {
+		return
+	}
+	defer f.Close()
+
+	vars := map[string]*string{
+		"SKYLIGHT_EMAIL":    email,
+		"SKYLIGHT_PASSWORD": password,
+		"SKYLIGHT_FRAME_ID": frameID,
+	}
+	scanner := bufio.NewScanner(f)
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		if line == "" || strings.HasPrefix(line, "#") {
+			continue
+		}
+		key, value, ok := strings.Cut(line, "=")
+		if !ok {
+			continue
+		}
+		if ptr, exists := vars[strings.TrimSpace(key)]; exists && *ptr == "" {
+			*ptr = strings.TrimSpace(value)
+		}
+	}
+}

--- a/lib/integration_test.go
+++ b/lib/integration_test.go
@@ -27,11 +27,14 @@ func integrationClient(t *testing.T) (*Client, string) {
 	password := os.Getenv("SKYLIGHT_PASSWORD")
 	frameID := os.Getenv("SKYLIGHT_FRAME_ID")
 
+	// Fall back to ~/.skylight/config for any values not set in the environment.
+	loadSkylightConfig(&email, &password, &frameID)
+
 	if frameID == "" {
-		t.Skip("skipping: SKYLIGHT_FRAME_ID must be set")
+		t.Skip("skipping: set SKYLIGHT_FRAME_ID or add it to ~/.skylight/config")
 	}
 	if email == "" || password == "" {
-		t.Skip("skipping: SKYLIGHT_EMAIL and SKYLIGHT_PASSWORD must be set")
+		t.Skip("skipping: set SKYLIGHT_EMAIL and SKYLIGHT_PASSWORD or add them to ~/.skylight/config")
 	}
 
 	clientOnce.Do(func() {


### PR DESCRIPTION
## Summary

- Adds `make integration` and `make integration-read` Makefile targets that mirror the CI command exactly
- `make integration-read` uses `-run 'TestIntegration_(Get|List[A-Z])'` to run only the 9 read-only tests, excluding all 6 CRUD tests safely
- `integrationClient()` now calls `loadSkylightConfig()` after `os.Getenv` — falls back to `~/.skylight/config` for any credentials not set in the environment, so no manual `export` needed
- New `lib/config_loader_test.go` (build tag `integration`) provides the config parser — same `bufio.Scanner` + `strings.Cut` pattern as `cmd/config.go`
- Documents the setup in `CONTRIBUTING.md`

## Test plan

- [ ] `make lint` clean
- [ ] `make test` passes (unit tests unaffected)
- [ ] `make integration-read` runs 9 read-only tests against live API
- [ ] `make integration` runs all 15 tests (read + 6 CRUD)