### PR TITLE
docs: add completed chores example with required date range flags

### DIFF
--- a/docs/examples/chores.md
+++ b/docs/examples/chores.md
@@ -6,6 +6,11 @@
 # All pending chores
 skylight chore list --status pending
 
+# Completed chores this week (--after/--before are required for status=complete)
+skylight chore list --status complete \
+  --after $(date -d 'last monday' +%Y-%m-%d) \
+  --before $(date +%Y-%m-%d)
+
 # Only up-for-grabs (unassigned) chores
 skylight chore list --up-for-grabs
 ```


### PR DESCRIPTION
## Summary

- Added a `--status complete` example to `docs/examples/chores.md`
- Includes the required `--after`/`--before` flags (the API returns a 422 without them)
- Uses `date` shell commands to default to the current week