### PR TITLE
fix(bounty): log cleanup errors instead of silently discarding (#181)

### DIFF
--- a/lib/bounty.go
+++ b/lib/bounty.go
@@ -25,7 +25,9 @@ func (c *Client) CreateBounty(frameID string, data BountyData) (*Bounty, error) 
 	if len(categoryIDs) == 0 && data.AssigneeID != "" {
 		id, err := strconv.Atoi(data.AssigneeID)
 		if err != nil {
-			_ = c.DeleteChore(frameID, chore.ID)
+			if delErr := c.DeleteChore(frameID, chore.ID); delErr != nil && c.logger != nil {
+				c.logger.Warn("bounty cleanup: failed to delete chore after assignee parse error", "chore_id", chore.ID, "error", delErr)
+			}
 			return nil, fmt.Errorf("assignee_id %q is not a valid numeric category ID: %w", data.AssigneeID, err)
 		}
 		categoryIDs = []int{id}
@@ -37,8 +39,9 @@ func (c *Client) CreateBounty(frameID string, data BountyData) (*Bounty, error) 
 		CategoryIDs: categoryIDs,
 	})
 	if err != nil {
-		// Best-effort cleanup
-		_ = c.DeleteChore(frameID, chore.ID)
+		if delErr := c.DeleteChore(frameID, chore.ID); delErr != nil && c.logger != nil {
+			c.logger.Warn("bounty cleanup: failed to delete chore after reward creation error", "chore_id", chore.ID, "error", delErr)
+		}
 		return nil, fmt.Errorf("failed to create bounty reward: %w", err)
 	}
 


### PR DESCRIPTION
## Summary

- On both failure paths in `CreateBounty`, `_ = c.DeleteChore(...)` silently discarded the cleanup error, leaving callers unaware if a chore leaked.
- Replace with `c.logger.Warn(...)` guarded by a nil check, matching the existing logger pattern on `Client` throughout `lib/client.go`.

## Context

Four external PRs were submitted for this issue (#192, #194, #195, #196). They were closed for the following reasons:
- #194 and #196 (Notime02): destructive — truncated or replaced the file, would not compile.
- #195 (gtx20060124-bot): correct logic but used `fmt.Fprintf(os.Stderr)` rather than the structured `slog` logger already on `Client`.
- #192 (zeroknowledge0x): best approach of the four, but bundled unrelated concurrency changes to `cmd/watch.go`.

This PR applies the minimal, focused fix.

## Test plan

- `make build` passes
- `make test` passes (all existing tests green)
- `make lint` is clean for the changed file (`./lib/...`)
