### PR TITLE
bug: use tabwriter for analytics --output table

### DIFF
--- a/cmd/analytics.go
+++ b/cmd/analytics.go
@@ -254,19 +254,25 @@ func printAnalyticsText(s AnalyticsStats) {
 	if len(s.Assignees) == 0 {
 		fmt.Println("  (none)")
 	} else {
+		w := newTableWriter()
+		fmt.Fprintln(w, "NAME\tCOMPLETED/TOTAL\tCOMPLETION RATE\tPOINTS")
 		for _, a := range s.Assignees {
-			fmt.Printf("  %-20s  %d/%d chores (%.1f%%)  points: %d\n",
+			fmt.Fprintf(w, "%s\t%d/%d\t%.1f%%\t%d\n",
 				a.Name, a.CompletedChores, a.TotalChores, a.CompletionRate, a.PointBalance)
 		}
+		w.Flush()
 	}
 
 	fmt.Println("\nTop Chores:")
 	if len(s.TopChores) == 0 {
 		fmt.Println("  (none)")
 	} else {
+		w := newTableWriter()
+		fmt.Fprintln(w, "TITLE\tTIMES\tCOMPLETED")
 		for _, c := range s.TopChores {
-			fmt.Printf("  %-30s  %d times  (%d completed)\n", c.Title, c.Count, c.Completed)
+			fmt.Fprintf(w, "%s\t%d\t%d\n", c.Title, c.Count, c.Completed)
 		}
+		w.Flush()
 	}
 
 	fmt.Printf("\nRewards:   %d total, %d redeemed\n", s.Rewards.Total, s.Rewards.Redeemed)


### PR DESCRIPTION
## Summary
- `printAnalyticsText` (`cmd/analytics.go`) used `fmt.Printf` with hardcoded `%-20s`/`%-30s` widths for the Family Members and Top Chores sections, so columns misaligned once a name/title was longer than assumed
- Replaced both sections with `tabwriter.NewWriter` via the existing `newTableWriter()` helper, matching every other `--output table` renderer in the codebase (e.g. `cmd/table_output.go`)

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./...` (769 tests pass, existing `TestPrintAnalyticsText_*` tests pass unchanged)
- [x] Ran `skylight analytics --output table` against a real Skylight account and confirmed columns line up correctly

Closes #180
