### PR TITLE
feat: add category delete and update commands

### DIFF
--- a/cmd/category.go
+++ b/cmd/category.go
@@ -1,11 +1,25 @@
 package cmd
 
 import (
+	"fmt"
+
+	"github.com/sebrandon1/go-skylight/lib"
 	"github.com/spf13/cobra"
+)
+
+var (
+	categoryID    string
+	categoryName  string
+	categoryColor string
 )
 
 var categoryCmd = &cobra.Command{
 	Use:   "category",
+	Short: "Category (profile/label) management commands",
+}
+
+var categoryListCmd = &cobra.Command{
+	Use:   "list",
 	Short: "List family members/categories",
 	Run: func(cmd *cobra.Command, args []string) {
 		requireFrameID()
@@ -19,4 +33,60 @@ var categoryCmd = &cobra.Command{
 
 		printOutput(categories)
 	},
+}
+
+var categoryDeleteCmd = &cobra.Command{
+	Use:   "delete",
+	Short: "Delete a category (profile/label)",
+	Run: func(cmd *cobra.Command, args []string) {
+		requireFrameID()
+
+		client := getClient()
+
+		err := client.DeleteCategory(frameID, categoryID)
+		if err != nil {
+			fatal("deleting category", err)
+		}
+
+		fmt.Println("Category deleted successfully")
+	},
+}
+
+var categoryUpdateCmd = &cobra.Command{
+	Use:   "update",
+	Short: "Update a category (profile/label)",
+	Run: func(cmd *cobra.Command, args []string) {
+		requireFrameID()
+
+		client := getClient()
+
+		data := lib.CategoryData{}
+		if cmd.Flags().Changed("name") {
+			data.Name = categoryName
+		}
+		if cmd.Flags().Changed("color") {
+			data.Color = categoryColor
+		}
+
+		category, err := client.UpdateCategory(frameID, categoryID, data)
+		if err != nil {
+			fatal("updating category", err)
+		}
+
+		printJSON(category)
+	},
+}
+
+func init() {
+	categoryCmd.AddCommand(categoryListCmd)
+	categoryCmd.AddCommand(categoryDeleteCmd)
+	categoryCmd.AddCommand(categoryUpdateCmd)
+
+	categoryDeleteCmd.Flags().StringVar(&categoryID, "category-id", "", "Category ID")
+	categoryDeleteCmd.MarkFlagRequired("category-id") //nolint:errcheck
+
+	categoryUpdateCmd.Flags().StringVar(&categoryID, "category-id", "", "Category ID to update")
+	categoryUpdateCmd.Flags().StringVar(&categoryName, "name", "", "Category name")
+	categoryUpdateCmd.Flags().StringVar(&categoryColor, "color", "", "Category color (hex, e.g. #FF0000)")
+	categoryUpdateCmd.MarkFlagRequired("category-id") //nolint:errcheck
 }

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -605,8 +605,8 @@ func TestCategoryCommandExists(t *testing.T) {
 	if categoryCmd.Use != "category" {
 		t.Errorf("Expected Use 'category', got '%s'", categoryCmd.Use)
 	}
-	if categoryCmd.Run == nil {
-		t.Error("categoryCmd should have a Run function")
+	if !categoryCmd.HasSubCommands() {
+		t.Error("categoryCmd should have subcommands")
 	}
 }
 
@@ -685,6 +685,9 @@ func TestAllCommandsHaveShortDescriptions(t *testing.T) {
 		"meal create-sitting": mealCreateSittingCmd,
 		"meal add-to-grocery": mealAddToGroceryCmd,
 		"category":            categoryCmd,
+		"category list":       categoryListCmd,
+		"category delete":     categoryDeleteCmd,
+		"category update":     categoryUpdateCmd,
 		"frame":               frameCmd,
 		"frame info":          frameInfoCmd,
 		"frame devices":       frameDevicesCmd,
@@ -738,7 +741,9 @@ func TestLeafCommandsHaveRunFunctions(t *testing.T) {
 		"meal sittings":       mealSittingsCmd,
 		"meal create-sitting": mealCreateSittingCmd,
 		"meal add-to-grocery": mealAddToGroceryCmd,
-		"category":            categoryCmd,
+		"category list":       categoryListCmd,
+		"category delete":     categoryDeleteCmd,
+		"category update":     categoryUpdateCmd,
 		"frame info":          frameInfoCmd,
 		"frame devices":       frameDevicesCmd,
 		"frame avatars":       frameAvatarsCmd,

--- a/lib/category.go
+++ b/lib/category.go
@@ -20,3 +20,33 @@ func (c *Client) ListCategories(frameID string) ([]Category, error) {
 	}
 	return categories, nil
 }
+
+// UpdateCategory updates an existing category (profile/label).
+func (c *Client) UpdateCategory(frameID, categoryID string, data CategoryData) (*Category, error) {
+	req, err := newRequestWithBody("PATCH", fmt.Sprintf("%s/frames/%s/categories/%s", c.effectiveURL(), frameID, categoryID), data)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create update category request: %w", err)
+	}
+
+	var apiResp categoryAPISingleResponse
+	if err := c.patch(req, &apiResp); err != nil {
+		return nil, fmt.Errorf("failed to update category: %w", err)
+	}
+
+	result := apiResp.Data.toCategory()
+	return &result, nil
+}
+
+// DeleteCategory deletes a category (profile/label).
+func (c *Client) DeleteCategory(frameID, categoryID string) error {
+	req, err := newRequest("DELETE", fmt.Sprintf("%s/frames/%s/categories/%s", c.effectiveURL(), frameID, categoryID))
+	if err != nil {
+		return fmt.Errorf("failed to create delete category request: %w", err)
+	}
+
+	if err := c.doDelete(req); err != nil {
+		return fmt.Errorf("failed to delete category: %w", err)
+	}
+
+	return nil
+}

--- a/lib/category_test.go
+++ b/lib/category_test.go
@@ -124,3 +124,124 @@ func TestListCategoriesRequestBody(t *testing.T) {
 		t.Errorf("expected color #FF0000, got %s", categories[0].Color)
 	}
 }
+
+func TestDeleteCategory(t *testing.T) {
+	tests := []struct {
+		name    string
+		status  int
+		wantErr bool
+	}{
+		{"deletes with 204", http.StatusNoContent, false},
+		{"deletes with 200", http.StatusOK, false},
+		{"server error returns error", http.StatusInternalServerError, true},
+		{"not found returns error", http.StatusNotFound, true},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if r.Method != http.MethodDelete {
+					t.Errorf("expected DELETE, got %s", r.Method)
+				}
+				if r.URL.Path != "/api/frames/frame1/categories/cat1" {
+					t.Errorf("unexpected path: %s", r.URL.Path)
+				}
+				w.WriteHeader(tc.status)
+			}))
+			defer srv.Close()
+
+			old := SkylightURL
+			SkylightURL = srv.URL + "/api"
+			defer func() { SkylightURL = old }()
+
+			client, _ := NewClientWithToken("u", "t")
+			err := client.DeleteCategory("frame1", "cat1")
+			if (err != nil) != tc.wantErr {
+				t.Fatalf("wantErr=%v got %v", tc.wantErr, err)
+			}
+		})
+	}
+}
+
+func TestUpdateCategory(t *testing.T) {
+	tests := []struct {
+		name     string
+		catID    string
+		input    CategoryData
+		status   int
+		response string
+		wantName string
+		wantErr  bool
+	}{
+		{
+			name:     "updates category name",
+			catID:    "cat1",
+			input:    CategoryData{Name: "Updated Name"},
+			status:   http.StatusOK,
+			response: `{"data":{"id":"cat1","attributes":{"label":"Updated Name","color":"#FF0000"}}}`,
+			wantName: "Updated Name",
+		},
+		{
+			name:   "204 no content succeeds",
+			catID:  "cat1",
+			input:  CategoryData{Color: "#00FF00"},
+			status: http.StatusNoContent,
+		},
+		{
+			name:    "bad request returns error",
+			catID:   "cat1",
+			input:   CategoryData{Name: "Test"},
+			status:  http.StatusBadRequest,
+			wantErr: true,
+		},
+		{
+			name:    "server error returns error",
+			catID:   "cat1",
+			input:   CategoryData{Name: "Test"},
+			status:  http.StatusInternalServerError,
+			wantErr: true,
+		},
+		{
+			name:     "invalid JSON returns error",
+			catID:    "cat1",
+			input:    CategoryData{Name: "Test"},
+			status:   http.StatusOK,
+			response: `{invalid json`,
+			wantErr:  true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if r.Method != http.MethodPatch {
+					t.Errorf("expected PATCH, got %s", r.Method)
+				}
+				if r.URL.Path != "/api/frames/frame1/categories/"+tc.catID {
+					t.Errorf("unexpected path: %s", r.URL.Path)
+				}
+				w.Header().Set("Content-Type", "application/json")
+				w.WriteHeader(tc.status)
+				if tc.response != "" {
+					if _, err := w.Write([]byte(tc.response)); err != nil {
+						t.Errorf("write: %v", err)
+					}
+				}
+			}))
+			defer srv.Close()
+
+			old := SkylightURL
+			SkylightURL = srv.URL + "/api"
+			defer func() { SkylightURL = old }()
+
+			client, _ := NewClientWithToken("u", "t")
+			category, err := client.UpdateCategory("frame1", tc.catID, tc.input)
+			if (err != nil) != tc.wantErr {
+				t.Fatalf("wantErr=%v got %v", tc.wantErr, err)
+			}
+			if !tc.wantErr && tc.wantName != "" && category != nil && category.Name != tc.wantName {
+				t.Errorf("Name: want %q got %q", tc.wantName, category.Name)
+			}
+		})
+	}
+}

