### PR TITLE
bug: require --recipe-id flag on meal update-recipe command

### DIFF
--- a/cmd/meal.go
+++ b/cmd/meal.go
@@ -334,6 +334,7 @@ func init() {
 	mealUpdateRecipeCmd.Flags().StringVar(&recipeDescription, "description", "", "Recipe description")
 	mealUpdateRecipeCmd.Flags().StringSliceVar(&recipeIngredients, "ingredients", nil, "Ingredients (comma-separated)")
 	mealUpdateRecipeCmd.Flags().StringVar(&recipeURL, "url", "", "Recipe URL")
+	mealUpdateRecipeCmd.MarkFlagRequired("recipe-id") //nolint:errcheck
 
 	mealDeleteRecipeCmd.Flags().StringVar(&recipeID, "recipe-id", "", "Recipe ID")
 	mealDeleteRecipeCmd.MarkFlagRequired("recipe-id") //nolint:errcheck


### PR DESCRIPTION
## Summary

- `mealUpdateRecipeCmd` defined `--recipe-id` but never called `MarkFlagRequired`, so running `meal update-recipe` without it silently issued a `PATCH` with an empty ID
- `mealDeleteRecipeCmd` and `mealRecipeInfoCmd` already mark `--recipe-id` as required — this brings `update-recipe` in line

## Test plan

- [ ] `make test` passes
- [ ] `./go-skylight meal update-recipe` (no flags) now prints `required flag(s) "recipe-id" not set`
- [ ] `./go-skylight meal update-recipe --recipe-id ID --title "New title"` still works correctly

Closes #178