### PR TITLE
bug: surface MarkFlagRequired() errors instead of silencing with nolint

### DIFF
--- a/cmd/bounty.go
+++ b/cmd/bounty.go
@@ -142,14 +142,14 @@ func init() {
 	bountyCreateCmd.Flags().StringVar(&bountyRewardTitle, "reward-title", "", "Reward title")
 	bountyCreateCmd.Flags().StringVar(&bountyEmojiIcon, "emoji-icon", "", "Reward emoji icon")
 	bountyCreateCmd.Flags().BoolVar(&bountyRecurring, "recurring", false, "Make chore recurring")
-	bountyCreateCmd.MarkFlagRequired("title")        //nolint:errcheck
-	bountyCreateCmd.MarkFlagRequired("points")       //nolint:errcheck
-	bountyCreateCmd.MarkFlagRequired("reward-title") //nolint:errcheck
+	markFlagRequired(bountyCreateCmd, "title")
+	markFlagRequired(bountyCreateCmd, "points")
+	markFlagRequired(bountyCreateCmd, "reward-title")
 
 	bountyDeleteCmd.Flags().StringVar(&bountyChoreID, "chore-id", "", "Chore ID of the bounty")
 	bountyDeleteCmd.Flags().StringVar(&bountyRewardID, "reward-id", "", "Reward ID of the bounty")
-	bountyDeleteCmd.MarkFlagRequired("chore-id")  //nolint:errcheck
-	bountyDeleteCmd.MarkFlagRequired("reward-id") //nolint:errcheck
+	markFlagRequired(bountyDeleteCmd, "chore-id")
+	markFlagRequired(bountyDeleteCmd, "reward-id")
 
 	bountyUpdateCmd.Flags().StringVar(&bountyChoreID, "chore-id", "", "Chore ID of the bounty")
 	bountyUpdateCmd.Flags().StringVar(&bountyRewardID, "reward-id", "", "Reward ID of the bounty")
@@ -158,6 +158,6 @@ func init() {
 	bountyUpdateCmd.Flags().IntVar(&bountyPoints, "points", 0, "New point value for chore and reward")
 	bountyUpdateCmd.Flags().StringVar(&bountyDueDate, "due-date", "", "New due date (YYYY-MM-DD)")
 	bountyUpdateCmd.Flags().StringVar(&bountyEmojiIcon, "emoji-icon", "", "New reward emoji icon")
-	bountyUpdateCmd.MarkFlagRequired("chore-id")  //nolint:errcheck
-	bountyUpdateCmd.MarkFlagRequired("reward-id") //nolint:errcheck
+	markFlagRequired(bountyUpdateCmd, "chore-id")
+	markFlagRequired(bountyUpdateCmd, "reward-id")
 }

--- a/cmd/calendar.go
+++ b/cmd/calendar.go
@@ -225,23 +225,23 @@ func init() {
 	calendarCreateCmd.Flags().StringVar(&calendarStartAt, "start-at", "", "Event start time")
 	calendarCreateCmd.Flags().StringVar(&calendarEndAt, "end-at", "", "Event end time")
 	calendarCreateCmd.Flags().BoolVar(&calendarAllDay, "all-day", false, "All day event")
-	calendarCreateCmd.MarkFlagRequired("title")    //nolint:errcheck
-	calendarCreateCmd.MarkFlagRequired("start-at") //nolint:errcheck
+	markFlagRequired(calendarCreateCmd, "title")
+	markFlagRequired(calendarCreateCmd, "start-at")
 
 	calendarUpdateCmd.Flags().StringVar(&calendarEventID, "event-id", "", "Event ID to update")
 	calendarUpdateCmd.Flags().StringVar(&calendarTitle, "title", "", "Event title")
 	calendarUpdateCmd.Flags().StringVar(&calendarStartAt, "start-at", "", "Event start time")
 	calendarUpdateCmd.Flags().StringVar(&calendarEndAt, "end-at", "", "Event end time")
 	calendarUpdateCmd.Flags().BoolVar(&calendarAllDay, "all-day", false, "All day event")
-	calendarUpdateCmd.MarkFlagRequired("event-id") //nolint:errcheck
+	markFlagRequired(calendarUpdateCmd, "event-id")
 
 	calendarDeleteCmd.Flags().StringVar(&calendarEventID, "event-id", "", "Event ID to delete")
-	calendarDeleteCmd.MarkFlagRequired("event-id") //nolint:errcheck
+	markFlagRequired(calendarDeleteCmd, "event-id")
 
 	calendarCreateCountdownCmd.Flags().StringVar(&calendarTitle, "title", "", "Countdown event title")
 	calendarCreateCountdownCmd.Flags().StringVar(&calendarCountdownDate, "date", "", "Target date (YYYY-MM-DD)")
-	calendarCreateCountdownCmd.MarkFlagRequired("title") //nolint:errcheck
-	calendarCreateCountdownCmd.MarkFlagRequired("date")  //nolint:errcheck
+	markFlagRequired(calendarCreateCountdownCmd, "title")
+	markFlagRequired(calendarCreateCountdownCmd, "date")
 
 	calendarWeekCmd.Flags().StringVar(&calendarWeekDate, "date", "", "Week containing this date (YYYY-MM-DD, default current week)")
 }

--- a/cmd/category.go
+++ b/cmd/category.go
@@ -109,13 +109,13 @@ func init() {
 
 	categoryCreateCmd.Flags().StringVar(&categoryName, "name", "", "Category name")
 	categoryCreateCmd.Flags().StringVar(&categoryColor, "color", "", "Category color (hex, e.g. #FF0000)")
-	categoryCreateCmd.MarkFlagRequired("name") //nolint:errcheck
+	markFlagRequired(categoryCreateCmd, "name")
 
 	categoryDeleteCmd.Flags().StringVar(&categoryID, "category-id", "", "Category ID")
-	categoryDeleteCmd.MarkFlagRequired("category-id") //nolint:errcheck
+	markFlagRequired(categoryDeleteCmd, "category-id")
 
 	categoryUpdateCmd.Flags().StringVar(&categoryID, "category-id", "", "Category ID to update")
 	categoryUpdateCmd.Flags().StringVar(&categoryName, "name", "", "Category name")
 	categoryUpdateCmd.Flags().StringVar(&categoryColor, "color", "", "Category color (hex, e.g. #FF0000)")
-	categoryUpdateCmd.MarkFlagRequired("category-id") //nolint:errcheck
+	markFlagRequired(categoryUpdateCmd, "category-id")
 }

--- a/cmd/chore.go
+++ b/cmd/chore.go
@@ -269,7 +269,7 @@ func init() {
 	choreCreateCmd.Flags().IntVar(&chorePoints, "points", 0, "Points value")
 	choreCreateCmd.Flags().BoolVar(&choreRecurring, "recurring", false, "Make chore recurring")
 	choreCreateCmd.Flags().BoolVar(&choreUpForGrabs, "up-for-grabs", false, "Make chore claimable by anyone")
-	choreCreateCmd.MarkFlagRequired("title") //nolint:errcheck
+	markFlagRequired(choreCreateCmd, "title")
 
 	choreUpdateCmd.Flags().StringVar(&choreID, "chore-id", "", "Chore ID to update")
 	choreUpdateCmd.Flags().StringVar(&choreTitle, "title", "", "Chore title")
@@ -278,19 +278,19 @@ func init() {
 	choreUpdateCmd.Flags().IntVar(&chorePoints, "points", 0, "Points value")
 	choreUpdateCmd.Flags().StringVar(&choreAssigneeID, "assignee-id", "", "Assignee ID")
 	choreUpdateCmd.Flags().StringVar(&choreDate, "date", "", "Due date")
-	choreUpdateCmd.MarkFlagRequired("chore-id") //nolint:errcheck
+	markFlagRequired(choreUpdateCmd, "chore-id")
 
 	choreDeleteCmd.Flags().StringVar(&choreID, "chore-id", "", "Chore ID to delete")
-	choreDeleteCmd.MarkFlagRequired("chore-id") //nolint:errcheck
+	markFlagRequired(choreDeleteCmd, "chore-id")
 
 	choreCompleteCmd.Flags().StringVar(&choreID, "chore-id", "", "Chore ID to complete")
-	choreCompleteCmd.MarkFlagRequired("chore-id") //nolint:errcheck
+	markFlagRequired(choreCompleteCmd, "chore-id")
 
 	choreSkipCmd.Flags().StringVar(&choreID, "chore-id", "", "Chore ID to skip")
-	choreSkipCmd.MarkFlagRequired("chore-id") //nolint:errcheck
+	markFlagRequired(choreSkipCmd, "chore-id")
 
 	choreClaimCmd.Flags().StringVar(&choreID, "chore-id", "", "Chore ID to claim")
 	choreClaimCmd.Flags().StringVar(&choreAssigneeID, "assignee-id", "", "Family member ID claiming the chore")
-	choreClaimCmd.MarkFlagRequired("chore-id")    //nolint:errcheck
-	choreClaimCmd.MarkFlagRequired("assignee-id") //nolint:errcheck
+	markFlagRequired(choreClaimCmd, "chore-id")
+	markFlagRequired(choreClaimCmd, "assignee-id")
 }

--- a/cmd/frame.go
+++ b/cmd/frame.go
@@ -117,5 +117,5 @@ func init() {
 	frameCmd.AddCommand(frameSetAlbumCmd)
 
 	frameSetAlbumCmd.Flags().IntVar(&currentAlbumID, "album-id", 0, "Album ID to display (-1 for all photos)")
-	frameSetAlbumCmd.MarkFlagRequired("album-id") //nolint:errcheck
+	markFlagRequired(frameSetAlbumCmd, "album-id")
 }

--- a/cmd/grocery.go
+++ b/cmd/grocery.go
@@ -182,26 +182,26 @@ func init() {
 	groceryCmd.AddCommand(groceryOrderCmd)
 
 	groceryCreateCmd.Flags().StringVar(&groceryTitle, "title", "", "Grocery list title")
-	groceryCreateCmd.MarkFlagRequired("title") //nolint:errcheck
+	markFlagRequired(groceryCreateCmd, "title")
 
 	groceryShowCmd.Flags().StringVar(&groceryListID, "list-id", "", "List ID")
-	groceryShowCmd.MarkFlagRequired("list-id") //nolint:errcheck
+	markFlagRequired(groceryShowCmd, "list-id")
 
 	groceryAddCmd.Flags().StringVar(&groceryListID, "list-id", "", "List ID")
 	groceryAddCmd.Flags().StringSliceVar(&groceryItems, "items", nil, "Items to add (comma-separated)")
-	groceryAddCmd.MarkFlagRequired("list-id") //nolint:errcheck
-	groceryAddCmd.MarkFlagRequired("items")   //nolint:errcheck
+	markFlagRequired(groceryAddCmd, "list-id")
+	markFlagRequired(groceryAddCmd, "items")
 
 	groceryAddRecipeCmd.Flags().StringVar(&groceryRecipeID, "recipe-id", "", "Recipe ID")
-	groceryAddRecipeCmd.MarkFlagRequired("recipe-id") //nolint:errcheck
+	markFlagRequired(groceryAddRecipeCmd, "recipe-id")
 
 	groceryClearCmd.Flags().StringVar(&groceryListID, "list-id", "", "List ID")
-	groceryClearCmd.MarkFlagRequired("list-id") //nolint:errcheck
+	markFlagRequired(groceryClearCmd, "list-id")
 
 	groceryOrganizeCmd.Flags().StringVar(&groceryListID, "list-id", "", "List ID")
-	groceryOrganizeCmd.MarkFlagRequired("list-id") //nolint:errcheck
+	markFlagRequired(groceryOrganizeCmd, "list-id")
 
 	groceryOrderCmd.Flags().StringVar(&groceryListID, "list-id", "", "List ID")
 	groceryOrderCmd.Flags().StringVar(&groceryRetailer, "retailer", "", "Retailer slug (e.g. costco)")
-	groceryOrderCmd.MarkFlagRequired("list-id") //nolint:errcheck
+	markFlagRequired(groceryOrderCmd, "list-id")
 }

--- a/cmd/helpers.go
+++ b/cmd/helpers.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/sebrandon1/go-skylight/lib"
+	"github.com/spf13/cobra"
 )
 
 const (
@@ -18,6 +19,16 @@ const (
 func fatal(msg string, err error) {
 	fmt.Fprintf(os.Stderr, "Error: %s: %v\n", msg, err)
 	os.Exit(1)
+}
+
+// markFlagRequired marks a flag as required, panicking if the flag name
+// doesn't exist on the command. A failure here is a programmer error
+// (typo'd flag name) that should be caught immediately rather than
+// silently leaving the flag optional.
+func markFlagRequired(cmd *cobra.Command, name string) {
+	if err := cmd.MarkFlagRequired(name); err != nil {
+		panic(fmt.Sprintf("marking flag %q required on %q: %v", name, cmd.CommandPath(), err))
+	}
 }
 
 func getFrameOrFail(client *lib.Client, id string) *lib.Frame {

--- a/cmd/import.go
+++ b/cmd/import.go
@@ -177,5 +177,5 @@ func init() {
 	importCmd.Flags().StringVar(&importFile, "file", "", "Path to export JSON file")
 	importCmd.Flags().BoolVar(&importDryRun, "dry-run", false, "Preview what would be imported without making API calls")
 	importCmd.Flags().StringVar(&importResources, "resources", "all", "Comma-separated resource types to import")
-	importCmd.MarkFlagRequired("file") //nolint:errcheck
+	markFlagRequired(importCmd, "file")
 }

--- a/cmd/list.go
+++ b/cmd/list.go
@@ -241,42 +241,42 @@ func init() {
 	listCmd.AddCommand(taskBoxItemCreateCmd)
 
 	taskBoxItemCreateCmd.Flags().StringVar(&listItemTitle, "title", "", "Task box item title")
-	taskBoxItemCreateCmd.MarkFlagRequired("title") //nolint:errcheck
+	markFlagRequired(taskBoxItemCreateCmd, "title")
 
 	listGetCmd.Flags().StringVar(&listID, "list-id", "", "List ID")
-	listGetCmd.MarkFlagRequired("list-id") //nolint:errcheck
+	markFlagRequired(listGetCmd, "list-id")
 
 	listCreateCmd.Flags().StringVar(&listTitle, "title", "", "List title")
 	listCreateCmd.Flags().StringVar(&listColor, "color", "", "List color")
 	listCreateCmd.Flags().BoolVar(&listHideFromFrame, "hide-from-frame", false, "Hide list from calendar devices")
-	listCreateCmd.MarkFlagRequired("title") //nolint:errcheck
+	markFlagRequired(listCreateCmd, "title")
 
 	listDeleteCmd.Flags().StringVar(&listID, "list-id", "", "List ID")
-	listDeleteCmd.MarkFlagRequired("list-id") //nolint:errcheck
+	markFlagRequired(listDeleteCmd, "list-id")
 
 	listUpdateCmd.Flags().StringVar(&listID, "list-id", "", "List ID")
 	listUpdateCmd.Flags().StringVar(&listTitle, "title", "", "List title")
 	listUpdateCmd.Flags().StringVar(&listColor, "color", "", "List color")
 	listUpdateCmd.Flags().BoolVar(&listHideFromFrame, "hide-from-frame", false, "Hide list from calendar devices")
-	listUpdateCmd.MarkFlagRequired("list-id") //nolint:errcheck
+	markFlagRequired(listUpdateCmd, "list-id")
 
 	listAddItemCmd.Flags().StringVar(&listID, "list-id", "", "List ID")
 	listAddItemCmd.Flags().StringVar(&listItemTitle, "title", "", "Item title")
-	listAddItemCmd.MarkFlagRequired("list-id") //nolint:errcheck
-	listAddItemCmd.MarkFlagRequired("title")   //nolint:errcheck
+	markFlagRequired(listAddItemCmd, "list-id")
+	markFlagRequired(listAddItemCmd, "title")
 
 	listUpdateItemCmd.Flags().StringVar(&listID, "list-id", "", "List ID")
 	listUpdateItemCmd.Flags().StringVar(&listItemID, "item-id", "", "Item ID")
 	listUpdateItemCmd.Flags().StringVar(&listItemTitle, "title", "", "Item title")
 	listUpdateItemCmd.Flags().BoolVar(&listItemCompleted, "completed", false, "Mark item as completed")
-	listUpdateItemCmd.MarkFlagRequired("list-id") //nolint:errcheck
-	listUpdateItemCmd.MarkFlagRequired("item-id") //nolint:errcheck
+	markFlagRequired(listUpdateItemCmd, "list-id")
+	markFlagRequired(listUpdateItemCmd, "item-id")
 
 	listDeleteItemCmd.Flags().StringVar(&listID, "list-id", "", "List ID")
 	listDeleteItemCmd.Flags().StringVar(&listItemID, "item-id", "", "Item ID")
-	listDeleteItemCmd.MarkFlagRequired("list-id") //nolint:errcheck
-	listDeleteItemCmd.MarkFlagRequired("item-id") //nolint:errcheck
+	markFlagRequired(listDeleteItemCmd, "list-id")
+	markFlagRequired(listDeleteItemCmd, "item-id")
 
 	listClearCompletedCmd.Flags().StringVar(&listID, "list-id", "", "List ID")
-	listClearCompletedCmd.MarkFlagRequired("list-id") //nolint:errcheck
+	markFlagRequired(listClearCompletedCmd, "list-id")
 }

--- a/cmd/meal.go
+++ b/cmd/meal.go
@@ -320,24 +320,24 @@ func init() {
 	mealCmd.AddCommand(mealPlanCmd)
 
 	mealRecipeInfoCmd.Flags().StringVar(&recipeID, "recipe-id", "", "Recipe ID")
-	mealRecipeInfoCmd.MarkFlagRequired("recipe-id") //nolint:errcheck
+	markFlagRequired(mealRecipeInfoCmd, "recipe-id")
 
 	mealCreateRecipeCmd.Flags().StringVar(&recipeTitle, "title", "", "Recipe title")
 	mealCreateRecipeCmd.Flags().StringVar(&recipeDescription, "description", "", "Recipe description")
 	mealCreateRecipeCmd.Flags().StringSliceVar(&recipeIngredients, "ingredients", nil, "Ingredients (comma-separated)")
 	mealCreateRecipeCmd.Flags().StringVar(&recipeURL, "url", "", "Recipe URL")
 	mealCreateRecipeCmd.Flags().StringVar(&recipeCategoryID, "meal-category-id", "", "Meal category ID")
-	mealCreateRecipeCmd.MarkFlagRequired("title") //nolint:errcheck
+	markFlagRequired(mealCreateRecipeCmd, "title")
 
 	mealUpdateRecipeCmd.Flags().StringVar(&recipeID, "recipe-id", "", "Recipe ID to update")
 	mealUpdateRecipeCmd.Flags().StringVar(&recipeTitle, "title", "", "Recipe title")
 	mealUpdateRecipeCmd.Flags().StringVar(&recipeDescription, "description", "", "Recipe description")
 	mealUpdateRecipeCmd.Flags().StringSliceVar(&recipeIngredients, "ingredients", nil, "Ingredients (comma-separated)")
 	mealUpdateRecipeCmd.Flags().StringVar(&recipeURL, "url", "", "Recipe URL")
-	mealUpdateRecipeCmd.MarkFlagRequired("recipe-id") //nolint:errcheck
+	markFlagRequired(mealUpdateRecipeCmd, "recipe-id")
 
 	mealDeleteRecipeCmd.Flags().StringVar(&recipeID, "recipe-id", "", "Recipe ID")
-	mealDeleteRecipeCmd.MarkFlagRequired("recipe-id") //nolint:errcheck
+	markFlagRequired(mealDeleteRecipeCmd, "recipe-id")
 
 	mealSittingsCmd.Flags().StringVar(&sittingDateMin, "date-min", "", "Minimum date filter (YYYY-MM-DD)")
 	mealSittingsCmd.Flags().StringVar(&sittingDateMax, "date-max", "", "Maximum date filter (YYYY-MM-DD)")
@@ -346,25 +346,25 @@ func init() {
 	mealCreateSittingCmd.Flags().StringVar(&sittingSummary, "summary", "", "Meal sitting summary/title")
 	mealCreateSittingCmd.Flags().StringVar(&sittingDate, "date", "", "Sitting date")
 	mealCreateSittingCmd.Flags().StringVar(&mealCategoryID, "meal-category-id", "", "Meal category ID")
-	mealCreateSittingCmd.MarkFlagRequired("recipe-id")        //nolint:errcheck
-	mealCreateSittingCmd.MarkFlagRequired("date")             //nolint:errcheck
-	mealCreateSittingCmd.MarkFlagRequired("meal-category-id") //nolint:errcheck
+	markFlagRequired(mealCreateSittingCmd, "recipe-id")
+	markFlagRequired(mealCreateSittingCmd, "date")
+	markFlagRequired(mealCreateSittingCmd, "meal-category-id")
 
 	mealDeleteSittingCmd.Flags().StringVar(&sittingID, "sitting-id", "", "Meal sitting ID")
 	mealDeleteSittingCmd.Flags().StringVar(&sittingDate, "date", "", "Instance date to delete (YYYY-MM-DD)")
-	mealDeleteSittingCmd.MarkFlagRequired("sitting-id") //nolint:errcheck
-	mealDeleteSittingCmd.MarkFlagRequired("date")       //nolint:errcheck
+	markFlagRequired(mealDeleteSittingCmd, "sitting-id")
+	markFlagRequired(mealDeleteSittingCmd, "date")
 
 	mealAddToGroceryCmd.Flags().StringVar(&recipeID, "recipe-id", "", "Recipe ID")
-	mealAddToGroceryCmd.MarkFlagRequired("recipe-id") //nolint:errcheck
+	markFlagRequired(mealAddToGroceryCmd, "recipe-id")
 
 	mealSittingRecipeCmd.Flags().StringVar(&sittingID, "sitting-id", "", "Meal sitting ID")
-	mealSittingRecipeCmd.MarkFlagRequired("sitting-id") //nolint:errcheck
+	markFlagRequired(mealSittingRecipeCmd, "sitting-id")
 
 	mealPlanCmd.Flags().StringSliceVar(&mealPlanRecipeIDs, "recipes", nil, "Recipe IDs (comma-separated)")
 	mealPlanCmd.Flags().StringSliceVar(&mealPlanCategoryIDs, "categories", nil, "Meal category IDs (comma-separated)")
 	mealPlanCmd.Flags().StringVar(&mealPlanStartDate, "start-date", "", "Start date (YYYY-MM-DD)")
-	mealPlanCmd.MarkFlagRequired("recipes")    //nolint:errcheck
-	mealPlanCmd.MarkFlagRequired("categories") //nolint:errcheck
-	mealPlanCmd.MarkFlagRequired("start-date") //nolint:errcheck
+	markFlagRequired(mealPlanCmd, "recipes")
+	markFlagRequired(mealPlanCmd, "categories")
+	markFlagRequired(mealPlanCmd, "start-date")
 }

--- a/cmd/photo.go
+++ b/cmd/photo.go
@@ -192,10 +192,10 @@ func init() {
 
 	photoUploadCmd.Flags().StringVar(&photoFile, "file", "", "Path to image file to upload")
 	photoUploadCmd.Flags().StringVar(&photoCaption, "caption", "", "Optional caption for the photo")
-	photoUploadCmd.MarkFlagRequired("file") //nolint:errcheck
+	markFlagRequired(photoUploadCmd, "file")
 
 	photoDeleteCmd.Flags().StringArrayVar(&photoMessageID, "message-id", nil, "Message ID to delete (repeatable)")
-	photoDeleteCmd.MarkFlagRequired("message-id") //nolint:errcheck
+	markFlagRequired(photoDeleteCmd, "message-id")
 
 	photoDownloadCmd.Flags().StringArrayVar(&photoMessageID, "message-id", nil, "Message ID to download (repeatable)")
 	photoDownloadCmd.Flags().BoolVar(&photoDownloadAll, "all", false, "Download all photos")

--- a/cmd/reward.go
+++ b/cmd/reward.go
@@ -180,21 +180,21 @@ func init() {
 	rewardCreateCmd.Flags().StringVar(&rewardEmojiIcon, "emoji-icon", "", "Emoji icon for the reward")
 	rewardCreateCmd.Flags().BoolVar(&rewardNoRespawn, "no-respawn", false, "Disable respawn on redemption")
 	rewardCreateCmd.Flags().IntSliceVar(&rewardCategoryIDs, "category-ids", nil, "Category IDs to assign reward to")
-	rewardCreateCmd.MarkFlagRequired("title")  //nolint:errcheck
-	rewardCreateCmd.MarkFlagRequired("points") //nolint:errcheck
+	markFlagRequired(rewardCreateCmd, "title")
+	markFlagRequired(rewardCreateCmd, "points")
 
 	rewardUpdateCmd.Flags().StringVar(&rewardID, "reward-id", "", "Reward ID to update")
 	rewardUpdateCmd.Flags().StringVar(&rewardTitle, "title", "", "Reward title")
 	rewardUpdateCmd.Flags().IntVar(&rewardPoints, "points", 0, "Points cost")
 	rewardUpdateCmd.Flags().StringVar(&rewardEmojiIcon, "emoji-icon", "", "Emoji icon for the reward")
-	rewardUpdateCmd.MarkFlagRequired("reward-id") //nolint:errcheck
+	markFlagRequired(rewardUpdateCmd, "reward-id")
 
 	rewardDeleteCmd.Flags().StringVar(&rewardID, "reward-id", "", "Reward ID")
-	rewardDeleteCmd.MarkFlagRequired("reward-id") //nolint:errcheck
+	markFlagRequired(rewardDeleteCmd, "reward-id")
 
 	rewardRedeemCmd.Flags().StringVar(&rewardID, "reward-id", "", "Reward ID")
-	rewardRedeemCmd.MarkFlagRequired("reward-id") //nolint:errcheck
+	markFlagRequired(rewardRedeemCmd, "reward-id")
 
 	rewardUnredeemCmd.Flags().StringVar(&rewardID, "reward-id", "", "Reward ID")
-	rewardUnredeemCmd.MarkFlagRequired("reward-id") //nolint:errcheck
+	markFlagRequired(rewardUnredeemCmd, "reward-id")
 }

--- a/cmd/reward_remove_stars.go
+++ b/cmd/reward_remove_stars.go
@@ -43,6 +43,6 @@ var rewardRemoveStarsCmd = &cobra.Command{
 func init() {
 	rewardRemoveStarsCmd.Flags().IntVar(&removeStarsAssigneeID, "assignee-id", 0, "Profile/category ID to deduct from")
 	rewardRemoveStarsCmd.Flags().IntVar(&removeStarsPoints, "points", 0, "Number of stars to remove")
-	rewardRemoveStarsCmd.MarkFlagRequired("assignee-id") //nolint:errcheck
-	rewardRemoveStarsCmd.MarkFlagRequired("points")      //nolint:errcheck
+	markFlagRequired(rewardRemoveStarsCmd, "assignee-id")
+	markFlagRequired(rewardRemoveStarsCmd, "points")
 }

--- a/cmd/routine.go
+++ b/cmd/routine.go
@@ -146,17 +146,17 @@ func init() {
 	routineCreateCmd.Flags().StringVar(&routineTitle, "title", "", "Routine title")
 	routineCreateCmd.Flags().StringVar(&routineAssignee, "assignee-id", "", "Assignee ID")
 	routineCreateCmd.Flags().StringSliceVar(&routineSteps, "steps", nil, "Step titles (comma-separated)")
-	routineCreateCmd.MarkFlagRequired("title") //nolint:errcheck
+	markFlagRequired(routineCreateCmd, "title")
 
 	routineUpdateCmd.Flags().StringVar(&routineID, "routine-id", "", "Routine ID")
 	routineUpdateCmd.Flags().StringVar(&routineTitle, "title", "", "Routine title")
 	routineUpdateCmd.Flags().StringVar(&routineAssignee, "assignee-id", "", "Assignee ID")
 	routineUpdateCmd.Flags().StringSliceVar(&routineSteps, "steps", nil, "Step titles (comma-separated)")
-	routineUpdateCmd.MarkFlagRequired("routine-id") //nolint:errcheck
+	markFlagRequired(routineUpdateCmd, "routine-id")
 
 	routineDeleteCmd.Flags().StringVar(&routineID, "routine-id", "", "Routine ID")
-	routineDeleteCmd.MarkFlagRequired("routine-id") //nolint:errcheck
+	markFlagRequired(routineDeleteCmd, "routine-id")
 
 	routineReorderCmd.Flags().StringSliceVar(&routineIDs, "routine-ids", nil, "Routine IDs in desired order (comma-separated)")
-	routineReorderCmd.MarkFlagRequired("routine-ids") //nolint:errcheck
+	markFlagRequired(routineReorderCmd, "routine-ids")
 }


### PR DESCRIPTION
## Summary
- Every `MarkFlagRequired()` call in `cmd/` was suppressed with `//nolint:errcheck`, so a typo'd flag name would silently fail to enforce the requirement
- Added a `markFlagRequired()` helper in `cmd/helpers.go` that panics if the flag name doesn't exist (an init-time failure here is a programmer typo, not something to recover from at runtime)
- Routed every call site across `cmd/*.go` through the new helper

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./...` (769 tests pass)
- [x] Manually verified `chore create` without `--title` still errors with `required flag(s) "title" not set`

Closes #168
