### PR TITLE
fix: apply client-side status filter for chore list

### DIFF
--- a/lib/chore.go
+++ b/lib/chore.go
@@ -92,6 +92,9 @@ func (c *Client) ListChores(frameID string, opts ChoreListOptions) ([]Chore, err
 	chores := make([]Chore, 0, len(apiResp.Data))
 	for i := range apiResp.Data {
 		c := apiResp.Data[i].toChore()
+		if opts.Status != "" && c.Status != opts.Status {
+			continue
+		}
 		if opts.UpForGrabs && !c.UpForGrabs {
 			continue
 		}


### PR DESCRIPTION
## Summary

- `skylight chore list --status complete` was returning all chores regardless of status
- The Skylight API silently ignores the `?status=` query param on the chore list endpoint
- Added client-side filtering in `ListChores` after the API returns results, consistent with how `UpForGrabs` filtering already works

## Test plan

- [ ] `skylight chore list --status complete --after 2026-06-01 --before 2026-06-30` returns only complete chores
- [ ] `skylight chore list --status pending --after 2026-06-01 --before 2026-06-30` returns only pending chores
- [ ] `skylight chore list` (no status flag) returns all chores unchanged
- [ ] Existing tests pass: `make test`