### PR TITLE
docs: simplify README by extracting content to docs/

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,351 +10,63 @@ Go CLI and client library for the [Skylight Calendar](https://app.ourskylight.co
 
 > **Disclaimer:** This is an unofficial, community-built tool and is not affiliated with or endorsed by Skylight. It interacts with Skylight's undocumented API — behavior may change without notice. Use at your own risk.
 
-## Architecture
+## Key Features
 
-```
-┌──────────────────────────────────────────────────────────────┐
-│  go-skylight CLI  (cmd/)                                     │
-│  Cobra commands: calendar · chore · reward · list · meal … │
-└──────────────────────┬───────────────────────────────────────┘
-                       │ calls
-┌──────────────────────▼───────────────────────────────────────┐
-│  lib.Client  (lib/)                                          │
-│  retry · rate-limit · slog logging · typed errors           │
-└──────────────────────┬───────────────────────────────────────┘
-                       │ HTTPS / Basic auth
-             ┌─────────▼──────────┐
-             │  Skylight REST API │
-             └────────────────────┘
-
-┌──────────────────────────────────────────────────────────────┐
-│  alpaca-trigger  (cmd/alpaca-trigger/)                       │
-│  lib.RewardsPoller ──► lib.Client ──► Skylight API          │
-│        │                                                     │
-│        └──► AlpacaClient ──► Alpaca v2 REST API             │
-│             POST /v2/orders  (VOO notional buy)             │
-└──────────────────────────────────────────────────────────────┘
-```
+- Full CRUD for calendar events, chores, rewards, lists, recipes, categories, photos, routines, and grocery lists
+- OAuth2 login with automatic token rotation and config file persistence
+- Table and JSON output formats
+- Go client library with retry, rate limiting, and typed errors
+- Alpaca Markets integration for reward-triggered stock purchases
+- Docker images for `linux/amd64` and `linux/arm64`
 
 ## Quick Start
 
-### Install
-
 ```bash
+# Install
 go install github.com/sebrandon1/go-skylight@latest
+
+# Login (saves credentials to ~/.skylight/config)
+skylight login --email user@example.com --password yourpassword --save
+
+# Use any command
+skylight chore list --frame-id FRAME_ID
+skylight calendar list --start-date 2024-01-15
+skylight reward points
 ```
 
-### Docker
-
-No Go toolchain required — pull the image and run any command directly:
-
-```bash
-docker run --rm \
-  sebrandon1/go-skylight:latest \
-  chore create \
-  --user-id YOUR_UID \
-  --token YOUR_TOKEN \
-  --frame-id FRAME_ID \
-  --title "Take out the trash" \
-  --points 5
-```
-
-Pass credentials via environment variables to keep the command tidy:
+Or run via Docker:
 
 ```bash
 docker run --rm \
   -e SKYLIGHT_USER_ID=YOUR_UID \
   -e SKYLIGHT_TOKEN=YOUR_TOKEN \
   -e SKYLIGHT_FRAME_ID=FRAME_ID \
-  sebrandon1/go-skylight:latest \
-  chore create --title "Take out the trash" --points 5
+  sebrandon1/go-skylight:latest chore list
 ```
 
-Images are published to [Docker Hub](https://hub.docker.com/r/sebrandon1/go-skylight) on every release for `linux/amd64` and `linux/arm64`.
+## Authentication
 
-### Authenticate
+| Mode | Flags / Env Vars |
+|------|------------------|
+| OAuth2 refresh token (recommended) | `--refresh-token` / `SKYLIGHT_REFRESH_TOKEN` |
+| Pre-existing bearer token | `--user-id` + `--token` / `SKYLIGHT_USER_ID` + `SKYLIGHT_TOKEN` |
+| Email + password (deprecated) | `--email` + `--password` / `SKYLIGHT_EMAIL` + `SKYLIGHT_PASSWORD` |
 
-```bash
-# Option 1: headless OAuth2 login (saves refresh token + device fingerprint to ~/.skylight/config)
-skylight login --email user@example.com --password yourpassword --save
+Config file: `~/.skylight/config` (override with `--config`). CLI flags take precedence.
 
-# Option 2: supply a refresh token directly on every command
-skylight chore list --refresh-token YOUR_REFRESH_TOKEN --frame-id FRAME_ID
+## Guides
 
-# Option 3 (legacy): pre-existing bearer token
-skylight chore list --user-id YOUR_UID --token YOUR_TOKEN --frame-id FRAME_ID
+| Document | Description |
+|----------|-------------|
+| [CLI Reference](docs/cli-reference.md) | Full command listing for all resources |
+| [Library Usage](docs/library-usage.md) | Go client API, examples, typed errors, and coverage matrix |
+| [Alpaca Integration](docs/alpaca-trigger.md) | Reward-triggered stock purchases via Alpaca Markets |
+
+## Architecture
+
 ```
-
-After `login --save`, the refresh token is stored in `~/.skylight/config` and loaded automatically; it rotates on use and the new token is persisted back to the config file.
-
-## Authentication Modes
-
-| Mode | Flags / Config Keys |
-|------|---------------------|
-| OAuth2 refresh token (recommended) | `--refresh-token` / `SKYLIGHT_REFRESH_TOKEN`, `--device-fingerprint` / `SKYLIGHT_DEVICE_FINGERPRINT` |
-| Pre-existing bearer token | `--user-id` / `--token` / `SKYLIGHT_USER_ID` / `SKYLIGHT_TOKEN` |
-| Email + password (deprecated) | `--email` / `--password` / `SKYLIGHT_EMAIL` / `SKYLIGHT_PASSWORD` |
-| Frame ID | `--frame-id` / `SKYLIGHT_FRAME_ID` |
-
-Config file location: `~/.skylight/config` (override with `--config`). CLI flags take precedence.
-
-## CLI Reference
-
-All commands accept `--user-id`/`--token`, `--refresh-token`, `--frame-id`, `--config`, and `--output (json|table)` as persistent flags. Resource commands are top-level (e.g. `skylight chore list`) — the legacy `skylight get <resource> ...` nesting was flattened and is no longer used.
-
-### Calendar
-
-```bash
-skylight calendar list [--start-date DATE] [--end-date DATE]
-skylight calendar create --title TITLE --start-at DATETIME [--end-at DATETIME] [--all-day]
-skylight calendar update --event-id ID [--title TITLE] [--start-at DATETIME] [--end-at DATETIME]
-skylight calendar delete --event-id ID
-skylight calendar sources
-skylight calendar create-countdown --title TITLE --date DATE
-skylight calendar week [--date DATE]
-```
-
-### Chores
-
-```bash
-skylight chore list [--date DATE] [--assignee-id ID] [--status S] [--after DATE] [--before DATE] [--include-late] [--up-for-grabs] [--week [DATE]]
-skylight chore create --title TITLE [--description D] [--points N] [--assignee-id ID] [--date DATE] [--recurring] [--up-for-grabs]
-skylight chore update --chore-id ID [--title T] [--description D] [--status S] [--points N] [--assignee-id ID] [--date DATE]
-skylight chore delete --chore-id ID
-skylight chore complete --chore-id ID
-skylight chore skip --chore-id ID
-skylight chore claim --chore-id ID --assignee-id ID
-skylight chore streak [--days N]
-```
-
-### Rewards
-
-```bash
-skylight reward list
-skylight reward create --title TITLE --points N [--emoji-icon EMOJI] [--no-respawn] [--category-ids 1,2]
-skylight reward update --reward-id ID [--title T] [--points N] [--emoji-icon EMOJI]
-skylight reward delete --reward-id ID
-skylight reward redeem   --reward-id ID
-skylight reward unredeem --reward-id ID
-skylight reward points
-```
-
-### Lists
-
-```bash
-skylight list all
-skylight list info       --list-id ID
-skylight list create     --title TITLE [--color COLOR] [--hide-from-frame]
-skylight list update     --list-id ID [--title T] [--color C] [--hide-from-frame]
-skylight list delete     --list-id ID
-skylight list add-item   --list-id ID --title TITLE
-skylight list update-item --list-id ID --item-id ITEM_ID [--title T] [--completed]
-skylight list delete-item --list-id ID --item-id ITEM_ID
-skylight list clear-completed --list-id ID
-```
-
-### Meals
-
-```bash
-skylight meal categories
-skylight meal recipes
-skylight meal recipe-info --recipe-id ID
-skylight meal create-recipe --title TITLE [--description D] [--ingredients a,b] [--url URL] [--meal-category-id ID]
-skylight meal update-recipe --recipe-id ID [--title T] [--description D] [--ingredients a,b] [--url URL]
-skylight meal delete-recipe --recipe-id ID
-skylight meal sittings [--date-min DATE] [--date-max DATE]
-skylight meal create-sitting --recipe-id ID --date DATE [--summary S] [--meal-category-id ID]
-skylight meal delete-sitting --sitting-id ID [--date DATE]
-skylight meal sitting-recipe --sitting-id ID
-skylight meal add-to-grocery --recipe-id ID
-skylight meal plan --recipes ID,ID --start-date DATE [--categories ID,ID]
-```
-
-### Photos
-
-```bash
-skylight photo list [--page-token TOKEN]
-skylight photo upload --file PATH [--caption TEXT]
-skylight photo delete --message-id ID [--message-id ID ...]
-skylight photo download [--message-id ID ...] [--all] [--output-dir DIR]
-```
-
-### Categories (Profiles & Labels)
-
-```bash
-skylight category list
-skylight category create --name NAME [--color COLOR]
-skylight category update --category-id ID [--name NAME] [--color COLOR]
-skylight category delete --category-id ID
-```
-
-### Frame
-
-```bash
-skylight frame list
-skylight frame info
-skylight frame devices
-skylight frame avatars
-skylight frame colors
-```
-
-### Bounties & Rotations
-
-```bash
-skylight bounty create --title TITLE --points N --reward-title R [--assignee-id ID] [--due-date DATE] [--emoji-icon EMOJI] [--recurring]
-skylight bounty list
-skylight bounty update --chore-id ID --reward-id ID [--title T] [--reward-title R] [--points N] [--due-date DATE] [--emoji-icon EMOJI]
-skylight bounty delete --chore-id ID --reward-id ID
-
-skylight rotation create --chores "Dishes,Vacuum" --assignee-ids "id1,id2" \
-    --start-date DATE --weeks N --points N
-```
-
-### Routines
-
-```bash
-skylight routine list
-skylight routine create --title TITLE [--assignee-id ID] [--steps "Step 1,Step 2"]
-skylight routine update --routine-id ID [--title T] [--assignee-id ID] [--steps "..."]
-skylight routine delete --routine-id ID
-skylight routine reorder --routine-ids "id1,id2,id3"
-```
-
-### Grocery
-
-```bash
-skylight grocery list
-skylight grocery show     --list-id ID
-skylight grocery create   --title TITLE
-skylight grocery add      --list-id ID --items "Milk,Eggs"
-skylight grocery add-recipe --recipe-id ID
-skylight grocery organize --list-id ID
-skylight grocery order    --list-id ID --retailer costco
-skylight grocery clear    --list-id ID
-```
-
-### Status, Home, Analytics & Watch
-
-```bash
-skylight status                     # quick overview of the connected frame
-skylight home [--no-tasks] [--no-lists]   # weekly combined view of events, tasks, and lists
-skylight analytics [--days N]       # family activity statistics over a time period
-skylight watch [--interval SECONDS] [--resources rewards,chores,calendar] [--persist]
-```
-
-### Export & Import
-
-```bash
-skylight export [--output-file PATH] [--resources chores,rewards,lists,recipes,sittings,calendar] [--days N]
-skylight import --file PATH [--dry-run] [--resources all]
-```
-
-## Library Usage
-
-```go
-import "github.com/sebrandon1/go-skylight/lib"
-
-// Basic client
-client, err := lib.NewClientWithToken("user-id", "api-token")
-
-// With functional options: retry, rate limiting, logging, custom base URL
-client, err := lib.NewClientWithToken("user-id", "api-token",
-    lib.WithRetry(3, 500*time.Millisecond, 10*time.Second),
-    lib.WithRateLimit(rate.Limit(5), 10),
-    lib.WithLogger(slog.Default()),
-    lib.WithBaseURL("https://staging.example.com/api"), // test seam
-)
-
-// List chores
-chores, err := client.ListChores("frame-id", lib.ChoreListOptions{Date: "2024-01-15"})
-
-// Create a bounty (chore + matched reward)
-bounty, err := client.CreateBounty("frame-id", lib.BountyData{
-    Title:       "Clean the kitchen",
-    Points:      10,
-    RewardTitle: "Ice cream night",
-    EmojiIcon:   "🍦",
-})
-
-// Stream reward redemptions
-poller := lib.NewRewardsPoller(client, "frame-id", 60*time.Second, "")
-poller.Start(ctx)
-for event := range poller.Events() {
-    fmt.Printf("%s redeemed %s (%d pts)\n",
-        event.ChildName, event.RewardName, event.Points)
-}
-```
-
-### Typed Errors
-
-```go
-var authErr *lib.AuthError
-var notFound *lib.NotFoundError
-var rateLimit *lib.RateLimitError
-var netErr *lib.NetworkError
-
-if errors.As(err, &authErr) {
-    // re-authenticate
-} else if errors.As(err, &rateLimit) {
-    time.Sleep(rateLimit.RetryAfter)
-}
-```
-
-## API Coverage
-
-| Resource | List | Create | Update | Delete | Extra |
-|----------|------|--------|--------|--------|-------|
-| Calendar events | ✓ | ✓ | ✓ | ✓ | sources |
-| Chores | ✓ | ✓ | ✓ | ✓ | filter by date/assignee/status |
-| Rewards | ✓ | ✓ | ✓ | ✓ | redeem, unredeem, points |
-| Lists | ✓ | ✓ | ✓ | ✓ | items CRUD, task box |
-| Recipes | ✓ | ✓ | ✓ | ✓ | sittings, grocery |
-| Categories | ✓ | ✓ | ✓ | ✓ | profiles & labels |
-| Frame | ✓ | — | — | — | info, devices, avatars, colors |
-| Photos | ✓ | ✓ | — | ✓ | paginated list, upload (S3), download, bulk delete |
-| Bounties | ✓ | ✓ | ✓ | ✓ | chore + reward pairs |
-| Rotations | — | ✓ | — | — | rotating chore assignments |
-| Routines | ✓ | ✓ | ✓ | ✓ | reorder |
-| Grocery | ✓ | ✓ | — | — | organize, order (Instacart), clear completed |
-| Status / Home / Analytics / Watch | — | — | — | — | dashboards, stats, and live polling |
-
-## Alpaca Integration
-
-`alpaca-trigger` watches for Skylight reward redemptions and places a notional
-VOO market buy on Alpaca Markets every time a reward is redeemed.
-
-### Setup
-
-```bash
-make build-trigger
-```
-
-### Environment Variables
-
-| Variable | Required | Default | Description |
-|----------|----------|---------|-------------|
-| `ALPACA_API_KEY` | ✓ | — | Alpaca API key ID |
-| `ALPACA_API_SECRET` | ✓ | — | Alpaca API secret key |
-| `ALPACA_BASE_URL` | — | `https://paper-api.alpaca.markets` | **Paper trading by default** |
-| `SKYLIGHT_USER_ID` | ✓ | — | Skylight user ID |
-| `SKYLIGHT_TOKEN` | ✓ | — | Skylight API token |
-| `SKYLIGHT_FRAME_ID` | ✓ | — | Skylight frame ID to watch |
-| `POLLER_INTERVAL` | — | `60s` | Poll frequency (Go duration string) |
-| `POLLER_STATE_FILE` | — | `~/.skylight/poller-state.json` | Deduplication state |
-| `VOO_NOTIONAL` | — | `1.00` | Dollar amount per redemption |
-
-> **Warning:** Set `ALPACA_BASE_URL=https://api.alpaca.markets` only when you intend to place real orders. The default is the paper-trading endpoint.
-
-### Run
-
-```bash
-export ALPACA_API_KEY=your_key
-export ALPACA_API_SECRET=your_secret
-export SKYLIGHT_USER_ID=uid
-export SKYLIGHT_TOKEN=tok
-export SKYLIGHT_FRAME_ID=fid
-
-./alpaca-trigger
+CLI (cmd/)  -->  lib.Client (lib/)  -->  Skylight REST API
+                                    -->  Alpaca v2 REST API (alpaca-trigger)
 ```
 
 ## Development

--- a/docs/alpaca-trigger.md
+++ b/docs/alpaca-trigger.md
@@ -1,0 +1,38 @@
+# Alpaca Integration
+
+`alpaca-trigger` watches for Skylight reward redemptions and places a notional
+VOO market buy on Alpaca Markets every time a reward is redeemed.
+
+## Setup
+
+```bash
+make build-trigger
+```
+
+## Environment Variables
+
+| Variable | Required | Default | Description |
+|----------|----------|---------|-------------|
+| `ALPACA_API_KEY` | Yes | — | Alpaca API key ID |
+| `ALPACA_API_SECRET` | Yes | — | Alpaca API secret key |
+| `ALPACA_BASE_URL` | — | `https://paper-api.alpaca.markets` | **Paper trading by default** |
+| `SKYLIGHT_USER_ID` | Yes | — | Skylight user ID |
+| `SKYLIGHT_TOKEN` | Yes | — | Skylight API token |
+| `SKYLIGHT_FRAME_ID` | Yes | — | Skylight frame ID to watch |
+| `POLLER_INTERVAL` | — | `60s` | Poll frequency (Go duration string) |
+| `POLLER_STATE_FILE` | — | `~/.skylight/poller-state.json` | Deduplication state |
+| `VOO_NOTIONAL` | — | `1.00` | Dollar amount per redemption |
+
+> **Warning:** Set `ALPACA_BASE_URL=https://api.alpaca.markets` only when you intend to place real orders. The default is the paper-trading endpoint.
+
+## Run
+
+```bash
+export ALPACA_API_KEY=your_key
+export ALPACA_API_SECRET=your_secret
+export SKYLIGHT_USER_ID=uid
+export SKYLIGHT_TOKEN=tok
+export SKYLIGHT_FRAME_ID=fid
+
+./alpaca-trigger
+```

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -1,0 +1,150 @@
+# CLI Reference
+
+All commands accept `--user-id`/`--token`, `--refresh-token`, `--frame-id`, `--config`, and `--output (json|table)` as persistent flags. Resource commands are top-level (e.g. `skylight chore list`).
+
+## Calendar
+
+```bash
+skylight calendar list [--start-date DATE] [--end-date DATE]
+skylight calendar create --title TITLE --start-at DATETIME [--end-at DATETIME] [--all-day]
+skylight calendar update --event-id ID [--title TITLE] [--start-at DATETIME] [--end-at DATETIME]
+skylight calendar delete --event-id ID
+skylight calendar sources
+skylight calendar create-countdown --title TITLE --date DATE
+skylight calendar week [--date DATE]
+```
+
+## Chores
+
+```bash
+skylight chore list [--date DATE] [--assignee-id ID] [--status S] [--after DATE] [--before DATE] [--include-late] [--up-for-grabs] [--week [DATE]]
+skylight chore create --title TITLE [--description D] [--points N] [--assignee-id ID] [--date DATE] [--recurring] [--up-for-grabs]
+skylight chore update --chore-id ID [--title T] [--description D] [--status S] [--points N] [--assignee-id ID] [--date DATE]
+skylight chore delete --chore-id ID
+skylight chore complete --chore-id ID
+skylight chore skip --chore-id ID
+skylight chore claim --chore-id ID --assignee-id ID
+skylight chore streak [--days N]
+```
+
+## Rewards
+
+```bash
+skylight reward list
+skylight reward create --title TITLE --points N [--emoji-icon EMOJI] [--no-respawn] [--category-ids 1,2]
+skylight reward update --reward-id ID [--title T] [--points N] [--emoji-icon EMOJI]
+skylight reward delete --reward-id ID
+skylight reward redeem   --reward-id ID
+skylight reward unredeem --reward-id ID
+skylight reward points
+```
+
+## Lists
+
+```bash
+skylight list all
+skylight list info       --list-id ID
+skylight list create     --title TITLE [--color COLOR] [--hide-from-frame]
+skylight list update     --list-id ID [--title T] [--color C] [--hide-from-frame]
+skylight list delete     --list-id ID
+skylight list add-item   --list-id ID --title TITLE
+skylight list update-item --list-id ID --item-id ITEM_ID [--title T] [--completed]
+skylight list delete-item --list-id ID --item-id ITEM_ID
+skylight list clear-completed --list-id ID
+```
+
+## Meals
+
+```bash
+skylight meal categories
+skylight meal recipes
+skylight meal recipe-info --recipe-id ID
+skylight meal create-recipe --title TITLE [--description D] [--ingredients a,b] [--url URL] [--meal-category-id ID]
+skylight meal update-recipe --recipe-id ID [--title T] [--description D] [--ingredients a,b] [--url URL]
+skylight meal delete-recipe --recipe-id ID
+skylight meal sittings [--date-min DATE] [--date-max DATE]
+skylight meal create-sitting --recipe-id ID --date DATE [--summary S] [--meal-category-id ID]
+skylight meal delete-sitting --sitting-id ID [--date DATE]
+skylight meal sitting-recipe --sitting-id ID
+skylight meal add-to-grocery --recipe-id ID
+skylight meal plan --recipes ID,ID --start-date DATE [--categories ID,ID]
+```
+
+## Photos
+
+```bash
+skylight photo list [--page-token TOKEN]
+skylight photo upload --file PATH [--caption TEXT]
+skylight photo delete --message-id ID [--message-id ID ...]
+skylight photo download [--message-id ID ...] [--all] [--output-dir DIR]
+```
+
+## Categories (Profiles & Labels)
+
+```bash
+skylight category list
+skylight category create --name NAME [--color COLOR]
+skylight category update --category-id ID [--name NAME] [--color COLOR]
+skylight category delete --category-id ID
+```
+
+## Frame
+
+```bash
+skylight frame list
+skylight frame info
+skylight frame devices
+skylight frame avatars
+skylight frame colors
+```
+
+## Bounties & Rotations
+
+```bash
+skylight bounty create --title TITLE --points N --reward-title R [--assignee-id ID] [--due-date DATE] [--emoji-icon EMOJI] [--recurring]
+skylight bounty list
+skylight bounty update --chore-id ID --reward-id ID [--title T] [--reward-title R] [--points N] [--due-date DATE] [--emoji-icon EMOJI]
+skylight bounty delete --chore-id ID --reward-id ID
+
+skylight rotation create --chores "Dishes,Vacuum" --assignee-ids "id1,id2" \
+    --start-date DATE --weeks N --points N
+```
+
+## Routines
+
+```bash
+skylight routine list
+skylight routine create --title TITLE [--assignee-id ID] [--steps "Step 1,Step 2"]
+skylight routine update --routine-id ID [--title T] [--assignee-id ID] [--steps "..."]
+skylight routine delete --routine-id ID
+skylight routine reorder --routine-ids "id1,id2,id3"
+```
+
+## Grocery
+
+```bash
+skylight grocery list
+skylight grocery show     --list-id ID
+skylight grocery create   --title TITLE
+skylight grocery add      --list-id ID --items "Milk,Eggs"
+skylight grocery add-recipe --recipe-id ID
+skylight grocery organize --list-id ID
+skylight grocery order    --list-id ID --retailer costco
+skylight grocery clear    --list-id ID
+```
+
+## Status, Home, Analytics & Watch
+
+```bash
+skylight status                     # quick overview of the connected frame
+skylight home [--no-tasks] [--no-lists]   # weekly combined view of events, tasks, and lists
+skylight analytics [--days N]       # family activity statistics over a time period
+skylight watch [--interval SECONDS] [--resources rewards,chores,calendar] [--persist]
+```
+
+## Export & Import
+
+```bash
+skylight export [--output-file PATH] [--resources chores,rewards,lists,recipes,sittings,calendar] [--days N]
+skylight import --file PATH [--dry-run] [--resources all]
+```

--- a/docs/library-usage.md
+++ b/docs/library-usage.md
@@ -1,0 +1,78 @@
+# Library Usage
+
+Import the `lib` package to use go-skylight as a Go library.
+
+```go
+import "github.com/sebrandon1/go-skylight/lib"
+```
+
+## Creating a Client
+
+```go
+// Basic client
+client, err := lib.NewClientWithToken("user-id", "api-token")
+
+// With functional options: retry, rate limiting, logging, custom base URL
+client, err := lib.NewClientWithToken("user-id", "api-token",
+    lib.WithRetry(3, 500*time.Millisecond, 10*time.Second),
+    lib.WithRateLimit(rate.Limit(5), 10),
+    lib.WithLogger(slog.Default()),
+    lib.WithBaseURL("https://staging.example.com/api"), // test seam
+)
+```
+
+## Examples
+
+```go
+// List chores
+chores, err := client.ListChores("frame-id", lib.ChoreListOptions{Date: "2024-01-15"})
+
+// Create a bounty (chore + matched reward)
+bounty, err := client.CreateBounty("frame-id", lib.BountyData{
+    Title:       "Clean the kitchen",
+    Points:      10,
+    RewardTitle: "Ice cream night",
+    EmojiIcon:   "🍦",
+})
+
+// Stream reward redemptions
+poller := lib.NewRewardsPoller(client, "frame-id", 60*time.Second, "")
+poller.Start(ctx)
+for event := range poller.Events() {
+    fmt.Printf("%s redeemed %s (%d pts)\n",
+        event.ChildName, event.RewardName, event.Points)
+}
+```
+
+## Typed Errors
+
+```go
+var authErr *lib.AuthError
+var notFound *lib.NotFoundError
+var rateLimit *lib.RateLimitError
+var netErr *lib.NetworkError
+
+if errors.As(err, &authErr) {
+    // re-authenticate
+} else if errors.As(err, &rateLimit) {
+    time.Sleep(rateLimit.RetryAfter)
+}
+```
+
+## API Coverage
+
+| Resource | List | Create | Update | Delete | Extra |
+|----------|------|--------|--------|--------|-------|
+| Calendar events | ✓ | ✓ | ✓ | ✓ | sources |
+| Chores | ✓ | ✓ | ✓ | ✓ | filter by date/assignee/status |
+| Rewards | ✓ | ✓ | ✓ | ✓ | redeem, unredeem, points |
+| Lists | ✓ | ✓ | ✓ | ✓ | items CRUD, task box |
+| Recipes | ✓ | ✓ | ✓ | ✓ | sittings, grocery |
+| Categories | ✓ | ✓ | ✓ | ✓ | profiles & labels |
+| Frame | ✓ | — | — | — | info, devices, avatars, colors |
+| Photos | ✓ | ✓ | — | ✓ | paginated list, upload (S3), download, bulk delete |
+| Bounties | ✓ | ✓ | ✓ | ✓ | chore + reward pairs |
+| Rotations | — | ✓ | — | — | rotating chore assignments |
+| Routines | ✓ | ✓ | ✓ | ✓ | reorder |
+| Grocery | ✓ | ✓ | — | — | organize, order (Instacart), clear completed |
+| Status / Home / Analytics / Watch | — | — | — | — | dashboards, stats, and live polling |


### PR DESCRIPTION
## Summary

- README reduced from **371 lines to 83 lines** (78% reduction)
- Detailed content extracted into focused docs/ files with no content lost

## Changes

| File | Lines | Content |
|------|-------|---------|
| README.md | 371 -> 83 | Slimmed to landing page with overview, quick start, auth summary, guides table |
| docs/cli-reference.md | 150 (new) | Full CLI command reference for all 13 resource types |
| docs/library-usage.md | 78 (new) | Go client API, examples, typed errors, API coverage matrix |
| docs/alpaca-trigger.md | 38 (new) | Alpaca Markets integration setup and env var reference |

## Guides

| Document | Description |
|----------|-------------|
| [CLI Reference](docs/cli-reference.md) | Full command listing for all resources |
| [Library Usage](docs/library-usage.md) | Go client API, examples, typed errors, and coverage matrix |
| [Alpaca Integration](docs/alpaca-trigger.md) | Reward-triggered stock purchases via Alpaca Markets |

## Test plan

- [ ] README renders correctly on GitHub
- [ ] All docs/ links resolve from the README
- [ ] No content was lost — CLI reference, library usage, API coverage, and Alpaca docs are preserved
- [ ] Badge links still work

## Related to

- sebrandon1/tls-compliance-operator [#209](https://github.com/sebrandon1/tls-compliance-operator/pull/209)
- sebrandon1/imagecertinfo-operator [#115](https://github.com/sebrandon1/imagecertinfo-operator/pull/115)
- sebrandon1/tls-config-lint [#16](https://github.com/sebrandon1/tls-config-lint/pull/16)
- openshift-kni/olm-annotation-lint [#50](https://github.com/openshift-kni/olm-annotation-lint/pull/50)
- sebrandon1/succulent-cli [#59](https://github.com/sebrandon1/succulent-cli/pull/59)
- sebrandon1/ocp-doc-checker [#55](https://github.com/sebrandon1/ocp-doc-checker/pull/55)
- sebrandon1/go-quay [#111](https://github.com/sebrandon1/go-quay/pull/111)
- sebrandon1/compliance-scripts [#122](https://github.com/sebrandon1/compliance-scripts/pull/122)
- sebrandon1/go-enphase [#22](https://github.com/sebrandon1/go-enphase/pull/22)
- sebrandon1/skylight-bridge [#18](https://github.com/sebrandon1/skylight-bridge/pull/18)
- sebrandon1/ztp-dashboard [#117](https://github.com/sebrandon1/ztp-dashboard/pull/117)
- sebrandon1/bps-operator [#110](https://github.com/sebrandon1/bps-operator/pull/110)
- sebrandon1/yaml-to-readme [#153](https://github.com/sebrandon1/yaml-to-readme/pull/153)
- sebrandon1/grab [#42](https://github.com/sebrandon1/grab/pull/42)
- sebrandon1/jiracrawler [#84](https://github.com/sebrandon1/jiracrawler/pull/84)
- sebrandon1/compliance-operator-dashboard [#121](https://github.com/sebrandon1/compliance-operator-dashboard/pull/121)