### PR TITLE
bug: require --chore-id flag on chore update command

### DIFF
--- a/cmd/chore.go
+++ b/cmd/chore.go
@@ -278,6 +278,7 @@ func init() {
 	choreUpdateCmd.Flags().IntVar(&chorePoints, "points", 0, "Points value")
 	choreUpdateCmd.Flags().StringVar(&choreAssigneeID, "assignee-id", "", "Assignee ID")
 	choreUpdateCmd.Flags().StringVar(&choreDate, "date", "", "Due date")
+	choreUpdateCmd.MarkFlagRequired("chore-id") //nolint:errcheck
 
 	choreDeleteCmd.Flags().StringVar(&choreID, "chore-id", "", "Chore ID to delete")
 	choreDeleteCmd.MarkFlagRequired("chore-id") //nolint:errcheck


### PR DESCRIPTION
## Summary

- `choreUpdateCmd` defined `--chore-id` but never called `MarkFlagRequired`, so running `chore update` without it silently issued a `PATCH` with an empty ID
- All other chore commands that accept `--chore-id` (`delete`, `complete`, `skip`, `claim`) already mark it required — this brings `update` in line

## Test plan

- [ ] `make test` passes
- [ ] `./go-skylight chore update` (no flags) now prints `required flag(s) "chore-id" not set`
- [ ] `./go-skylight chore update --chore-id ID --title "New title"` still works correctly

Closes #177