--- a/lib/structs.go
+++ b/lib/structs.go
@@ -609,6 +609,17 @@ type categoryAPIEntry struct {
 	} `json:"attributes"`
 }
 
+// categoryAPISingleResponse wraps the JSON-API envelope for single category responses.
+type categoryAPISingleResponse struct {
+	Data categoryAPIEntry `json:"data"`
+}
+
+// CategoryData holds the category fields for update requests.
+type CategoryData struct {
+	Name  string `json:"label,omitempty"`
+	Color string `json:"color,omitempty"`
+}
+
 func (e *categoryAPIEntry) toCategory() Category {
 	c := Category{
 		ID:    e.ID,


### PR DESCRIPTION
## Summary
- Add `DeleteCategory` and `UpdateCategory` methods to the library
- Add `skylight category {list,delete,update}` CLI subcommands
- Enable deleting stale profiles/labels and renaming or recoloring existing ones -- operations the Skylight app does not expose
- Add `CategoryData` struct and `categoryAPISingleResponse` for API interaction
- Add tests for both new methods (9 test cases)
- Update `root_test.go` for new subcommand structure

## Motivation
Skylight users cannot delete profiles or labels through the app -- only merge or convert. This leaves empty/stale entries cluttering the calendar with no way to remove them. This PR adds the missing CRUD operations via the CLI.

## Test plan
- [x] `go test ./...` passes (all existing + 9 new tests)
- [x] `make build` succeeds
- [ ] Manual test: create a test profile, then delete it via CLI
- [ ] Manual test: update a profile name/color via CLI