### PR TITLE
feat: add addon list and frame set-album commands for Disney Mode (#197)

### DIFF
--- a/cmd/addon.go
+++ b/cmd/addon.go
@@ -1,0 +1,42 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/spf13/cobra"
+)
+
+var addonCmd = &cobra.Command{
+	Use:   "addon",
+	Short: "Manage frame add-ons",
+}
+
+var addonListCmd = &cobra.Command{
+	Use:   "list",
+	Short: "List available add-ons and their enabled state",
+	Run: func(cmd *cobra.Command, args []string) {
+		requireFrameID()
+
+		client := getClient()
+
+		frame, err := client.GetFrame(frameID)
+		if err != nil {
+			fatal("listing addons", err)
+		}
+
+		if !frame.Plus {
+			fmt.Fprintln(os.Stderr, "Warning: Skylight Plus subscription required to access add-ons.")
+		}
+		if len(frame.FeatureBundle) == 0 {
+			fmt.Println("No add-ons found.")
+			return
+		}
+
+		printOutput(frame.FeatureBundle)
+	},
+}
+
+func init() {
+	addonCmd.AddCommand(addonListCmd)
+}

--- a/cmd/frame.go
+++ b/cmd/frame.go
@@ -1,8 +1,12 @@
 package cmd
 
 import (
+	"fmt"
+
 	"github.com/spf13/cobra"
 )
+
+var currentAlbumID int
 
 var frameCmd = &cobra.Command{
 	Use:   "frame",
@@ -88,10 +92,30 @@ var frameColorsCmd = &cobra.Command{
 	},
 }
 
