### PR TITLE
chore: trim redundant comments from integration test config loader

### DIFF
--- a/lib/config_loader_test.go
+++ b/lib/config_loader_test.go
@@ -11,7 +11,6 @@ import (
 
 // loadSkylightConfig reads ~/.skylight/config and populates the provided
 // pointers only when the corresponding value is currently empty.
-// Env vars take precedence — call this after os.Getenv.
 func loadSkylightConfig(email, password, frameID *string) {
 	home, err := os.UserHomeDir()
 	if err != nil {

--- a/lib/integration_test.go
+++ b/lib/integration_test.go
@@ -27,7 +27,6 @@ func integrationClient(t *testing.T) (*Client, string) {
 	password := os.Getenv("SKYLIGHT_PASSWORD")
 	frameID := os.Getenv("SKYLIGHT_FRAME_ID")
 
-	// Fall back to ~/.skylight/config for any values not set in the environment.
 	loadSkylightConfig(&email, &password, &frameID)
 
 	if frameID == "" {


### PR DESCRIPTION
## Summary

- Removes `// Fall back to ~/.skylight/config...` comment in `integrationClient` — the `loadSkylightConfig` call is self-explanatory
- Removes `Env vars take precedence — call this after os.Getenv` line from the `loadSkylightConfig` doc — the `*ptr == ""` guard already makes this obvious

## Test plan

- [ ] `make lint` clean
- [ ] `make test` passes