### PR TITLE
fix: apply simplify-and-squash review fixes dropped from #223's squash

### DIFF
--- a/cmd/addon_test.go
+++ b/cmd/addon_test.go
@@ -46,14 +46,5 @@ func TestAddonListCmd_WarnsWithoutPlus(t *testing.T) {
 }
 
 func TestAddonCmdExists(t *testing.T) {
-	found := false
-	for _, c := range rootCmd.Commands() {
-		if c.Use == "addon" {
-			found = true
-			break
-		}
-	}
-	if !found {
-		t.Error("addon command not registered on root")
-	}
+	assertCommandRegistered(t, rootCmd, "addon")
 }

--- a/cmd/analytics_run_test.go
+++ b/cmd/analytics_run_test.go
@@ -77,14 +77,5 @@ func TestAnalyticsCmd_CalendarErrorIsNonFatal(t *testing.T) {
 }
 
 func TestAnalyticsCmdExists(t *testing.T) {
-	found := false
-	for _, c := range rootCmd.Commands() {
-		if c.Use == "analytics" {
-			found = true
-			break
-		}
-	}
-	if !found {
-		t.Error("analytics command not registered on root")
-	}
+	assertCommandRegistered(t, rootCmd, "analytics")
 }

--- a/cmd/bounty_run_test.go
+++ b/cmd/bounty_run_test.go
@@ -72,6 +72,8 @@ func TestBountyUpdateCmd(t *testing.T) {
 	bountyChoreID, bountyRewardID, bountyTitle = "c1", "r1", "Updated"
 	t.Cleanup(func() { bountyChoreID, bountyRewardID, bountyTitle = origChoreID, origRewardID, origTitle })
 
+	// pflag.Set() marks the flag as permanently "changed" on the shared
+	// command singleton (no unset API), so this only runs once per process.
 	if err := bountyUpdateCmd.Flags().Set("title", "Updated"); err != nil {
 		t.Fatalf("setting title flag: %v", err)
 	}
@@ -83,14 +85,5 @@ func TestBountyUpdateCmd(t *testing.T) {
 }
 
 func TestBountyCmdExists(t *testing.T) {
-	found := false
-	for _, c := range rootCmd.Commands() {
-		if c.Use == "bounty" {
-			found = true
-			break
-		}
-	}
-	if !found {
-		t.Error("bounty command not registered on root")
-	}
+	assertCommandRegistered(t, rootCmd, "bounty")
 }

--- a/cmd/calendar_run_test.go
+++ b/cmd/calendar_run_test.go
@@ -112,14 +112,5 @@ func TestCalendarWeekCmd(t *testing.T) {
 }
 
 func TestCalendarCmdExists(t *testing.T) {
-	found := false
-	for _, c := range rootCmd.Commands() {
-		if c.Use == "calendar" {
-			found = true
-			break
-		}
-	}
-	if !found {
-		t.Error("calendar command not registered on root")
-	}
+	assertCommandRegistered(t, rootCmd, "calendar")
 }

--- a/cmd/category_run_test.go
+++ b/cmd/category_run_test.go
@@ -75,14 +75,5 @@ func TestCategoryUpdateCmd(t *testing.T) {
 }
 
 func TestCategoryCmdExists(t *testing.T) {
-	found := false
-	for _, c := range rootCmd.Commands() {
-		if c.Use == "category" {
-			found = true
-			break
-		}
-	}
-	if !found {
-		t.Error("category command not registered on root")
-	}
+	assertCommandRegistered(t, rootCmd, "category")
 }

--- a/cmd/chore_run_test.go
+++ b/cmd/chore_run_test.go
@@ -39,6 +39,8 @@ func TestChoreListCmd(t *testing.T) {
 func TestChoreListCmd_WeekView(t *testing.T) {
 	newCmdTestClient(t, choreMockHandler())
 
+	// pflag.Set() marks the flag as permanently "changed" on the shared
+	// command singleton (no unset API), so this only runs once per process.
 	if err := choreListCmd.Flags().Set("week", "current"); err != nil {
 		t.Fatalf("setting week flag: %v", err)
 	}
@@ -140,14 +142,5 @@ func TestChoreClaimCmd(t *testing.T) {
 }
 
 func TestChoreCmdExists(t *testing.T) {
-	found := false
-	for _, c := range rootCmd.Commands() {
-		if c.Use == "chore" {
-			found = true
-			break
-		}
-	}
-	if !found {
-		t.Error("chore command not registered on root")
-	}
+	assertCommandRegistered(t, rootCmd, "chore")
 }

--- a/cmd/chore_streak_run_test.go
+++ b/cmd/chore_streak_run_test.go
@@ -25,14 +25,5 @@ func TestChoreStreakCmd(t *testing.T) {
 }
 
 func TestChoreStreakCmdExists(t *testing.T) {
-	found := false
-	for _, c := range choreCmd.Commands() {
-		if c.Use == "streak" {
-			found = true
-			break
-		}
-	}
-	if !found {
-		t.Error("streak command not registered on chore command")
-	}
+	assertCommandRegistered(t, choreCmd, "streak")
 }

--- a/cmd/grocery_run_test.go
+++ b/cmd/grocery_run_test.go
@@ -128,14 +128,5 @@ func TestGroceryClearCmd(t *testing.T) {
 }
 
 func TestGroceryCmdExists(t *testing.T) {
-	found := false
-	for _, c := range rootCmd.Commands() {
-		if c.Use == "grocery" {
-			found = true
-			break
-		}
-	}
-	if !found {
-		t.Error("grocery command not registered on root")
-	}
+	assertCommandRegistered(t, rootCmd, "grocery")
 }

--- a/cmd/home_run_test.go
+++ b/cmd/home_run_test.go
@@ -69,14 +69,5 @@ func TestHomeCmd_NoTasksNoLists(t *testing.T) {
 }
 
 func TestHomeCmdExists(t *testing.T) {
-	found := false
-	for _, c := range rootCmd.Commands() {
-		if c.Use == "home" {
-			found = true
-			break
-		}
-	}
-	if !found {
-		t.Error("home command not registered on root")
-	}
+	assertCommandRegistered(t, rootCmd, "home")
 }

--- a/cmd/list_run_test.go
+++ b/cmd/list_run_test.go
@@ -72,6 +72,8 @@ func TestListCreateCmd_HideFromFrame(t *testing.T) {
 	listTitle = "Groceries"
 	t.Cleanup(func() { listTitle = origTitle })
 
+	// pflag.Set() marks the flag as permanently "changed" on the shared
+	// command singleton (no unset API), so this only runs once per process.
 	if err := listCreateCmd.Flags().Set("hide-from-frame", "true"); err != nil {
 		t.Fatalf("setting hide-from-frame flag: %v", err)
 	}
@@ -142,6 +144,8 @@ func TestListUpdateItemCmd(t *testing.T) {
 	listID, listItemID, listItemTitle = "list1", "item1", "Updated"
 	t.Cleanup(func() { listID, listItemID, listItemTitle = origID, origItemID, origTitle })
 
+	// pflag.Set() marks the flag as permanently "changed" on the shared
+	// command singleton (no unset API), so this only runs once per process.
 	if err := listUpdateItemCmd.Flags().Set("title", "Updated"); err != nil {
 		t.Fatalf("setting title flag: %v", err)
 	}
@@ -185,14 +189,5 @@ func TestListClearCompletedCmd(t *testing.T) {
 }
 
 func TestListCmdExists(t *testing.T) {
-	found := false
-	for _, c := range rootCmd.Commands() {
-		if c.Use == "list" {
-			found = true
-			break
-		}
-	}
-	if !found {
-		t.Error("list command not registered on root")
-	}
+	assertCommandRegistered(t, rootCmd, "list")
 }

--- a/cmd/meal_run_test.go
+++ b/cmd/meal_run_test.go
@@ -198,14 +198,5 @@ func TestMealUpdateRecipeCmd(t *testing.T) {
 }
 
 func TestMealCmdExists(t *testing.T) {
-	found := false
-	for _, c := range rootCmd.Commands() {
-		if c.Use == "meal" {
-			found = true
-			break
-		}
-	}
-	if !found {
-		t.Error("meal command not registered on root")
-	}
+	assertCommandRegistered(t, rootCmd, "meal")
 }

--- a/cmd/reward_remove_stars_test.go
+++ b/cmd/reward_remove_stars_test.go
@@ -28,14 +28,5 @@ func TestRewardRemoveStarsCmd(t *testing.T) {
 }
 
 func TestRewardRemoveStarsCmdExists(t *testing.T) {
-	found := false
-	for _, c := range rewardCmd.Commands() {
-		if c.Use == "remove-stars" {
-			found = true
-			break
-		}
-	}
-	if !found {
-		t.Error("remove-stars command not registered on reward command")
-	}
+	assertCommandRegistered(t, rewardCmd, "remove-stars")
 }

--- a/cmd/reward_run_test.go
+++ b/cmd/reward_run_test.go
@@ -131,14 +131,5 @@ func TestRewardUpdateCmd(t *testing.T) {
 }
 
 func TestRewardCmdExists(t *testing.T) {
-	found := false
-	for _, c := range rootCmd.Commands() {
-		if c.Use == "reward" {
-			found = true
-			break
-		}
-	}
-	if !found {
-		t.Error("reward command not registered on root")
-	}
+	assertCommandRegistered(t, rootCmd, "reward")
 }

--- a/cmd/rotation_test.go
+++ b/cmd/rotation_test.go
@@ -30,14 +30,5 @@ func TestRotationCreateCmd(t *testing.T) {
 }
 
 func TestRotationCmdExists(t *testing.T) {
-	found := false
-	for _, c := range rootCmd.Commands() {
-		if c.Use == "rotation" {
-			found = true
-			break
-		}
-	}
-	if !found {
-		t.Error("rotation command not registered on root")
-	}
+	assertCommandRegistered(t, rootCmd, "rotation")
 }

--- a/cmd/routine_run_test.go
+++ b/cmd/routine_run_test.go
@@ -52,6 +52,8 @@ func TestRoutineUpdateCmd(t *testing.T) {
 	routineID, routineTitle = "routine1", "Updated"
 	t.Cleanup(func() { routineID, routineTitle = origID, origTitle })
 
+	// pflag.Set() marks the flag as permanently "changed" on the shared
+	// command singleton (no unset API), so this only runs once per process.
 	if err := routineUpdateCmd.Flags().Set("title", "Updated"); err != nil {
 		t.Fatalf("setting title flag: %v", err)
 	}
@@ -87,14 +89,5 @@ func TestRoutineReorderCmd(t *testing.T) {
 }
 
 func TestRoutineCmdExists(t *testing.T) {
-	found := false
-	for _, c := range rootCmd.Commands() {
-		if c.Use == "routine" {
-			found = true
-			break
-		}
-	}
-	if !found {
-		t.Error("routine command not registered on root")
-	}
+	assertCommandRegistered(t, rootCmd, "routine")
 }

--- a/cmd/session_test.go
+++ b/cmd/session_test.go
@@ -207,14 +207,5 @@ func TestLoginCmd_LoginFailure(t *testing.T) {
 }
 
 func TestLoginCmdExists(t *testing.T) {
-	found := false
-	for _, c := range rootCmd.Commands() {
-		if c.Use == "login" {
-			found = true
-			break
-		}
-	}
-	if !found {
-		t.Error("login command not registered on root")
-	}
+	assertCommandRegistered(t, rootCmd, "login")
 }

--- a/cmd/status_test.go
+++ b/cmd/status_test.go
@@ -84,14 +84,5 @@ func TestStatusCmd_NoPoints(t *testing.T) {
 }
 
 func TestStatusCmdExists(t *testing.T) {
-	found := false
-	for _, c := range rootCmd.Commands() {
-		if c.Use == "status" {
-			found = true
-			break
-		}
-	}
-	if !found {
-		t.Error("status command not registered on root")
-	}
+	assertCommandRegistered(t, rootCmd, "status")
 }

--- a/cmd/testhelpers_test.go
+++ b/cmd/testhelpers_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/sebrandon1/go-skylight/lib"
+	"github.com/spf13/cobra"
 )
 
 // captureStderr redirects os.Stderr for the duration of fn and returns
@@ -65,4 +66,16 @@ func pointClientAt(t *testing.T, client *lib.Client) {
 func newCmdTestClient(t *testing.T, handler http.HandlerFunc) {
 	t.Helper()
 	pointClientAt(t, newMockClient(t, handler))
+}
+
+// assertCommandRegistered fails the test unless parent has a direct
+// subcommand whose Use matches use.
+func assertCommandRegistered(t *testing.T, parent *cobra.Command, use string) {
+	t.Helper()
+	for _, c := range parent.Commands() {
+		if c.Use == use {
+			return
+		}
+	}
+	t.Errorf("%q command not registered on %q", use, parent.Use)
 }


### PR DESCRIPTION
## Summary

My mistake while squashing #223: I ran `git reset --soft main` (which only moves the branch pointer, not the index) followed by `git commit -F <file>` without `git add`-ing the working-tree edits from the simplify-and-squash review pass first. The commit silently captured the stale index state, so the merged commit reverted to pre-review code:

- 17 verbose `TestXCmdExists` boilerplate blocks (9 lines each) instead of the collapsed `assertCommandRegistered(t, parent, use)` helper
- 5 `pflag.Set()` calls missing the "permanently changed" explanatory comment used at every other call site

This PR applies those fixes for real, on top of current `main`.

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./...` (963 tests pass)
- [x] `gofmt -l` clean
- [x] `make lint` clean on all changed files