+var frameSetAlbumCmd = &cobra.Command{
+	Use:   "set-album",
+	Short: "Set the active slideshow album by album ID (-1 for all photos)",
+	Run: func(cmd *cobra.Command, args []string) {
+		requireFrameID()
+
+		client := getClient()
+
+		if err := client.SetCurrentAlbum(frameID, currentAlbumID); err != nil {
+			fatal("setting current album", err)
+		}
+
+		fmt.Printf("Current album set to %d\n", currentAlbumID)
+	},
+}
+
 func init() {
 	frameCmd.AddCommand(frameListCmd)
 	frameCmd.AddCommand(frameInfoCmd)
 	frameCmd.AddCommand(frameDevicesCmd)
 	frameCmd.AddCommand(frameAvatarsCmd)
 	frameCmd.AddCommand(frameColorsCmd)
+	frameCmd.AddCommand(frameSetAlbumCmd)
+
+	frameSetAlbumCmd.Flags().IntVar(&currentAlbumID, "album-id", 0, "Album ID to display (-1 for all photos)")
+	frameSetAlbumCmd.MarkFlagRequired("album-id") //nolint:errcheck
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -108,6 +108,7 @@ func init() {
 	rootCmd.AddCommand(loginCmd)
 	rootCmd.AddCommand(bountyCmd)
 	rootCmd.AddCommand(rotationCmd)
+	rootCmd.AddCommand(addonCmd)
 	rootCmd.AddCommand(calendarCmd)
 	rootCmd.AddCommand(choreCmd)
 	rootCmd.AddCommand(listCmd)

--- a/lib/frame.go
+++ b/lib/frame.go
@@ -1,6 +1,8 @@
 package lib
 
-import "fmt"
+import (
+	"fmt"
+)
 
 // ListFrames retrieves all frames accessible to the authenticated user.
 func (c *Client) ListFrames() ([]Frame, error) {
@@ -73,6 +75,27 @@ func (c *Client) GetAvatars() ([]Avatar, error) {
 		avatars[i] = apiResp.Data[i].toAvatar()
 	}
 	return avatars, nil
+}
+
+// SetCurrentAlbum sets the active slideshow album for a frame by album ID.
+// Use -1 to revert to the default (all photos) album.
+func (c *Client) SetCurrentAlbum(frameID string, albumID int) error {
+	body := struct {
+		Frame struct {
+			CurrentAlbumID int `json:"current_album_id"`
+		} `json:"frame"`
+	}{}
+	body.Frame.CurrentAlbumID = albumID
+
+	req, err := newRequestWithBody("PATCH", fmt.Sprintf("%s/frames/%s", c.effectiveURL(), frameID), body)
+	if err != nil {
+		return fmt.Errorf("failed to create set album request: %w", err)
+	}
+
+	if err := c.patch(req, nil); err != nil {
+		return fmt.Errorf("failed to set current album: %w", err)
+	}
+	return nil
 }
 
 // GetColors retrieves available colors.

--- a/lib/frame_test.go
+++ b/lib/frame_test.go
@@ -275,6 +275,58 @@ func TestGetAvatars(t *testing.T) {
 	}
 }
 
+func TestSetCurrentAlbum(t *testing.T) {
+	tests := []struct {
+		name    string
+		status  int
+		wantErr bool
+	}{
+		{
+			name:   "sets album successfully",
+			status: http.StatusNoContent,
+		},
+		{
+			name:   "200 ok also succeeds",
+			status: http.StatusOK,
+		},
+		{
+			name:    "not found returns error",
+			status:  http.StatusNotFound,
+			wantErr: true,
+		},
+		{
+			name:    "server error returns error",
+			status:  http.StatusInternalServerError,
+			wantErr: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if r.Method != http.MethodPatch {
+					t.Errorf("expected PATCH, got %s", r.Method)
+				}
+				if r.URL.Path != "/api/frames/frame1" {
+					t.Errorf("unexpected path: %s", r.URL.Path)
+				}
+				w.WriteHeader(tc.status)
+			}))
+			defer srv.Close()
+
+			old := SkylightURL
+			SkylightURL = srv.URL + "/api"
+			defer func() { SkylightURL = old }()
+
+			client, _ := NewClientWithToken("u", "t")
+			err := client.SetCurrentAlbum("frame1", 42)
+			if (err != nil) != tc.wantErr {
+				t.Fatalf("wantErr=%v got %v", tc.wantErr, err)
+			}
+		})
+	}
+}
+
 func TestGetColors(t *testing.T) {
 	tests := []struct {
 		name     string

--- a/lib/structs.go
+++ b/lib/structs.go
@@ -1,5 +1,7 @@
 package lib
 
+import "encoding/json"
+
 // apiRelationshipData is the JSON-API "data" object inside a to-one relationship.
 type apiRelationshipData struct {
 	ID string `json:"id"`
@@ -633,12 +635,19 @@ func (e *categoryAPIEntry) toCategory() Category {
 }
 
 // Frame represents a Skylight frame/device group.
+// FeatureState represents the enabled/disabled state of a single frame feature.
+type FeatureState struct {
+	Enabled bool `json:"enabled"`
+}
+
 type Frame struct {
-	ID        string `json:"id,omitempty"`
-	Name      string `json:"name,omitempty"`
-	TimeZone  string `json:"timezone,omitempty"`
-	CreatedAt string `json:"created_at,omitempty"`
-	UpdatedAt string `json:"updated_at,omitempty"`
+	ID            string                  `json:"id,omitempty"`
+	Name          string                  `json:"name,omitempty"`
+	TimeZone      string                  `json:"timezone,omitempty"`
+	Plus          bool                    `json:"plus,omitempty"`
+	FeatureBundle map[string]FeatureState `json:"feature_bundle,omitempty"`
+	CreatedAt     string                  `json:"created_at,omitempty"`
+	UpdatedAt     string                  `json:"updated_at,omitempty"`
 }
 
 // frameAPIResponse wraps the JSON-API envelope for single frame responses.
@@ -655,16 +664,27 @@ type framesAPIResponse struct {
 type frameAPIEntry struct {
 	ID         string `json:"id"`
 	Attributes struct {
-		Name     string `json:"name"`
-		TimeZone string `json:"timezone"`
+		Name          string                     `json:"name"`
+		TimeZone      string                     `json:"timezone"`
+		Plus          bool                       `json:"plus"`
+		FeatureBundle map[string]json.RawMessage `json:"feature_bundle"`
 	} `json:"attributes"`
 }
 
 func (e *frameAPIEntry) toFrame() Frame {
+	bundle := make(map[string]FeatureState, len(e.Attributes.FeatureBundle))
+	for k, raw := range e.Attributes.FeatureBundle {
+		var fs FeatureState
+		if err := json.Unmarshal(raw, &fs); err == nil {
+			bundle[k] = fs
+		}
+	}
 	return Frame{
-		ID:       e.ID,
-		Name:     e.Attributes.Name,
-		TimeZone: e.Attributes.TimeZone,
+		ID:            e.ID,
+		Name:          e.Attributes.Name,
+		TimeZone:      e.Attributes.TimeZone,
+		Plus:          e.Attributes.Plus,
+		FeatureBundle: bundle,
 	}
 }
 


### PR DESCRIPTION
## Summary

- Adds `addon list` command: reads add-on eligibility from the frame's `feature_bundle` field (e.g. `disney: {enabled: true}`)
- Adds `frame set-album --album-id N` command: PATCHes `current_album_id` on the frame to switch the active slideshow album
- `frame info` now surfaces `plus` and the full `feature_bundle` map

## Investigation findings

There is no separate `/api/addons` endpoint — all add-on state lives inside `GET /api/frames/{id}` under `attributes.feature_bundle`. Disney Mode eligibility is subscription-driven for Plus accounts and is not togglable via API, so no enable/disable commands were implemented.

The `feature_bundle` map contains both feature objects (`{"enabled": bool}`) and metadata strings (`bundle_name`, `bundle_names`). The implementation uses `json.RawMessage` internally and silently skips non-object entries so the public map is clean `map[string]FeatureState`.

## Test plan

- `make build`, `make test`, `make lint` all pass
- Live tested against a real Skylight Plus account — `addon list` returns the full feature bundle with `disney: {enabled: true}`
