### PR TITLE
fix: map real Device attributes from live Skylight API

### DIFF
--- a/cmd/helpers_test.go
+++ b/cmd/helpers_test.go
@@ -396,7 +396,7 @@ func TestPrintOutputDevicesTable(t *testing.T) {
 	outputFormat = outputTable
 	t.Cleanup(func() { outputFormat = outputJSON })
 	devices := []lib.Device{
-		{ID: "d1", Name: "Kitchen Frame", Online: true},
+		{ID: "d1", Name: "Kitchen Frame", Online: true, Brightness: 200, SleepsAt: "00:00", WakesAt: "06:00", Nightlight: true},
 		{ID: "d2", Name: "Bedroom Frame", Online: false},
 	}
 	output := captureStdout(func() { printOutput(devices) })
@@ -408,6 +408,9 @@ func TestPrintOutputDevicesTable(t *testing.T) {
 	}
 	if !strings.Contains(output, boolNo) {
 		t.Errorf("Expected 'no' for offline device, got: %s", output)
+	}
+	if !strings.Contains(output, "00:00-06:00") {
+		t.Errorf("Expected sleep schedule in output, got: %s", output)
 	}
 }
 

--- a/cmd/table_output.go
+++ b/cmd/table_output.go
@@ -146,13 +146,18 @@ func printSourceCalendarsTable(cals []lib.SourceCalendar) {
 
 func printDevicesTable(devices []lib.Device) {
 	w := newTableWriter()
-	fmt.Fprintln(w, "ID\tNAME\tONLINE")
+	fmt.Fprintln(w, "ID\tNAME\tONLINE\tBRIGHTNESS\tSLEEP SCHEDULE\tNIGHTLIGHT")
 	for _, d := range devices {
 		online := boolNo
 		if d.Online {
 			online = boolYes
 		}
-		fmt.Fprintf(w, "%s\t%s\t%s\n", d.ID, d.Name, online)
+		nightlight := boolNo
+		if d.Nightlight {
+			nightlight = boolYes
+		}
+		sleepSchedule := fmt.Sprintf("%s-%s", d.SleepsAt, d.WakesAt)
+		fmt.Fprintf(w, "%s\t%s\t%s\t%d\t%s\t%s\n", d.ID, d.Name, online, d.Brightness, sleepSchedule, nightlight)
 	}
 	w.Flush()
 }

--- a/lib/frame_test.go
+++ b/lib/frame_test.go
@@ -1,6 +1,7 @@
 package lib
 
 import (
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -148,19 +149,22 @@ func TestGetFrame(t *testing.T) {
 
 func TestListDevices(t *testing.T) {
 	tests := []struct {
-		name       string
-		status     int
-		response   string
-		wantLen    int
-		wantOnline bool
-		wantErr    bool
+		name         string
+		status       int
+		response     string
+		wantLen      int
+		wantOnline   bool
+		wantTimezone string
+		wantErr      bool
 	}{
 		{
-			name:       "returns devices",
-			status:     http.StatusOK,
-			response:   `{"data":[{"id":"dev1","type":"device","attributes":{"name":"Kitchen","activated":true}},{"id":"dev2","type":"device","attributes":{"name":"Living Room","activated":false}}]}`,
-			wantLen:    2,
-			wantOnline: true,
+			name:   "returns devices",
+			status: http.StatusOK,
+			response: fmt.Sprintf(`{"data":[{"id":"dev1","type":"device","attributes":{"name":"Kitchen","activated":true,"timezone":%q,"brightness":%d,"sleeps_at":%q,"wakes_at":%q,"nightlight":true}},{"id":"dev2","type":"device","attributes":{"name":"Living Room","activated":false}}]}`,
+				testDeviceTimezone, testDeviceBrightness, testDeviceSleepsAt, testDeviceWakesAt),
+			wantLen:      2,
+			wantOnline:   true,
+			wantTimezone: testDeviceTimezone,
 		},
 		{
 			name:    "not found returns error",
@@ -210,6 +214,9 @@ func TestListDevices(t *testing.T) {
 			}
 			if len(devices) > 0 && devices[0].Online != tc.wantOnline {
 				t.Errorf("devices[0].Online: want %v got %v", tc.wantOnline, devices[0].Online)
+			}
+			if tc.wantTimezone != "" && devices[0].Timezone != tc.wantTimezone {
+				t.Errorf("devices[0].Timezone: want %q got %q", tc.wantTimezone, devices[0].Timezone)
 			}
 		})
 	}

--- a/lib/structs.go
+++ b/lib/structs.go
@@ -670,14 +670,20 @@ func (e *frameAPIEntry) toFrame() Frame {
 
 // Device represents a physical Skylight device.
 type Device struct {
-	ID           string `json:"id,omitempty"`
-	Name         string `json:"name,omitempty"`
-	Model        string `json:"model,omitempty"`
-	FirmwareVer  string `json:"firmware_version,omitempty"`
-	LastOnlineAt string `json:"last_online_at,omitempty"`
-	Online       bool   `json:"online,omitempty"`
-	CreatedAt    string `json:"created_at,omitempty"`
-	UpdatedAt    string `json:"updated_at,omitempty"`
+	ID                   string `json:"id,omitempty"`
+	Name                 string `json:"name,omitempty"`
+	Online               bool   `json:"online,omitempty"`
+	Timezone             string `json:"timezone,omitempty"`
+	Role                 string `json:"role,omitempty"`
+	CategoryID           string `json:"category_id,omitempty"`
+	Brightness           int    `json:"brightness,omitempty"`
+	SleepsAt             string `json:"sleeps_at,omitempty"`
+	WakesAt              string `json:"wakes_at,omitempty"`
+	CurrentlySleeping    bool   `json:"currently_sleeping,omitempty"`
+	SleepModeOn          bool   `json:"sleep_mode_on,omitempty"`
+	SleepMode            string `json:"sleep_mode,omitempty"`
+	Nightlight           bool   `json:"nightlight,omitempty"`
+	NightlightBrightness int    `json:"nightlight_brightness,omitempty"`
 }
 
 // deviceAPIResponse wraps the JSON-API envelope for device list responses.
@@ -689,16 +695,38 @@ type deviceAPIResponse struct {
 type deviceAPIEntry struct {
 	ID         string `json:"id"`
 	Attributes struct {
-		Name      string `json:"name"`
-		Activated bool   `json:"activated"`
+		Name                 string `json:"name"`
+		Activated            bool   `json:"activated"`
+		Timezone             string `json:"timezone"`
+		Role                 string `json:"role"`
+		CategoryID           string `json:"category_id"`
+		Brightness           int    `json:"brightness"`
+		SleepsAt             string `json:"sleeps_at"`
+		WakesAt              string `json:"wakes_at"`
+		CurrentlySleeping    bool   `json:"currently_sleeping"`
+		SleepModeOn          bool   `json:"sleep_mode_on"`
+		SleepMode            string `json:"sleep_mode"`
+		Nightlight           bool   `json:"nightlight"`
+		NightlightBrightness int    `json:"nightlight_brightness"`
 	} `json:"attributes"`
 }
 
 func (e *deviceAPIEntry) toDevice() Device {
 	return Device{
-		ID:     e.ID,
-		Name:   e.Attributes.Name,
-		Online: e.Attributes.Activated,
+		ID:                   e.ID,
+		Name:                 e.Attributes.Name,
+		Online:               e.Attributes.Activated,
+		Timezone:             e.Attributes.Timezone,
+		Role:                 e.Attributes.Role,
+		CategoryID:           e.Attributes.CategoryID,
+		Brightness:           e.Attributes.Brightness,
+		SleepsAt:             e.Attributes.SleepsAt,
+		WakesAt:              e.Attributes.WakesAt,
+		CurrentlySleeping:    e.Attributes.CurrentlySleeping,
+		SleepModeOn:          e.Attributes.SleepModeOn,
+		SleepMode:            e.Attributes.SleepMode,
+		Nightlight:           e.Attributes.Nightlight,
+		NightlightBrightness: e.Attributes.NightlightBrightness,
 	}
 }
 

--- a/lib/structs_test.go
+++ b/lib/structs_test.go
@@ -209,13 +209,40 @@ func TestToFrame(t *testing.T) {
 	}
 }
 
+const (
+	testDeviceTimezone   = "America/Chicago"
+	testDeviceBrightness = 200
+	testDeviceSleepsAt   = "00:00"
+	testDeviceWakesAt    = "06:00"
+)
+
 func TestToDevice(t *testing.T) {
 	entry := deviceAPIEntry{ID: "d1"}
 	entry.Attributes.Name = "Frame"
 	entry.Attributes.Activated = true
+	entry.Attributes.Timezone = testDeviceTimezone
+	entry.Attributes.Brightness = testDeviceBrightness
+	entry.Attributes.SleepsAt = testDeviceSleepsAt
+	entry.Attributes.WakesAt = testDeviceWakesAt
+	entry.Attributes.Nightlight = true
 	d := entry.toDevice()
 	if !d.Online {
 		t.Error("Online should be true when Activated is true")
+	}
+	if d.Timezone != entry.Attributes.Timezone {
+		t.Errorf("Timezone = %q, want %q", d.Timezone, entry.Attributes.Timezone)
+	}
+	if d.Brightness != entry.Attributes.Brightness {
+		t.Errorf("Brightness = %d, want %d", d.Brightness, entry.Attributes.Brightness)
+	}
+	if d.SleepsAt != entry.Attributes.SleepsAt {
+		t.Errorf("SleepsAt = %q, want %q", d.SleepsAt, entry.Attributes.SleepsAt)
+	}
+	if d.WakesAt != entry.Attributes.WakesAt {
+		t.Errorf("WakesAt = %q, want %q", d.WakesAt, entry.Attributes.WakesAt)
+	}
+	if !d.Nightlight {
+		t.Error("Nightlight should be true")
 	}
 }
 


### PR DESCRIPTION
## Summary
- The original version of this PR guessed that `deviceAPIEntry` should map `Model`, `FirmwareVer`, `LastOnlineAt`, `CreatedAt`, `UpdatedAt` — fields the public `Device` struct had declared since the very first commit but never actually verified against the live API.
- I verified against a real frame's `GET /frames/:id/devices` response and **none of those fields exist**. The real response instead returns: `timezone`, `role`, `category_id`, `brightness`, `slideshow_speed`, `slideshow_style`, `start_sound`, `show_caption`, `show_heart`, `blur_effect`, `current_album_id`, `sleeps_at`, `wakes_at`, `currently_sleeping`, `sleep_mode_on`, `side_by_side`, `sleep_mode`, `sleep_sound`, `sleep_sound_volume`, `nightlight`, `nightlight_brightness`.
- Replaced the fictional fields with the confirmed real ones most relevant to a device overview: `Timezone`, `Role`, `CategoryID`, `Brightness`, `SleepsAt`/`WakesAt`, `CurrentlySleeping`, `SleepModeOn`/`SleepMode`, `Nightlight`/`NightlightBrightness`.
- Surfaced brightness, sleep schedule, and nightlight status in the `frame devices` table output (previously only ID/NAME/ONLINE).

Closes #167.

## Test plan
- [x] Verified against a live Skylight frame: confirmed the real attribute names, then confirmed `frame devices -o json` and `-o table` correctly surface them after this fix
- [x] `go test ./...` — all passing
- [x] `make lint` — no new issues (pre-existing goconst findings unrelated to this change)
- [x] Updated `TestToDevice`, `TestListDevices`, and `TestPrintOutputDevicesTable` to cover the real fields instead of the fictional ones
