### PR TITLE
feat: add meal plan command for batch meal scheduling

### DIFF
--- a/cmd/meal.go
+++ b/cmd/meal.go
@@ -21,6 +21,10 @@ var (
 	sittingDateMin    string
 	sittingDateMax    string
 	mealCategoryID    string
+
+	mealPlanRecipeIDs   []string
+	mealPlanCategoryIDs []string
+	mealPlanStartDate   string
 )
 
 var mealCmd = &cobra.Command{
@@ -239,6 +243,37 @@ var mealSittingRecipeCmd = &cobra.Command{
 	},
 }
 
+var mealPlanCmd = &cobra.Command{
+	Use:   "plan",
+	Short: "Schedule a batch of meals from a recipe list",
+	Run: func(cmd *cobra.Command, args []string) {
+		requireFrameID()
+
+		if err := validateDate(mealPlanStartDate); err != nil {
+			fmt.Fprintln(os.Stderr, err)
+			os.Exit(1)
+		}
+
+		client := getClient()
+
+		result, err := client.PlanMeals(frameID, lib.MealPlanData{
+			RecipeIDs:   mealPlanRecipeIDs,
+			CategoryIDs: mealPlanCategoryIDs,
+			StartDate:   mealPlanStartDate,
+		})
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Error: planning meals: %v\n", err)
+			if result != nil && len(result.Sittings) > 0 {
+				fmt.Fprintf(os.Stderr, "Partial result (%d sittings created):\n", len(result.Sittings))
+				printJSON(result)
+			}
+			os.Exit(1)
+		}
+
+		printJSON(result)
+	},
+}
+
 var mealUpdateRecipeCmd = &cobra.Command{
 	Use:   "update-recipe",
 	Short: "Update a recipe",
@@ -282,6 +317,7 @@ func init() {
 	mealCmd.AddCommand(mealDeleteSittingCmd)
 	mealCmd.AddCommand(mealAddToGroceryCmd)
 	mealCmd.AddCommand(mealSittingRecipeCmd)
+	mealCmd.AddCommand(mealPlanCmd)
 
 	mealRecipeInfoCmd.Flags().StringVar(&recipeID, "recipe-id", "", "Recipe ID")
 	mealRecipeInfoCmd.MarkFlagRequired("recipe-id") //nolint:errcheck
@@ -323,4 +359,11 @@ func init() {
 
 	mealSittingRecipeCmd.Flags().StringVar(&sittingID, "sitting-id", "", "Meal sitting ID")
 	mealSittingRecipeCmd.MarkFlagRequired("sitting-id") //nolint:errcheck
+
+	mealPlanCmd.Flags().StringSliceVar(&mealPlanRecipeIDs, "recipes", nil, "Recipe IDs (comma-separated)")
+	mealPlanCmd.Flags().StringSliceVar(&mealPlanCategoryIDs, "categories", nil, "Meal category IDs (comma-separated)")
+	mealPlanCmd.Flags().StringVar(&mealPlanStartDate, "start-date", "", "Start date (YYYY-MM-DD)")
+	mealPlanCmd.MarkFlagRequired("recipes")    //nolint:errcheck
+	mealPlanCmd.MarkFlagRequired("categories") //nolint:errcheck
+	mealPlanCmd.MarkFlagRequired("start-date") //nolint:errcheck
 }

--- a/lib/meal.go
+++ b/lib/meal.go
@@ -1,6 +1,10 @@
 package lib
 
-import "fmt"
+import (
+	"errors"
+	"fmt"
+	"time"
+)
 
 // ListMealCategories retrieves meal categories for a frame.
 func (c *Client) ListMealCategories(frameID string) ([]MealCategory, error) {
@@ -206,6 +210,44 @@ func (c *Client) GetSittingRecipe(frameID, sittingID string) (*SittingWithRecipe
 	result.Recipe = recipe
 
 	return result, nil
+}
+
+// PlanMeals schedules a list of recipes as meal sittings starting from a given date,
+// rotating through the provided meal categories across consecutive days.
+func (c *Client) PlanMeals(frameID string, data MealPlanData) (*MealPlanResult, error) {
+	if len(data.RecipeIDs) == 0 {
+		return nil, errors.New("at least one recipe is required")
+	}
+	if len(data.CategoryIDs) == 0 {
+		return nil, errors.New("at least one category is required")
+	}
+
+	startDate, err := time.Parse(DateFormat, data.StartDate)
+	if err != nil {
+		return nil, fmt.Errorf("invalid start_date format (expected YYYY-MM-DD): %w", err)
+	}
+
+	numCategories := len(data.CategoryIDs)
+	var created []MealSitting
+
+	for i, recipeID := range data.RecipeIDs {
+		dayOffset, catIdx := i/numCategories, i%numCategories
+		categoryID := data.CategoryIDs[catIdx]
+		date := startDate.AddDate(0, 0, dayOffset).Format(DateFormat)
+
+		sitting, err := c.CreateMealSitting(frameID, MealSittingData{
+			RecipeID:       recipeID,
+			Date:           date,
+			MealCategoryID: categoryID,
+		})
+		if err != nil {
+			return &MealPlanResult{Sittings: created}, fmt.Errorf("failed scheduling recipe %q on %s: %w", recipeID, date, err)
+		}
+
+		created = append(created, *sitting)
+	}
+
+	return &MealPlanResult{Sittings: created}, nil
 }
 
 // AddRecipeToGroceryList adds a recipe's ingredients to the grocery list.

--- a/lib/meal_test.go
+++ b/lib/meal_test.go
@@ -2,8 +2,10 @@ package lib
 
 import (
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"sync/atomic"
 	"testing"
 )
 
@@ -769,5 +771,168 @@ func TestDeleteMealSitting(t *testing.T) {
 				t.Fatalf("wantErr=%v got %v", tc.wantErr, err)
 			}
 		})
+	}
+}
+
+func TestPlanMeals(t *testing.T) {
+	var n int
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			t.Errorf("expected POST, got %s", r.Method)
+		}
+		n++
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusCreated)
+		if err := json.NewEncoder(w).Encode(mealSittingAPIResponse{
+			Data: []mealSittingAPIEntry{
+				{ID: fmt.Sprintf("s%d", n)},
+			},
+		}); err != nil {
+			t.Errorf("encode: %v", err)
+		}
+	}))
+	defer srv.Close()
+
+	old := SkylightURL
+	SkylightURL = srv.URL + "/api"
+	defer func() { SkylightURL = old }()
+
+	client, _ := NewClientWithToken("u", "t")
+	result, err := client.PlanMeals("frame1", MealPlanData{
+		RecipeIDs:   []string{"r1", "r2", "r3", "r4", "r5"},
+		CategoryIDs: []string{"cat-lunch", "cat-dinner"},
+		StartDate:   "2026-04-21",
+	})
+	if err != nil {
+		t.Fatalf("PlanMeals failed: %v", err)
+	}
+
+	if len(result.Sittings) != 5 {
+		t.Errorf("want 5 sittings, got %d", len(result.Sittings))
+	}
+}
+
+func TestPlanMealsValidation(t *testing.T) {
+	client, _ := NewClientWithToken("u", "t")
+
+	tests := []struct {
+		name string
+		data MealPlanData
+	}{
+		{"no recipes", MealPlanData{CategoryIDs: []string{"cat1"}, StartDate: "2026-04-21"}},
+		{"no categories", MealPlanData{RecipeIDs: []string{"r1"}, StartDate: "2026-04-21"}},
+		{"bad date", MealPlanData{RecipeIDs: []string{"r1"}, CategoryIDs: []string{"cat1"}, StartDate: "not-a-date"}},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := client.PlanMeals("frame1", tc.data)
+			if err == nil {
+				t.Error("expected validation error, got nil")
+			}
+		})
+	}
+}
+
+func TestPlanMealsDayRotation(t *testing.T) {
+	type call struct {
+		recipeID   string
+		categoryID string
+		date       string
+	}
+	var calls []call
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var body map[string]any
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			t.Errorf("decode body: %v", err)
+			w.WriteHeader(http.StatusBadRequest)
+			return
+		}
+		calls = append(calls, call{
+			recipeID:   fmt.Sprint(body["meal_recipe_id"]),
+			categoryID: fmt.Sprint(body["meal_category_id"]),
+			date:       fmt.Sprint(body["date"]),
+		})
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusCreated)
+		if _, err := w.Write([]byte(`{"data":[{"id":"s1","attributes":{},"relationships":{"meal_category":{"data":null},"meal_recipe":{"data":null}}}]}`)); err != nil {
+			t.Errorf("write: %v", err)
+		}
+	}))
+	defer srv.Close()
+
+	old := SkylightURL
+	SkylightURL = srv.URL + "/api"
+	defer func() { SkylightURL = old }()
+
+	client, _ := NewClientWithToken("u", "t")
+	_, err := client.PlanMeals("frame1", MealPlanData{
+		RecipeIDs:   []string{"r1", "r2", "r3", "r4"},
+		CategoryIDs: []string{"lunch", "dinner"},
+		StartDate:   "2026-04-21",
+	})
+	if err != nil {
+		t.Fatalf("PlanMeals: %v", err)
+	}
+
+	want := []call{
+		{"r1", "lunch", "2026-04-21"},
+		{"r2", "dinner", "2026-04-21"},
+		{"r3", "lunch", "2026-04-22"},
+		{"r4", "dinner", "2026-04-22"},
+	}
+
+	if len(calls) != len(want) {
+		t.Fatalf("want %d calls, got %d", len(want), len(calls))
+	}
+	for i, w := range want {
+		if calls[i] != w {
+			t.Errorf("call[%d]: want %+v, got %+v", i, w, calls[i])
+		}
+	}
+}
+
+func TestPlanMealsPartialFailure(t *testing.T) {
+	var callCount atomic.Int32
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		idx := callCount.Add(1)
+		w.Header().Set("Content-Type", "application/json")
+		if idx >= 3 {
+			w.WriteHeader(http.StatusInternalServerError)
+			if _, err := w.Write([]byte(`{"error":"fail"}`)); err != nil {
+				t.Errorf("write: %v", err)
+			}
+			return
+		}
+		w.WriteHeader(http.StatusCreated)
+		if err := json.NewEncoder(w).Encode(mealSittingAPIResponse{
+			Data: []mealSittingAPIEntry{{ID: fmt.Sprintf("s%d", idx)}},
+		}); err != nil {
+			t.Errorf("encode: %v", err)
+		}
+	}))
+	defer srv.Close()
+
+	old := SkylightURL
+	SkylightURL = srv.URL + "/api"
+	defer func() { SkylightURL = old }()
+
+	client, _ := NewClientWithToken("u", "t")
+	result, err := client.PlanMeals("frame1", MealPlanData{
+		RecipeIDs:   []string{"r1", "r2", "r3"},
+		CategoryIDs: []string{"cat1"},
+		StartDate:   "2026-04-21",
+	})
+	if err == nil {
+		t.Fatal("expected error for partial failure, got nil")
+	}
+	if result == nil {
+		t.Fatal("expected partial result, got nil")
+	}
+	if len(result.Sittings) != 2 {
+		t.Errorf("want 2 partial sittings, got %d", len(result.Sittings))
 	}
 }

