### PR TITLE
fix: check scanner.Err() after config file reads

### DIFF
--- a/cmd/config.go
+++ b/cmd/config.go
@@ -59,6 +59,9 @@ func loadConfig() {
 			*ptr = value
 		}
 	}
+	if err := scanner.Err(); err != nil {
+		fmt.Fprintf(os.Stderr, "warning: error reading config file: %v\n", err)
+	}
 }
 
 func saveConfig(values map[string]string) error {
@@ -95,6 +98,9 @@ func saveConfig(values map[string]string) error {
 			orderedKeys = append(orderedKeys, key)
 		}
 		f.Close()
+		if err := scanner.Err(); err != nil {
+			return fmt.Errorf("reading existing config: %w", err)
+		}
 	}
 
 	// Merge new values
@@ -155,6 +161,9 @@ func deleteFromConfig(key string) (bool, error) {
 		lines = append(lines, line)
 	}
 	f.Close()
+	if err := scanner.Err(); err != nil {
+		return false, fmt.Errorf("reading config: %w", err)
+	}
 
 	if !found {
 		return false, nil


### PR DESCRIPTION
## Summary

- `loadConfig`, `saveConfig`, and `deleteFromConfig` in `cmd/config.go` each run a `bufio.Scanner` loop but never call `scanner.Err()` after the loop exits
- An I/O error mid-scan (e.g. disk error, network filesystem) would cause the loop to silently stop early and return partial or empty config with no indication of failure
- `loadConfig` prints a warning to stderr (it has no return value); `saveConfig` and `deleteFromConfig` now return the error to the caller

Fixes #201

## Test plan

- [ ] `make test` passes
- [ ] `make lint` shows no new warnings (pre-existing `goconst` warnings in config.go are unrelated)
- [ ] `skylight login --save` still writes and reads config correctly
- [ ] `skylight config get` still reads config correctly
- [ ] `skylight config delete` still removes keys correctly
