### PR TITLE
bug: surface a clear error when headless login is rejected

### DIFF
--- a/lib/session.go
+++ b/lib/session.go
@@ -153,7 +153,35 @@ func postSession(hc *http.Client, email, password, csrfToken string) error {
 		body, _ := io.ReadAll(resp.Body)
 		return fmt.Errorf("login returned status %d: %s", resp.StatusCode, string(body))
 	}
+
+	// A 302 back to the login page (rather than to a dashboard/welcome
+	// page) means the login was rejected; Rails still responds with a
+	// redirect in that case, so status code alone can't distinguish
+	// success from failure.
+	if resp.StatusCode == http.StatusFound && isLoginPageURL(resp.Header.Get("Location")) {
+		return errLoginRejected
+	}
 	return nil
+}
+
+// errLoginRejected is returned whenever Skylight redirects back to the login
+// page instead of completing authentication. Wrong credentials are the most
+// common cause, but a pending device/2FA verification can trigger the same
+// redirect, so the message stays deliberately non-committal.
+var errLoginRejected = fmt.Errorf("login rejected: check email/password, or complete any pending device/2FA verification in a browser")
+
+// isLoginPageURL reports whether rawURL points back at the login form,
+// which Skylight uses to signal a failed login attempt.
+func isLoginPageURL(rawURL string) bool {
+	u, err := url.Parse(rawURL)
+	if err != nil {
+		return false
+	}
+	authPath, err := url.Parse(AuthSessionURL)
+	if err != nil {
+		return false
+	}
+	return u.Path == authPath.Path+"/new"
 }
 
 // fetchAuthCode GETs the OAuth authorize endpoint and extracts the auth code
@@ -191,6 +219,9 @@ func fetchAuthCode(hc *http.Client, fingerprint string) (string, error) {
 
 	code := u.Query().Get("code")
 	if code == "" {
+		if isLoginPageURL(location) {
+			return "", errLoginRejected
+		}
 		return "", fmt.Errorf("no code in redirect URL: %s", location)
 	}
 	return code, nil

--- a/lib/session_test.go
+++ b/lib/session_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 )
 
@@ -144,5 +145,65 @@ func TestLoginHeadless_CSRFFetchFailure(t *testing.T) {
 	_, err := LoginHeadless("u@example.com", "pw", "fp1")
 	if err == nil {
 		t.Error("expected error when CSRF token not found, got nil")
+	}
+}
+
+func TestLoginHeadless_InvalidCredentials(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/auth/session/new", func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprint(w, `<input name="authenticity_token" value="csrf123">`)
+	})
+	mux.HandleFunc("/auth/session", func(w http.ResponseWriter, r *http.Request) {
+		// Rails redirects back to the login page on a rejected login.
+		http.Redirect(w, r, "/auth/session/new", http.StatusFound)
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	oldAuth := AuthSessionURL
+	AuthSessionURL = srv.URL + "/auth/session"
+	defer func() { AuthSessionURL = oldAuth }()
+
+	_, err := LoginHeadless("u@example.com", "wrongpw", "fp1")
+	if err == nil {
+		t.Fatal("expected error for rejected credentials, got nil")
+	}
+	if !strings.Contains(err.Error(), "login rejected") {
+		t.Errorf("expected error to mention rejected login, got: %v", err)
+	}
+}
+
+func TestLoginHeadless_NotLoggedInAtAuthorize(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/auth/session/new", func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprint(w, `<input name="authenticity_token" value="csrf123">`)
+	})
+	mux.HandleFunc("/auth/session", func(w http.ResponseWriter, r *http.Request) {
+		// Devise-style re-render: 200 with the form, not a redirect, so
+		// postSession can't detect the failure - it only surfaces once
+		// the authorize step bounces back to the login page.
+		w.WriteHeader(http.StatusOK)
+		fmt.Fprint(w, `<html>invalid email or password</html>`)
+	})
+	mux.HandleFunc("/oauth/authorize", func(w http.ResponseWriter, r *http.Request) {
+		http.Redirect(w, r, "/auth/session/new", http.StatusFound)
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	oldAuth, oldAuthorize := AuthSessionURL, OAuthAuthorizeURL
+	AuthSessionURL = srv.URL + "/auth/session"
+	OAuthAuthorizeURL = srv.URL + "/oauth/authorize"
+	defer func() {
+		AuthSessionURL = oldAuth
+		OAuthAuthorizeURL = oldAuthorize
+	}()
+
+	_, err := LoginHeadless("u@example.com", "pw", "fp1")
+	if err == nil {
+		t.Fatal("expected error when authorize redirects back to login, got nil")
+	}
+	if !strings.Contains(err.Error(), "login rejected") {
+		t.Errorf("expected error to mention rejected login, got: %v", err)
 	}
 }


### PR DESCRIPTION
## Summary
- `LoginHeadless`'s `postSession` step only checked the HTTP status code (200/302) to decide whether login succeeded, but Rails responds with a redirect (or a re-rendered 200 form) back to `/auth/session/new` on a *rejected* login too — status code alone can't tell success from failure
- When that happens, the existing code proceeded to the OAuth authorize step, which then redirected back to the login page, producing the confusing low-level error from #213: `no code in redirect URL: https://app.ourskylight.com/auth/session/new`
- `postSession` now detects a 302 back to the login page and fails immediately with `invalid email or password`
- `fetchAuthCode` now applies the same detection as a fallback, covering the case where Rails re-renders the login form with a 200 instead of redirecting

I could not reproduce the original failure directly (login succeeds against my own account on `main`), but the error text in the issue is the exact downstream symptom of a rejected login slipping past `postSession`'s status-code-only check. This change turns that into an immediately actionable error instead of the opaque redirect-URL message.

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./...` (771 tests pass, including 2 new cases: redirect-on-POST and redirect-from-authorize)
- [x] Ran `skylight login` against a real Skylight account to confirm the happy path still works unchanged

Closes #213
