### PR TITLE
feat: add meal sitting-recipe command (issue #123)

### DIFF
--- a/cmd/meal.go
+++ b/cmd/meal.go
@@ -217,6 +217,28 @@ var mealAddToGroceryCmd = &cobra.Command{
 	},
 }
 
+var mealSittingRecipeCmd = &cobra.Command{
+	Use:   "sitting-recipe",
+	Short: "View recipe details from a meal sitting",
+	Run: func(cmd *cobra.Command, args []string) {
+		requireFrameID()
+
+		client := getClient()
+
+		result, err := client.GetSittingRecipe(frameID, sittingID)
+		if err != nil {
+			fatal("getting sitting recipe", err)
+		}
+
+		if result.Recipe == nil {
+			fmt.Println("No recipe linked to this meal sitting")
+			return
+		}
+
+		printJSON(result)
+	},
+}
+
 var mealUpdateRecipeCmd = &cobra.Command{
 	Use:   "update-recipe",
 	Short: "Update a recipe",
@@ -259,6 +281,7 @@ func init() {
 	mealCmd.AddCommand(mealCreateSittingCmd)
 	mealCmd.AddCommand(mealDeleteSittingCmd)
 	mealCmd.AddCommand(mealAddToGroceryCmd)
+	mealCmd.AddCommand(mealSittingRecipeCmd)
 
 	mealRecipeInfoCmd.Flags().StringVar(&recipeID, "recipe-id", "", "Recipe ID")
 	mealRecipeInfoCmd.MarkFlagRequired("recipe-id") //nolint:errcheck
@@ -297,4 +320,7 @@ func init() {
 
 	mealAddToGroceryCmd.Flags().StringVar(&recipeID, "recipe-id", "", "Recipe ID")
 	mealAddToGroceryCmd.MarkFlagRequired("recipe-id") //nolint:errcheck
+
+	mealSittingRecipeCmd.Flags().StringVar(&sittingID, "sitting-id", "", "Meal sitting ID")
+	mealSittingRecipeCmd.MarkFlagRequired("sitting-id") //nolint:errcheck
 }

--- a/lib/meal.go
+++ b/lib/meal.go
@@ -169,6 +169,45 @@ func (c *Client) DeleteMealSitting(frameID, sittingID, date string) error {
 	return nil
 }
 
+// GetMealSitting retrieves a single meal sitting by ID.
+func (c *Client) GetMealSitting(frameID, sittingID string) (*MealSitting, error) {
+	req, err := newRequest("GET", fmt.Sprintf("%s/frames/%s/meals/sittings/%s", c.effectiveURL(), frameID, sittingID))
+	if err != nil {
+		return nil, fmt.Errorf("failed to create get meal sitting request: %w", err)
+	}
+
+	var apiResp mealSittingAPISingleResponse
+	if err := c.get(req, &apiResp); err != nil {
+		return nil, fmt.Errorf("failed to get meal sitting: %w", err)
+	}
+
+	result := apiResp.Data.toMealSitting()
+	return &result, nil
+}
+
+// GetSittingRecipe fetches a meal sitting and its linked recipe in one call.
+// Returns a result with a nil Recipe field if the sitting has no linked recipe.
+func (c *Client) GetSittingRecipe(frameID, sittingID string) (*SittingWithRecipe, error) {
+	sitting, err := c.GetMealSitting(frameID, sittingID)
+	if err != nil {
+		return nil, err
+	}
+
+	result := &SittingWithRecipe{Sitting: *sitting}
+
+	if sitting.RecipeID == "" {
+		return result, nil
+	}
+
+	recipe, err := c.GetRecipe(frameID, sitting.RecipeID)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get recipe for sitting: %w", err)
+	}
+	result.Recipe = recipe
+
+	return result, nil
+}
+
 // AddRecipeToGroceryList adds a recipe's ingredients to the grocery list.
 func (c *Client) AddRecipeToGroceryList(frameID, recipeID string) error {
 	req, err := newRequest("POST", fmt.Sprintf("%s/frames/%s/meals/recipes/%s/add_to_grocery_list", c.effectiveURL(), frameID, recipeID))

--- a/lib/meal_test.go
+++ b/lib/meal_test.go
@@ -587,6 +587,158 @@ func TestCreateMealSittingSummary(t *testing.T) {
 	}
 }
 
+func TestGetMealSitting(t *testing.T) {
+	tests := []struct {
+		name       string
+		sittingID  string
+		status     int
+		response   string
+		wantID     string
+		wantRecipe string
+		wantErr    bool
+	}{
+		{
+			name:       "returns sitting with recipe",
+			sittingID:  "s1",
+			status:     http.StatusOK,
+			response:   `{"data":{"id":"s1","type":"meal_sitting","attributes":{"summary":"Dinner"},"relationships":{"meal_category":{"data":{"id":"cat1","type":"meal_category"}},"meal_recipe":{"data":{"id":"r1","type":"meal_recipe"}}}}}`,
+			wantID:     "s1",
+			wantRecipe: "r1",
+		},
+		{
+			name:      "returns sitting without recipe",
+			sittingID: "s2",
+			status:    http.StatusOK,
+			response:  `{"data":{"id":"s2","type":"meal_sitting","attributes":{"summary":"Lunch"},"relationships":{"meal_category":{"data":null},"meal_recipe":{"data":null}}}}`,
+			wantID:    "s2",
+		},
+		{
+			name:      "not found returns error",
+			sittingID: "nonexistent",
+			status:    http.StatusNotFound,
+			wantErr:   true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if r.Method != http.MethodGet {
+					t.Errorf("expected GET, got %s", r.Method)
+				}
+				w.Header().Set("Content-Type", "application/json")
+				w.WriteHeader(tc.status)
+				if tc.response != "" {
+					if _, err := w.Write([]byte(tc.response)); err != nil {
+						t.Errorf("write: %v", err)
+					}
+				}
+			}))
+			defer srv.Close()
+
+			old := SkylightURL
+			SkylightURL = srv.URL + "/api"
+			defer func() { SkylightURL = old }()
+
+			client, _ := NewClientWithToken("u", "t")
+			sitting, err := client.GetMealSitting("frame1", tc.sittingID)
+			if (err != nil) != tc.wantErr {
+				t.Fatalf("wantErr=%v got %v", tc.wantErr, err)
+			}
+			if tc.wantErr {
+				return
+			}
+			if sitting.ID != tc.wantID {
+				t.Errorf("ID: want %q got %q", tc.wantID, sitting.ID)
+			}
+			if sitting.RecipeID != tc.wantRecipe {
+				t.Errorf("RecipeID: want %q got %q", tc.wantRecipe, sitting.RecipeID)
+			}
+		})
+	}
+}
+
+func TestGetSittingRecipe(t *testing.T) {
+	tests := []struct {
+		name          string
+		sittingResp   string
+		sittingStatus int
+		recipeResp    string
+		recipeStatus  int
+		wantRecipe    bool
+		wantErr       bool
+	}{
+		{
+			name:          "returns sitting with linked recipe",
+			sittingResp:   `{"data":{"id":"s1","type":"meal_sitting","attributes":{"summary":"Dinner"},"relationships":{"meal_category":{"data":null},"meal_recipe":{"data":{"id":"r1","type":"meal_recipe"}}}}}`,
+			sittingStatus: http.StatusOK,
+			recipeResp:    `{"data":{"id":"r1","type":"meal_recipe","attributes":{"summary":"Pasta","description":"Classic dish"}}}`,
+			recipeStatus:  http.StatusOK,
+			wantRecipe:    true,
+		},
+		{
+			name:          "returns sitting with no linked recipe",
+			sittingResp:   `{"data":{"id":"s2","type":"meal_sitting","attributes":{"summary":"Lunch"},"relationships":{"meal_category":{"data":null},"meal_recipe":{"data":null}}}}`,
+			sittingStatus: http.StatusOK,
+			wantRecipe:    false,
+		},
+		{
+			name:          "sitting not found returns error",
+			sittingStatus: http.StatusNotFound,
+			wantErr:       true,
+		},
+		{
+			name:          "recipe fetch error returns error",
+			sittingResp:   `{"data":{"id":"s1","type":"meal_sitting","attributes":{"summary":"Dinner"},"relationships":{"meal_category":{"data":null},"meal_recipe":{"data":{"id":"r1","type":"meal_recipe"}}}}}`,
+			sittingStatus: http.StatusOK,
+			recipeStatus:  http.StatusInternalServerError,
+			wantErr:       true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			callCount := 0
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				callCount++
+				w.Header().Set("Content-Type", "application/json")
+				if callCount == 1 {
+					w.WriteHeader(tc.sittingStatus)
+					if tc.sittingResp != "" {
+						if _, err := w.Write([]byte(tc.sittingResp)); err != nil {
+							t.Errorf("write: %v", err)
+						}
+					}
+				} else {
+					w.WriteHeader(tc.recipeStatus)
+					if tc.recipeResp != "" {
+						if _, err := w.Write([]byte(tc.recipeResp)); err != nil {
+							t.Errorf("write: %v", err)
+						}
+					}
+				}
+			}))
+			defer srv.Close()
+
+			old := SkylightURL
+			SkylightURL = srv.URL + "/api"
+			defer func() { SkylightURL = old }()
+
+			client, _ := NewClientWithToken("u", "t")
+			result, err := client.GetSittingRecipe("frame1", "s1")
+			if (err != nil) != tc.wantErr {
+				t.Fatalf("wantErr=%v got %v", tc.wantErr, err)
+			}
+			if tc.wantErr {
+				return
+			}
+			if (result.Recipe != nil) != tc.wantRecipe {
+				t.Errorf("wantRecipe=%v got recipe=%v", tc.wantRecipe, result.Recipe)
+			}
+		})
+	}
+}
+
 func TestDeleteMealSitting(t *testing.T) {
 	tests := []struct {
 		name    string

--- a/lib/structs.go
+++ b/lib/structs.go
@@ -514,6 +514,17 @@ type mealSittingAPIResponse struct {
 	Data []mealSittingAPIEntry `json:"data"`
 }
 
+// mealSittingAPISingleResponse wraps the JSON-API envelope for single meal sitting responses.
+type mealSittingAPISingleResponse struct {
+	Data mealSittingAPIEntry `json:"data"`
+}
+
+// SittingWithRecipe holds a meal sitting and its linked recipe details.
+type SittingWithRecipe struct {
+	Sitting MealSitting `json:"sitting"`
+	Recipe  *Recipe     `json:"recipe,omitempty"`
+}
+
 // mealSittingAPIEntry represents a single meal sitting in JSON-API format.
 type mealSittingAPIEntry struct {
 	ID         string `json:"id"`


### PR DESCRIPTION
## Summary

- Adds `get meal sitting-recipe --sitting-id <ID>` command that fetches a meal sitting and its linked recipe in a single call
- Adds `GetMealSitting` and `GetSittingRecipe` to `lib/meal.go` and a new `mealSittingAPISingleResponse` + `SittingWithRecipe` struct in `lib/structs.go`
- Shows a clear message when the sitting has no linked recipe; otherwise outputs combined JSON

## Usage

Look up a sitting that has a recipe linked:

```sh
$ go-skylight get meal sitting-recipe --sitting-id s123
{
  "sitting": {
    "id": "s123",
    "summary": "Tuesday Dinner",
    "recipe_id": "r456",
    "date": "2026-06-03"
  },
  "recipe": {
    "id": "r456",
    "summary": "Spaghetti Bolognese",
    "description": "Classic Italian meat sauce",
    "ingredients": ["pasta", "beef", "tomato", "onion"],
    "url": "https://example.com/bolognese"
  }
}
```

Look up a sitting with no recipe linked:

```sh
$ go-skylight get meal sitting-recipe --sitting-id s789
No recipe linked to this meal sitting
```

## Test plan

- [x] `TestGetMealSitting` — happy path (with recipe), no-recipe, not-found error
- [x] `TestGetSittingRecipe` — happy path, no-recipe path, sitting error, recipe fetch error
- [x] `make build` passes
- [x] `make test` passes
- [x] `make lint` passes

Closes #123