--- a/lib/structs.go
+++ b/lib/structs.go
@@ -763,6 +763,18 @@ type RotationResult struct {
 	Chores []Chore `json:"chores"`
 }
 
+// MealPlanData holds the input for scheduling meals from a recipe list.
+type MealPlanData struct {
+	RecipeIDs   []string
+	CategoryIDs []string
+	StartDate   string
+}
+
+// MealPlanResult holds the sittings created by a meal plan.
+type MealPlanResult struct {
+	Sittings []MealSitting `json:"sittings"`
+}
+
 // Photo represents a photo (or video) message on a Skylight frame.
 type Photo struct {
 	ID           string `json:"id"`


### PR DESCRIPTION
Closes #49

## Summary

- Adds `meal plan` subcommand under `mealCmd` that schedules a list of recipes as meal sittings starting from a given date
- Recipes are assigned to consecutive days, rotating through the provided meal category IDs (e.g. `--categories lunch-id,dinner-id` fills one lunch and one dinner slot per day before advancing)
- Returns a partial result alongside the error if any sitting creation fails mid-plan

## Usage

```
go-skylight meal plan   --frame-id FRAME_ID   --recipes id1,id2,id3,id4,id5   --start-date 2026-04-21   --categories lunch-cat-id,dinner-cat-id
```

## Changes

- `lib/structs.go` — `MealPlanData` and `MealPlanResult` types
- `lib/meal.go` — `PlanMeals` function with partial-failure return (mirrors `CreateChoreRotation` pattern)
- `cmd/meal.go` — `meal plan` subcommand with `--recipes`, `--categories`, `--start-date` flags and upfront date validation
- `lib/meal_test.go` — count, day/category rotation, validation, and partial-failure tests

## Test plan

- [ ] `make test` passes
- [ ] `make lint` passes (0 issues)