### PR TITLE
bug: handle os.UserHomeDir() error in NewRewardsPoller

### DIFF
--- a/lib/poller.go
+++ b/lib/poller.go
@@ -59,8 +59,13 @@ type RewardsPoller struct {
 // NewRewardsPoller constructs a RewardsPoller. stateFile may be empty, in
 // which case it defaults to ~/.skylight/poller-state.json.
 func NewRewardsPoller(client *Client, frameID string, interval time.Duration, stateFile string) *RewardsPoller {
+	var homeDirErr error
 	if stateFile == "" {
-		home, _ := os.UserHomeDir()
+		home, err := os.UserHomeDir()
+		if err != nil {
+			homeDirErr = err
+			home = os.TempDir()
+		}
 		stateFile = filepath.Join(home, ".skylight", "poller-state.json")
 	}
 	p := &RewardsPoller{
@@ -73,6 +78,10 @@ func NewRewardsPoller(client *Client, frameID string, interval time.Duration, st
 		stop:      make(chan struct{}),
 		done:      make(chan struct{}),
 		seen:      make(map[string]struct{}),
+	}
+	if homeDirErr != nil && p.logger != nil {
+		p.logger.Warn("poller: home directory unavailable, state file in temp dir and may be lost on reboot",
+			slog.String("path", stateFile), slog.String("error", homeDirErr.Error()))
 	}
 	p.loadState()
 	return p


### PR DESCRIPTION
## Summary

- `home, _ := os.UserHomeDir()` silently produced a broken state-file path on systems where the home directory cannot be determined
- Falls back to `os.TempDir()` and logs a warning via the poller's `slog` logger so the operator knows state durability is reduced
- Warning format matches the existing pattern used throughout `lib/poller.go`

## Test plan

- [ ] `make test` passes
- [ ] Normal operation unchanged when home directory is available
- [ ] When `os.UserHomeDir()` fails, state file resolves to `<tmpdir>/.skylight/poller-state.json` instead of silently writing to root

Closes #182