### PR TITLE
fix: mask sensitive values in config get by default

### DIFF
--- a/cmd/configcmd.go
+++ b/cmd/configcmd.go
@@ -78,6 +78,8 @@ var configShowCmd = &cobra.Command{
 	},
 }
 
+var configGetReveal bool
+
 var configGetCmd = &cobra.Command{
 	Use:   "get <key>",
 	Short: "Get the value of a configuration key",
@@ -91,8 +93,12 @@ var configGetCmd = &cobra.Command{
 		}
 		if *ptr == "" {
 			fmt.Fprintln(cmd.OutOrStdout(), notSet)
-		} else {
+			return nil
+		}
+		if configGetReveal {
 			fmt.Fprintln(cmd.OutOrStdout(), *ptr)
+		} else {
+			fmt.Fprintln(cmd.OutOrStdout(), maskValue(key, *ptr))
 		}
 		return nil
 	},
@@ -192,6 +198,7 @@ var configEditCmd = &cobra.Command{
 }
 
 func init() {
+	configGetCmd.Flags().BoolVar(&configGetReveal, "reveal", false, "Print the full value of sensitive keys instead of masking")
 	configCmd.AddCommand(configShowCmd)
 	configCmd.AddCommand(configGetCmd)
 	configCmd.AddCommand(configSetCmd)

--- a/cmd/configcmd_test.go
+++ b/cmd/configcmd_test.go
@@ -119,10 +119,11 @@ func TestConfigGetEmptyValue(t *testing.T) {
 	}
 }
 
-func TestConfigGetKnownValue(t *testing.T) {
+func TestConfigGetMasksSensitiveKeys(t *testing.T) {
 	resetGlobals(t)
 	token = "plaintext-value"
-	t.Cleanup(func() { token = "" })
+	configGetReveal = false
+	t.Cleanup(func() { token = ""; configGetReveal = false })
 
 	var buf bytes.Buffer
 	configGetCmd.SetOut(&buf)
@@ -130,9 +131,45 @@ func TestConfigGetKnownValue(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	// get must return plaintext (no masking) for scripting use
+	out := strings.TrimSpace(buf.String())
+	if strings.Contains(out, "plaintext-value") {
+		t.Errorf("config get should mask sensitive value, got %q", out)
+	}
+	if !strings.Contains(out, masked) {
+		t.Errorf("config get should contain mask marker %q, got %q", masked, out)
+	}
+}
+
+func TestConfigGetRevealFlag(t *testing.T) {
+	resetGlobals(t)
+	token = "plaintext-value"
+	configGetReveal = true
+	t.Cleanup(func() { token = ""; configGetReveal = false })
+
+	var buf bytes.Buffer
+	configGetCmd.SetOut(&buf)
+	err := configGetCmd.RunE(configGetCmd, []string{"SKYLIGHT_TOKEN"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
 	if strings.TrimSpace(buf.String()) != "plaintext-value" {
-		t.Errorf("expected %q, got %q", "plaintext-value", buf.String())
+		t.Errorf("config get --reveal should print full value, got %q", buf.String())
+	}
+}
+
+func TestConfigGetNonSensitiveUnmasked(t *testing.T) {
+	resetGlobals(t)
+	frameID = "frame-abc-123"
+	t.Cleanup(func() { frameID = "" })
+
+	var buf bytes.Buffer
+	configGetCmd.SetOut(&buf)
+	err := configGetCmd.RunE(configGetCmd, []string{"SKYLIGHT_FRAME_ID"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if strings.TrimSpace(buf.String()) != "frame-abc-123" {
+		t.Errorf("config get for non-sensitive key should print full value, got %q", buf.String())
 	}
 }
 


### PR DESCRIPTION
## Summary

- `config get SKYLIGHT_TOKEN` (and PASSWORD, REFRESH_TOKEN) now masks the value using the same `maskValue()` logic as `config show`, preventing credentials from appearing in shell history and terminal output
- New `--reveal` flag allows intentional full-value display when needed
- Updated `TestConfigGetKnownValue` → `TestConfigGetMasksSensitiveKeys` to reflect the corrected behavior
- Added `TestConfigGetRevealFlag` and `TestConfigGetNonSensitiveUnmasked` for full coverage

## Test plan

- [ ] `config get SKYLIGHT_TOKEN` returns `abcd****` format when set
- [ ] `config get --reveal SKYLIGHT_TOKEN` returns full value
- [ ] `config get SKYLIGHT_EMAIL` returns full value (non-sensitive)
- [ ] `config get SKYLIGHT_TOKEN` returns `(not set)` when unset
- [ ] All existing config tests pass