### PR TITLE
perf: parallelize sequential API calls in cmd/watch.go poll()

### DIFF
--- a/cmd/watch.go
+++ b/cmd/watch.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"os/signal"
 	"strings"
+	"sync"
 	"syscall"
 	"time"
 
@@ -188,16 +189,31 @@ func parseWatchResources(s string) []string {
 func poll(client *lib.Client, state *watchState, resources []string) {
 	now := time.Now()
 	ts := now.Format("15:04:05")
+
+	var wg sync.WaitGroup
 	for _, r := range resources {
 		switch r {
 		case watchResourceRewards:
-			pollRewards(client, state, ts)
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+				pollRewards(client, state, ts)
+			}()
 		case watchResourceChores:
-			pollChores(client, state, now, ts)
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+				pollChores(client, state, now, ts)
+			}()
 		case watchResourceCalendar:
-			pollCalendar(client, state, now, ts)
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+				pollCalendar(client, state, now, ts)
+			}()
 		}
 	}
+	wg.Wait()
 }
 
 func pollRewards(client *lib.Client, state *watchState, ts string) {


### PR DESCRIPTION
## Summary

`poll()` in `cmd/watch.go` called `pollRewards`, `pollChores`, and `pollCalendar` sequentially in a loop. These are three independent API calls that can run concurrently. This PR uses `sync.WaitGroup` to launch them as goroutines, cutting each poll cycle's wall-clock latency by up to 3x.

## Changes

- Added `"sync"` to imports in `cmd/watch.go`
- Refactored `poll()` to dispatch each resource poller as a goroutine via `sync.WaitGroup`
- `wg.Wait()` ensures all three complete before the next cycle

## Thread Safety

Each goroutine writes exclusively to its own map in `watchState`:
- `pollRewards` → `state.seenRewardIDs`
- `pollChores` → `state.seenChoreIDs`
- `pollCalendar` → `state.seenEventIDs`

No shared mutable state, so no mutex is needed. This matches the existing parallelization patterns in `lib/bounty.go` and `cmd/export.go`.

## Testing

- `go build ./...` passes
- `go test ./cmd/ ./lib/` — same pre-existing failures (unrelated `TestSaveConfigWriteError`, `TestSaveStateWriteError`), zero new failures

Fixes #183